### PR TITLE
Remove auto-select on input fields

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -765,10 +765,6 @@ $(function() {
 		});
 	});
 
-	windows.on("click", ".input", function() {
-		$(this).select();
-	});
-
 	forms.on("submit", "form", function(e) {
 		e.preventDefault();
 		var event = "auth";


### PR DESCRIPTION
This removes the very annoying behavior that selects an entire input every time you click on it. This is very unusual and unexpected, I end up deleting the entire field by accident every time.
I would clearly mark this as a bug if it wasn't there on purpose.

(Now that I think of it, the only place where it's actually common to see this is Chrome's URL field...)