### PR TITLE
Remove attempts to set file modes

### DIFF
--- a/src/clientManager.js
+++ b/src/clientManager.js
@@ -80,8 +80,7 @@ ClientManager.prototype.addUser = function(name, password) {
 		mkdirp.sync(path);
 		fs.writeFileSync(
 			path + "/" + name + ".json",
-			JSON.stringify(user, null, "  "),
-			{mode: "0777"}
+			JSON.stringify(user, null, "  ")
 		);
 	} catch (e) {
 		throw e;
@@ -111,7 +110,6 @@ ClientManager.prototype.updateUser = function(name, opts) {
 	fs.writeFileSync(
 		path,
 		JSON.stringify(user, null, " "),
-		{mode: "0777"},
 		function(err) {
 			if (err) {
 				console.log(err);


### PR DESCRIPTION
After some testing and manually trying to set sane file modes, it turns out the umask still applies. So it seems the logical way to handle this is to actually rely on the OS umask to set proper permissions.

I have set mine to 0007, which results in the following structure:
```
drwxrwx--- 3 thelounge thelounge 4096 27 fév 21:34 ./
-rw-rw---- 1 thelounge thelounge 4040 27 fév 21:34 config.js
drwxrwx--- 2 thelounge thelounge 4096 27 fév 21:34 users/
-rw-rw---- 1 thelounge thelounge  133 27 fév 21:34 users/Max-P.json
```

This seems to be the best permissions for me, as the files are restricted to The Lounge, but the user can still allow a web server or other utilities to change the files by adding them to the lounge group.