### PR TITLE
Only update the users list when needed

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -394,6 +394,19 @@ $(function() {
 	});
 
 	socket.on("users", function(data) {
+		var chan = chat.find("#chan-" + data.chan);
+
+		if (chan.hasClass("active")) {
+			socket.emit("names", {
+				target: data.chan
+			});
+		}
+		else {
+			chan.data("needsNamesRefresh", true);
+		}
+	});
+
+	socket.on("names", function(data) {
 		var users = chat.find("#chan-" + data.chan).find(".users").html(render("user", data));
 		var nicks = [];
 		for (var i in data.users) {
@@ -570,6 +583,11 @@ $(function() {
 			if (nick) {
 				setNick(nick);
 			}
+		}
+
+		if (chan.data("needsNamesRefresh") === true) {
+			chan.data("needsNamesRefresh", false);
+			socket.emit("names", {target: self.data("id")});
 		}
 
 		if (screen.width > 768 && chan.hasClass("chan")) {

--- a/src/client.js
+++ b/src/client.js
@@ -303,6 +303,19 @@ Client.prototype.sort = function(data) {
 	}
 };
 
+Client.prototype.names = function(data) {
+	var client = this;
+	var target = client.find(data.target);
+	if (!target) {
+		return;
+	}
+
+	client.emit("names", {
+		chan: target.chan.id,
+		users: target.chan.users
+	});
+};
+
 Client.prototype.quit = function() {
 	var sockets = this.sockets.sockets;
 	var room = sockets.adapter.rooms[this.id] || [];

--- a/src/plugins/irc-events/join.js
+++ b/src/plugins/irc-events/join.js
@@ -21,8 +21,7 @@ module.exports = function(irc, network) {
 		chan.users.push(new User({name: data.nick}));
 		chan.sortUsers();
 		client.emit("users", {
-			chan: chan.id,
-			users: chan.users
+			chan: chan.id
 		});
 		var self = false;
 		if (data.nick.toLowerCase() === irc.me.toLowerCase()) {

--- a/src/plugins/irc-events/kick.js
+++ b/src/plugins/irc-events/kick.js
@@ -19,8 +19,7 @@ module.exports = function(irc, network) {
 		}
 
 		client.emit("users", {
-			chan: chan.id,
-			users: chan.users
+			chan: chan.id
 		});
 
 		var self = false;

--- a/src/plugins/irc-events/names.js
+++ b/src/plugins/irc-events/names.js
@@ -14,8 +14,7 @@ module.exports = function(irc, network) {
 		});
 		chan.sortUsers();
 		client.emit("users", {
-			chan: chan.id,
-			users: chan.users
+			chan: chan.id
 		});
 	});
 };

--- a/src/plugins/irc-events/nick.js
+++ b/src/plugins/irc-events/nick.js
@@ -31,8 +31,7 @@ module.exports = function(irc, network) {
 			user.name = nick;
 			chan.sortUsers();
 			client.emit("users", {
-				chan: chan.id,
-				users: chan.users
+				chan: chan.id
 			});
 			var msg = new Msg({
 				type: Msg.Type.NICK,

--- a/src/plugins/irc-events/part.js
+++ b/src/plugins/irc-events/part.js
@@ -19,8 +19,7 @@ module.exports = function(irc, network) {
 			var user = _.findWhere(chan.users, {name: from});
 			chan.users = _.without(chan.users, user);
 			client.emit("users", {
-				chan: chan.id,
-				users: chan.users
+				chan: chan.id
 			});
 			var reason = data.message || "";
 			if (reason.length > 0) {

--- a/src/plugins/irc-events/quit.js
+++ b/src/plugins/irc-events/quit.js
@@ -12,8 +12,7 @@ module.exports = function(irc, network) {
 			}
 			chan.users = _.without(chan.users, user);
 			client.emit("users", {
-				chan: chan.id,
-				users: chan.users
+				chan: chan.id
 			});
 			var reason = data.message || "";
 			if (reason.length > 0) {

--- a/src/server.js
+++ b/src/server.js
@@ -121,6 +121,12 @@ function init(socket, client, token) {
 				client.sort(data);
 			}
 		);
+		socket.on(
+			"names",
+			function(data) {
+				client.names(data);
+			}
+		);
 		socket.join(client.id);
 		socket.emit("init", {
 			active: client.activeChannel,


### PR DESCRIPTION
Currently, for join/part/kick/nick/... the server will send an updated list of users and the client will re-render the list entirely. This ends up being a very expensive operation when joined on large channels and causes the client to slow down a lot.

This patch makes it so the user list is only updated when it is actually visible, avoiding lots and lots of user list re-renders on large channels.