### PR TITLE
Move actions to templates

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -201,18 +201,7 @@ $(function() {
 			"topic",
 			"action",
 		].indexOf(type) !== -1) {
-			switch (type) {
-			case "invite": data.msg.formattedAction = "invited " + data.msg.target + " to"; break;
-			case "join": data.msg.formattedAction = "has joined the channel"; break;
-			case "mode": data.msg.formattedAction = "sets mode"; break;
-			case "kick": data.msg.formattedAction = "has kicked"; break;
-			case "nick": data.msg.formattedAction = "is now known as"; break;
-			case "part": data.msg.formattedAction = "has left the channel"; break;
-			case "quit": data.msg.formattedAction = "has quit"; break;
-			case "topic": data.msg.formattedAction = "has changed the topic to:"; break;
-			default: data.msg.formattedAction = "";
-			}
-
+			data.msg.template = "actions/" + type;
 			msg = $(render("msg_action", data.msg));
 		} else {
 			msg = $(render("msg", data.msg));

--- a/client/views/actions/action.tpl
+++ b/client/views/actions/action.tpl
@@ -1,0 +1,2 @@
+<a href="#" class="user">{{mode}}{{from}}</a>
+{{{parse text}}}

--- a/client/views/actions/invite.tpl
+++ b/client/views/actions/invite.tpl
@@ -1,0 +1,5 @@
+<a href="#" class="user">{{from}}</a>
+invited
+<a href="#" class="user">{{target}}</a>
+to
+{{{parse text}}}

--- a/client/views/actions/join.tpl
+++ b/client/views/actions/join.tpl
@@ -1,0 +1,3 @@
+<a href="#" class="user">{{mode}}{{from}}</a>
+<i class="hostmask">({{hostmask}})</i>
+has joined the channel

--- a/client/views/actions/kick.tpl
+++ b/client/views/actions/kick.tpl
@@ -1,0 +1,6 @@
+<a href="#" class="user">{{mode}}{{from}}</a>
+has kicked
+<a href="#" class="user">{{target}}</a>
+{{#if text}}
+	<i class="part-reason">({{{parse text}}})</i>
+{{/if}}

--- a/client/views/actions/mode.tpl
+++ b/client/views/actions/mode.tpl
@@ -1,0 +1,3 @@
+<a href="#" class="user">{{mode}}{{from}}</a>
+sets mode
+{{{parse text}}}

--- a/client/views/actions/nick.tpl
+++ b/client/views/actions/nick.tpl
@@ -1,0 +1,3 @@
+<a href="#" class="user">{{mode}}{{from}}</a>
+is now known as
+<a href="#" class="user">{{mode}}{{text}}</a>

--- a/client/views/actions/part.tpl
+++ b/client/views/actions/part.tpl
@@ -1,0 +1,6 @@
+<a href="#" class="user">{{mode}}{{from}}</a>
+<i class="hostmask">({{hostmask}})</i>
+has left the channel
+{{#if text}}
+	<i class="part-reason">({{{parse text}}})</i>
+{{/if}}

--- a/client/views/actions/quit.tpl
+++ b/client/views/actions/quit.tpl
@@ -1,0 +1,6 @@
+<a href="#" class="user">{{mode}}{{from}}</a>
+<i class="hostmask">({{hostmask}})</i>
+has quit
+{{#if text}}
+	<i class="quit-reason">({{{parse text}}})</i>
+{{/if}}

--- a/client/views/actions/topic.tpl
+++ b/client/views/actions/topic.tpl
@@ -1,0 +1,8 @@
+{{#if isSetByChan}}
+	The topic is:
+{{else}}
+	<a href="#" class="user">{{mode}}{{from}}</a>
+	has changed the topic to:
+{{/if}}
+
+<span class="new-topic">{{{parse text}}}</span>

--- a/client/views/msg_action.tpl
+++ b/client/views/msg_action.tpl
@@ -4,8 +4,6 @@
 	</span>
 	<span class="from"></span>
 	<span class="text">
-		<a href="#" class="user">{{mode}}{{from}}</a>
-		{{formattedAction}}
-		{{{parse text}}}
+		{{partial template}}
 	</span>
 </div>

--- a/src/plugins/irc-events/join.js
+++ b/src/plugins/irc-events/join.js
@@ -29,6 +29,7 @@ module.exports = function(irc, network) {
 		}
 		var msg = new Msg({
 			from: data.nick,
+			hostmask: data.hostmask.username + "@" + data.hostmask.hostname,
 			type: Msg.Type.JOIN,
 			self: self
 		});

--- a/src/plugins/irc-events/kick.js
+++ b/src/plugins/irc-events/kick.js
@@ -26,15 +26,12 @@ module.exports = function(irc, network) {
 		if (data.nick.toLowerCase() === irc.me.toLowerCase()) {
 			self = true;
 		}
-		var reason = data.message || "";
-		if (reason.length > 0) {
-			reason = " (" + reason + ")";
-		}
 		var msg = new Msg({
 			type: Msg.Type.KICK,
 			mode: mode,
 			from: from,
-			text: data.client + reason,
+			target: data.client,
+			text: data.message || "",
 			self: self
 		});
 		chan.messages.push(msg);

--- a/src/plugins/irc-events/part.js
+++ b/src/plugins/irc-events/part.js
@@ -21,14 +21,11 @@ module.exports = function(irc, network) {
 			client.emit("users", {
 				chan: chan.id
 			});
-			var reason = data.message || "";
-			if (reason.length > 0) {
-				reason = "(" + reason + ")";
-			}
 			var msg = new Msg({
 				type: Msg.Type.PART,
 				mode: chan.getMode(from),
-				text: reason,
+				text: data.message || "",
+				hostmask:data.hostmask.username + "@" + data.hostmask.hostname,
 				from: from
 			});
 			chan.messages.push(msg);

--- a/src/plugins/irc-events/quit.js
+++ b/src/plugins/irc-events/quit.js
@@ -14,14 +14,11 @@ module.exports = function(irc, network) {
 			client.emit("users", {
 				chan: chan.id
 			});
-			var reason = data.message || "";
-			if (reason.length > 0) {
-				reason = "(" + reason + ")";
-			}
 			var msg = new Msg({
 				type: Msg.Type.QUIT,
 				mode: chan.getMode(from),
-				text: reason,
+				text: data.message || "",
+				hostmask: data.hostmask.username + "@" + data.hostmask.hostname,
 				from: from
 			});
 			chan.messages.push(msg);

--- a/src/plugins/irc-events/topic.js
+++ b/src/plugins/irc-events/topic.js
@@ -16,6 +16,7 @@ module.exports = function(irc, network) {
 			mode: chan.getMode(from),
 			from: from,
 			text: topic,
+			isSetByChan: from === chan.name,
 			self: (from.toLowerCase() === irc.me.toLowerCase())
 		});
 		chan.messages.push(msg);


### PR DESCRIPTION
This makes it easier to add action specific rendering (e.g. hostmasks in join messages).

This fixes #86 and #55.