### PR TITLE
Allow shout-irc to be proxied behind a /path/ url

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -16,9 +16,9 @@
 	<link rel="stylesheet" href="css/style.css">
 	<link id="theme" rel="stylesheet" href="<%= theme %>">
 
-	<link rel="shortcut icon" href="/img/favicon.png">
-	<link rel="icon" sizes="192x192" href="/img/touch-icon-192x192.png">
-	<link rel="apple-touch-icon" sizes="120x120" href="/img/apple-touch-icon-120x120.png">
+	<link rel="shortcut icon" href="img/favicon.png">
+	<link rel="icon" sizes="192x192" href="img/touch-icon-192x192.png">
+	<link rel="apple-touch-icon" sizes="120x120" href="img/apple-touch-icon-120x120.png">
 
 	</head>
 	<body class="<%= public ? "public" : "" %>">

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -1,5 +1,5 @@
 $(function() {
-	var socket = io();
+	var socket = io({path:"./socket.io/"});
 	var commands = [
 		"/close",
 		"/connect",
@@ -38,7 +38,7 @@ $(function() {
 	var pop;
 	try {
 		pop = new Audio();
-		pop.src = "/audio/pop.ogg";
+		pop.src = "audio/pop.ogg";
 	} catch (e) {
 		pop = {
 			play: $.noop
@@ -656,7 +656,7 @@ $(function() {
 				if (settings.badge && Notification.permission === "granted") {
 					var notify = new Notification(msg.from + " says:", {
 						body: msg.text.trim(),
-						icon: "/img/logo-64.png",
+						icon: "img/logo-64.png",
 						tag: target
 					});
 					notify.onclick = function() {


### PR DESCRIPTION
contains three small changes to use relative urls instead of absolute rooted at /
* favicons in index.html
* badge and pop sound in shout.js
* the url for the socket.io endpoint