### PR TITLE
update default settings to be more usable than technical

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -406,17 +406,17 @@ $(function() {
 
 	var settings = $("#settings");
 	var options = $.extend({
-		badge: false,
-		colors: false,
-		join: true,
+		badge: true,
+		colors: true,
+		join: false,
 		links: true,
-		mode: true,
+		mode: false,
 		motd: false,
-		nick: true,
-		notification: true,
-		part: true,
+		nick: false,
+		notification: false,
+		part: false,
 		thumbnails: true,
-		quit: true,
+		quit: false,
 		notifyAllMessages: false,
 	}, $.cookie("settings"));
 


### PR DESCRIPTION
Reasoning:
- enable colored nicknames by default so people can be more easily distinguished. In the future we should try to have something like avatars, fed from email/gravatar/profile or something similar.
- show notification badge instead of notification sound to be less distracting
- do not show joins/parts/quits/nickchanges: just not that interesting and mostly cluttering up the history. In the future we could group these messages similar to how IRCCloud does it, but meanwhile this is just too noisy.
- do not show mode: technical detail – can be shown on hover or whatever, but has no place there by default.

What do you think @YaManicKill @astorije?