### PR TITLE
Bump grunt-contrib-uglify and pin versions of grunt packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,10 +43,10 @@
   "devDependencies": {
     "stylelint": "4.3.3",
     "eslint": "^1.5.1",
-    "grunt": "~0.4.5",
-    "grunt-cli": "^0.1.13",
-    "grunt-contrib-uglify": "~0.5.0",
-    "grunt-contrib-watch": "^0.6.1",
+    "grunt": "0.4.5",
+    "grunt-cli": "0.1.13",
+    "grunt-contrib-uglify": "0.11.1",
+    "grunt-contrib-watch": "0.6.1",
     "handlebars": "^2.0.0",
     "mocha": "2.4.5"
   }


### PR DESCRIPTION
Made different tests locally and it seems to work fine (only change is `grunt-contrib-uglify`) but since this can break publication, I wouldn't be against some more testing from other reviewers :-) (will not set the `second review needed` label myself for this reason).