### PR TITLE
Remove #foo channel from default config

### DIFF
--- a/defaults/config.js
+++ b/defaults/config.js
@@ -186,11 +186,12 @@ module.exports = {
 
 		//
 		// Channels
+		// This is a comma-separated list.
 		//
 		// @type     string
-		// @default  "#foo, #thelounge"
+		// @default  "#thelounge"
 		//
-		join: "#foo, #thelounge"
+		join: "#thelounge"
 	},
 
 	//


### PR DESCRIPTION
I actually don't see the point of having `#foo` as a default channel... Maybe there is a channel exactly design for that (testing that your client is well connected) that we should use, otherwise simply `#thelounge` is enough IMO.