### PR TITLE
Changed the hostname of freenode in the default config

### DIFF
--- a/defaults/config.js
+++ b/defaults/config.js
@@ -132,9 +132,9 @@ module.exports = {
 		// Host
 		//
 		// @type     string
-		// @default  "irc.freenode.org"
+		// @default  "chat.freenode.net"
 		//
-		host: "irc.freenode.org",
+		host: "chat.freenode.net",
 
 		//
 		// Port

--- a/src/client.js
+++ b/src/client.js
@@ -124,7 +124,7 @@ Client.prototype.connect = function(args) {
 	var client = this;
 	var server = {
 		name: args.name || "",
-		host: args.host || "irc.freenode.org",
+		host: args.host || "chat.freenode.net",
 		port: args.port || (args.tls ? 6697 : 6667),
 		rejectUnauthorized: false
 	};


### PR DESCRIPTION
As suggested in erming/shout#647 the default freenode hostname is not correct. Yes, it works, but Freenode suggests to use chat.freenode.net instead.

It's a super easy fix, so why not?