### PR TITLE
Wrap badge and notifications in try/catch

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -655,25 +655,32 @@ $(function() {
 		var highlight = type.contains("highlight");
 		var message = type.contains("message");
 		if (highlight || isQuery || (options.notifyAllMessages && message)) {
-			if (!document.hasFocus() || !$(target).hasClass("active")) {
-				if (options.notification) {
-					pop.play();
+			try {
+				if (!document.hasFocus() || !$(target).hasClass("active")) {
+					if (options.notification) {
+						pop.play();
+					}
+					favico.badge("!");
+					if (options.badge && Notification.permission === "granted") {
+						var notify = new Notification(msg.from + " says:", {
+							body: msg.text.trim(),
+							icon: "img/logo-64.png",
+							tag: target
+						});
+						notify.onclick = function() {
+							window.focus();
+							button.click();
+							this.close();
+						};
+						window.setTimeout(function() {
+							notify.close();
+						}, 5 * 1000);
+					}
 				}
-				favico.badge("!");
-				if (options.badge && Notification.permission === "granted") {
-					var notify = new Notification(msg.from + " says:", {
-						body: msg.text.trim(),
-						icon: "img/logo-64.png",
-						tag: target
-					});
-					notify.onclick = function() {
-						window.focus();
-						button.click();
-						this.close();
-					};
-					window.setTimeout(function() {
-						notify.close();
-					}, 5 * 1000);
+			}
+			catch (e) {
+				if (console) {
+					console.warn("Failed to set up badge or send notification: ", e);
 				}
 			}
 		}


### PR DESCRIPTION
This fixes a somewhat rare/unusual bug where if bots dumps too much output to the user (such as `/msg ChanServ help` commands or `/msg *status help`), it crashes the client and reloads. Also fixes an Android deprecation issue with notifications that also crashed the client.

As a general rule I think crashing on notifications is a bit silly so I just wrapped the whole thing in a try/catch.