### PR TITLE
frontend password change functionality

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1116,6 +1116,19 @@ button,
 	line-height: 1.8;
 }
 
+#settings #change-password .error,
+#settings #change-password .success {
+	margin-bottom: 1em;
+}
+
+#settings #change-password .error {
+	color: #e74c3c;
+}
+
+#settings #change-password .success {
+	color: #2ecc40;
+}
+
 #form {
 	background: #eee;
 	border-top: 1px solid #ddd;

--- a/client/index.html
+++ b/client/index.html
@@ -265,6 +265,31 @@
 									Enable notification for all messages
 								</label>
 							</div>
+							<% if (!public) { %>
+							<div id="change-password">
+								<form action="" method="post">
+									<div class="col-sm-12">
+										<h2>Change password</h2>
+									</div>
+									<div class="col-sm-12">
+										<label for="old_password" class="sr-only">Enter current password</label>
+										<input type="password" name="old_password" class="input" placeholder="Enter current password">
+									</div>
+									<div class="col-sm-12">
+										<label for="new_password" class="sr-only">Enter desired new password</label>
+										<input type="password" name="new_password" class="input" placeholder="Enter desired new password">
+									</div>
+									<div class="col-sm-12">
+										<label for="verify_password" class="sr-only">Repeat new password</label>
+										<input type="password" name="verify_password" class="input" placeholder="Repeat new password">
+									</div>
+									<div class="col-sm-12 feedback"></div>
+									<div class="col-sm-12">
+										<button type="submit" class="btn">Change password</button>
+									</div>
+								</form>
+							</div>
+							<% } %>
 							<div class="col-sm-12">
 								<h2>About The Lounge</h2>
 							</div>

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -112,6 +112,31 @@ $(function() {
 			.show();
 	});
 
+	socket.on("change-password", function(data) {
+		var passwordForm = $("#change-password");
+		if (data.error || data.success) {
+			var message = data.success ? data.success : data.error;
+			var feedback = passwordForm.find(".feedback");
+
+			if (data.success) {
+				feedback.addClass("success").removeClass("error");
+			} else {
+				feedback.addClass("error").removeClass("success");
+			}
+
+			feedback.text(message).show();
+			feedback.closest("form").one("submit", function() {
+				feedback.hide();
+			});
+		}
+		passwordForm
+			.find("input")
+			.val("")
+			.end()
+			.find(".btn")
+			.prop("disabled", false);
+	});
+
 	socket.on("init", function(data) {
 		if (data.networks.length === 0) {
 			$("#footer").find(".connect").trigger("click");
@@ -734,7 +759,7 @@ $(function() {
 	});
 
 	var windows = $("#windows");
-	var forms = $("#sign-in, #connect");
+	var forms = $("#sign-in, #connect, #change-password");
 
 	windows.on("show", "#sign-in", function() {
 		var self = $(this);
@@ -761,6 +786,8 @@ $(function() {
 			.end();
 		if (form.closest(".window").attr("id") === "connect") {
 			event = "conn";
+		} else if (form.closest("div").attr("id") === "change-password") {
+			event = "change-password";
 		}
 		var values = {};
 		$.each(form.serializeArray(), function(i, obj) {

--- a/src/clientManager.js
+++ b/src/clientManager.js
@@ -29,18 +29,14 @@ ClientManager.prototype.loadUsers = function() {
 
 ClientManager.prototype.loadUser = function(name) {
 	try {
-		var json = fs.readFileSync(
-			Helper.HOME + "/users/" + name + ".json",
-			"utf-8"
-		);
-		json = JSON.parse(json);
+		var json = this.readUserConfig(name);
 	} catch (e) {
 		console.log(e);
 		return;
 	}
 	if (!this.findClient(name)) {
 		this.clients.push(new Client(
-			this.sockets,
+			this,
 			name,
 			json
 		));
@@ -91,6 +87,50 @@ ClientManager.prototype.addUser = function(name, password) {
 		throw e;
 	}
 	return true;
+};
+
+ClientManager.prototype.updateUser = function(name, opts) {
+	var users = this.getUsers();
+	if (users.indexOf(name) === -1) {
+		return false;
+	}
+	if (typeof opts === "undefined") {
+		return false;
+	}
+	var path = Helper.HOME + "/users/" + name + ".json";
+	var user = {};
+
+	try {
+		user = this.readUserConfig(name);
+		_.merge(user, opts);
+	} catch (e) {
+		console.log(e);
+		return;
+	}
+
+	fs.writeFileSync(
+		path,
+		JSON.stringify(user, null, " "),
+		{mode: "0777"},
+		function(err) {
+			if (err) {
+				console.log(err);
+			}
+		}
+	);
+	return true;
+};
+
+ClientManager.prototype.readUserConfig = function(name) {
+	var users = this.getUsers();
+	if (users.indexOf(name) === -1) {
+		return false;
+	}
+	var path = Helper.HOME + "/users/" + name + ".json";
+	var user = {};
+	var data = fs.readFileSync(path, "utf-8");
+	user = JSON.parse(data);
+	return user;
 };
 
 ClientManager.prototype.removeUser = function(name) {


### PR DESCRIPTION
  - refactor clientManager.js to allow configuration parsing as a serparate
  function.
  - refactor clientManager.js to add configuration writing function.
  - add new plugin for /setpass command.
  - add server.js changes to allow for new "profile" screen
  - add password change ui to "profile" screen
  - modify css, front-end shout.js and index.html to add "profile" ui
  - refactor client.js to use new clientManager functionality for saving
    the configuration files

duplicates erming/shout#506