### PR TITLE
package.json: lint all .js files

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "start": "node index",
     "build": "grunt",
     "test": "HOME=test/fixtures mocha test/**/*.js && npm run lint",
-    "lint": "eslint index.js Gruntfile.js src/ test/ client/ defaults/"
+    "lint": "eslint ."
   },
   "keywords": [
     "browser",


### PR DESCRIPTION
This makes the linting process less prone to miss new (or even
existing) files. Ignoring specific file paths is delegated to the
.eslintignore file in the root directory.