### PR TITLE
Fixes channels listed on the whois message to be links

### DIFF
--- a/src/plugins/irc-events/whois.js
+++ b/src/plugins/irc-events/whois.js
@@ -28,6 +28,9 @@ module.exports = function(irc, network) {
 		};
 		for (var k in data) {
 			var key = prefix[k];
+			if (key === "on") {
+				data[k] = data[k].join(", ");
+			}
 			if (!key || data[k].toString() === "") {
 				continue;
 			}


### PR DESCRIPTION
There's probably a better way to do this...

![this](https://sr.ht/e-_w.png) vs ![that](https://sr.ht/2YuU.png) 

Notice the commas