### PR TITLE
Replace deprecated moment().zone

### DIFF
--- a/src/log.js
+++ b/src/log.js
@@ -16,7 +16,7 @@ module.exports.write = function(user, network, chan, msg) {
 	var format = (config.logs || {}).format || "YYYY-MM-DD HH:mm:ss";
 	var tz = (config.logs || {}).timezone || "UTC+00:00";
 
-	var time = moment().zone(tz).format(format);
+	var time = moment().utcOffset(tz).format(format);
 	var line = "[" + time + "] ";
 
 	var type = msg.type.trim();


### PR DESCRIPTION
This PR attempts to fix https://github.com/thelounge/lounge/issues/36. Use `moment().utcOffset` instead of the deprecated `moment().zone`, as per https://github.com/moment/moment/issues/1779.