### PR TITLE
Fix show-more being displayed over chat messages

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -685,6 +685,13 @@ button,
 #chat .show-more {
 	display: none;
 	padding: 10px;
+<<<<<<< d21b31981081912207b6d1359cb99b27575f2bd3
+=======
+<<<<<<< HEAD
+=======
+	position: relative;
+>>>>>>> 2e19518... Fix show-more being displayed over chat messages
+>>>>>>> Fix show-more being displayed over chat messages
 	width: 100%;
 }
 
@@ -1652,6 +1659,19 @@ button,
 }
 
 ::-webkit-scrollbar {
+	width: 8px;
+	background-color: rgba(0, 0, 0, 0);
+}
+
+::-webkit-scrollbar:hover {
+	background-color: rgba(0, 0, 0, .09);
+}
+
+::-webkit-scrollbar-thumb:vertical {
+	background: rgba(0, 0, 0, .5);
+	border-radius: 100px;
+}
+ {
 	width: 8px;
 	background-color: rgba(0, 0, 0, 0);
 }

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -685,16 +685,15 @@ button,
 #chat .show-more {
 	display: none;
 	padding: 10px;
-	position: absolute;
+<<<<<<< HEAD
+<<<<<<< HEAD
+=======
+	position: relative;
+>>>>>>> 6682fd7... Fix show-more being displayed over chat messages
+=======
+	position: relative;
+>>>>>>> 2e19518... Fix show-more being displayed over chat messages
 	width: 100%;
-}
-
-#chat .show-more.show + .messages .msg:first-child {
-	padding-top: 47px !important;
-}
-
-#chat .show-more.show + .messages .msg:first-child > span {
-	padding-top: 52px !important;
 }
 
 #chat .show-more-button {
@@ -722,10 +721,6 @@ button,
 #chat .msg {
 	display: table-row;
 	word-wrap: break-word;
-}
-
-#chat .msg:first-child > span {
-	padding-top: 10px;
 }
 
 #chat .msg:last-child {

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -685,14 +685,6 @@ button,
 #chat .show-more {
 	display: none;
 	padding: 10px;
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
-	position: relative;
->>>>>>> 6682fd7... Fix show-more being displayed over chat messages
-=======
-	position: relative;
->>>>>>> 2e19518... Fix show-more being displayed over chat messages
 	width: 100%;
 }
 

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -685,13 +685,6 @@ button,
 #chat .show-more {
 	display: none;
 	padding: 10px;
-<<<<<<< d21b31981081912207b6d1359cb99b27575f2bd3
-=======
-<<<<<<< HEAD
-=======
-	position: relative;
->>>>>>> 2e19518... Fix show-more being displayed over chat messages
->>>>>>> Fix show-more being displayed over chat messages
 	width: 100%;
 }
 


### PR DESCRIPTION
As per https://github.com/erming/shout/pull/568:

With this PR I tried fixing #366 by changing it's position to relative.
It wasn't a pretty sight to see "Show more" bar on existing chat
messages.

With this fix Show More button no more will overlap with the underneath
text.
As in:

![chrome_2016-02-22_16-43-50](https://cloud.githubusercontent.com/assets/10355660/13222386/6e609994-d988-11e5-9568-b2cb97fe4137.png)

Result will be like:
![Test
image](https://cloud.githubusercontent.com/assets/10355660/12207394/0d0ff402-b64f-11e5-9e9d-28108b518998.png)

This fix also includes @xPaw 's contribution as well.
PS: I mistakenly added another commit to this PR and removed it later.
See #88 for the next one.