### PR TITLE
Add notifications for channel invites

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -682,21 +682,31 @@ $(function() {
 	chat.on("msg", ".messages", function(e, target, msg) {
 		var button = sidebar.find(".chan[data-target='" + target + "']");
 		var isQuery = button.hasClass("query");
-		if (msg.highlight || isQuery || (options.notifyAllMessages && msg.type === "message")) {
+		if (msg.type === "invite" || msg.highlight || isQuery || (options.notifyAllMessages && msg.type === "message")) {
 			if (!document.hasFocus() || !$(target).hasClass("active")) {
 				if (options.notification) {
 					pop.play();
 				}
 				toggleFaviconNotification(true);
+
 				if (options.badge && Notification.permission === "granted") {
-					var title = msg.from;
-					if (!isQuery) {
-						title += " (" + button.text().trim() + ")";
+					var title;
+					var body;
+
+					if (msg.type === "invite") {
+						title = "New channel invite:";
+						body = msg.from + " invited you to " + msg.text;
+					} else {
+						title = msg.from;
+						if (!isQuery) {
+							title += " (" + button.text().trim() + ")";
+						}
+						title += " says:";
+						body = msg.text.trim();
 					}
-					title += " says:";
 
 					var notify = new Notification(title, {
-						body: msg.text.trim(),
+						body: body,
 						icon: "img/logo-64.png",
 						tag: target
 					});


### PR DESCRIPTION
Here is how it looks:

<img width="374" alt="screen shot 2016-02-29 at 02 29 31" src="https://cloud.githubusercontent.com/assets/113730/13388245/6c813486-de8c-11e5-9dd6-62fc0ef8a870.png">

Regarding title, I'm fine with this above (suggested by @maxpoulin64), or `You were invited to a channel:`, ... (maybe as long as it ends with `:` to keep consistency with other notifications?)
Make an offer if you think you have better, I don't have a strong opinion on this :-)