### PR TITLE
Fix autocomplete problem

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -278,7 +278,7 @@
 					</div>
 				</div>
 			</div>
-			<form id="form" method="post" action="">
+			<form id="form" autocomplete="off">
 				<div class="inner">
 					<button id="submit" type="submit">
 						Send


### PR DESCRIPTION
Updated the form to not auto complete what we wrote before by removing method="post" action="" and adding autocomplete="off"

This patch denies https://github.com/erming/shout/pull/518 and removes that. Because without autocomplete, writing suggestions for mobile keyboards was enabled but at the mean time also whenever you clicked on text area to write a new message, you were given a number of your last typed sentences. Especially on mobile, this was a huge buzzkill because after 3-5 sentences on any channel, these suggestions covered your whole screen.

So, in order to remove it I did some changes, ensuring writing suggestions still work.
I have added autocomplete=off .

This commit is related to https://github.com/erming/shout/pull/532