### PR TITLE
Remove "badge" setting and rely on browser choice for desktop notifcations

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1109,6 +1109,11 @@ button,
 	color: #2ecc40;
 }
 
+#settings .error {
+	color: #e74c3c;
+	margin-top: .2em;
+}
+
 #form {
 	background: #eee;
 	border-top: 1px solid #ddd;

--- a/client/index.html
+++ b/client/index.html
@@ -243,8 +243,9 @@
 							</div>
 							<div class="col-sm-12">
 								<label class="opt">
-								<input id="badge" type="checkbox" name="badge">
-								Enable badge
+								<input id="desktopNotifications" type="checkbox" name="desktopNotifications">
+								Enable desktop notifications<br>
+								<div class="error" id="warnDisabledDesktopNotifications"><strong>Warning</strong>: Desktop notifications are blocked by your web browser</div>
 								</label>
 							</div>
 							<div class="col-sm-12">

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -427,7 +427,7 @@ $(function() {
 	var userStyles = $("#user-specified-css");
 	var settings = $("#settings");
 	var options = $.extend({
-		badge: false,
+		desktopNotifications: false,
 		colors: false,
 		join: true,
 		links: true,
@@ -487,11 +487,11 @@ $(function() {
 	}).find("input")
 		.trigger("change");
 
-	$("#badge").on("change", function() {
+	$("#desktopNotifications").on("change", function() {
 		var self = $(this);
 		if (self.prop("checked")) {
 			if (Notification.permission !== "granted") {
-				Notification.requestPermission();
+				Notification.requestPermission(updateDesktopNotificationStatus);
 			}
 		}
 	});
@@ -689,7 +689,7 @@ $(function() {
 				}
 				toggleFaviconNotification(true);
 
-				if (options.badge && Notification.permission === "granted") {
+				if (options.desktopNotifications && Notification.permission === "granted") {
 					var title;
 					var body;
 
@@ -791,6 +791,8 @@ $(function() {
 			}
 		});
 	});
+
+	windows.on("show", "#settings", updateDesktopNotificationStatus);
 
 	forms.on("submit", "form", function(e) {
 		e.preventDefault();
@@ -916,6 +918,23 @@ $(function() {
 	function refresh() {
 		window.onbeforeunload = null;
 		location.reload();
+	}
+
+	function updateDesktopNotificationStatus(){
+		var checkbox = $("#desktopNotifications");
+		var warning = $("#warnDisabledDesktopNotifications");
+
+		if (Notification.permission === "denied"){
+			checkbox.attr("disabled", true);
+			checkbox.attr("checked", false);
+			warning.show();
+		} else {
+			if (Notification.permission === "default" && checkbox.prop("checked")){
+				checkbox.attr("checked", false);
+			}
+			checkbox.attr("disabled", false);
+			warning.hide();
+		}
 	}
 
 	function sortable() {


### PR DESCRIPTION
Remove the badge setting and rely on browser choice for desktop notifications.

But the user still have to activate the desktop notifications via the lounge settings page. Making lounge ask the permission to the browser.

The status on whether or not it's activated is also displayed on the settings page.

Some screens to show how it looks :
> 
> "Deactivated" state :
> <img width="480" alt="notification_deactivated" src="https://cloud.githubusercontent.com/assets/110898/13030377/0e18cfce-d2a9-11e5-9107-9d69799ccfdd.png">
> Activated :
> <img width="468" alt="notifications_activated" src="https://cloud.githubusercontent.com/assets/110898/13030378/0e227be6-d2a9-11e5-8edd-8912994373f2.png">
> Blocked by web browser
> <img width="476" alt="notification_blocked" src="https://cloud.githubusercontent.com/assets/110898/13030376/0e0d76ba-d2a9-11e5-8528-f060837d4c6a.png">
> 