### PR TITLE
Fix /invite command broken by lodash update

### DIFF
--- a/src/plugins/irc-events/invite.js
+++ b/src/plugins/irc-events/invite.js
@@ -9,7 +9,7 @@ module.exports = function(irc, network) {
 			target = "you";
 		}
 
-		var chan = _.findWhere(network.channels, {name: data.channel});
+		var chan = _.find(network.channels, {name: data.channel});
 		if (typeof chan === "undefined") {
 			chan = network.channels[0];
 		}


### PR DESCRIPTION
Broken by #38 / 19bc4f3

receiving a `/invite` was crashing shout.