### PR TITLE
Fix CSS selector syntax in channel message handler

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -649,7 +649,7 @@ $(function() {
 	});
 
 	chat.on("msg", ".messages", function(e, target, msg) {
-		var button = sidebar.find(".chan[data-target=" + target + "]");
+		var button = sidebar.find(".chan[data-target='" + target + "']");
 		var isQuery = button.hasClass("query");
 		var type = msg.type;
 		var highlight = type.contains("highlight");


### PR DESCRIPTION
Doesn't do much, but it prevents unneeded exceptions which are annoying when debugging. This makes the selector valid. An exception is thrown on every single message sent to any channel, so when you have a lot of them the debugger endlessly pauses for nothing.

It might also possibly improve performance slightly as jQuery won't have to fallback to its own implementation (but don't quote me on that).