### PR TITLE
Switch a power-off icon for logging out

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -480,7 +480,7 @@ button,
 }
 
 #footer .sign-out:before {
-	content: "\f13e";
+	content: "\f011";
 }
 
 #main {


### PR DESCRIPTION
The current icon is a lock, commonly used for encryption stuff. As a matter of fact, when @JocelynDelalande and I started to work on OTR support for Shout (TBC on The Lounge :-) ), we used the lock icons to signify that the session was encrypted, unencrypted, ...

Before | After
--- | ---
<img width="218" alt="screen shot 2016-03-01 at 01 33 59" src="https://cloud.githubusercontent.com/assets/113730/13419672/f7ba721c-df4d-11e5-96e6-e6be45834e98.png"> | <img width="220" alt="screen shot 2016-03-01 at 01 34 24" src="https://cloud.githubusercontent.com/assets/113730/13419673/f7c2bb02-df4d-11e5-8369-6e284c72ce52.png">
