### PR TITLE
Remove highlights from @mentions

### DIFF
--- a/src/plugins/irc-events/message.js
+++ b/src/plugins/irc-events/message.js
@@ -38,7 +38,7 @@ module.exports = function(irc, network) {
 
 		var highlight = false;
 		textSplit.forEach(function(w) {
-			if (w.replace(/^@/, "").toLowerCase().indexOf(irc.me.toLowerCase()) === 0) {
+			if (w.toLowerCase().indexOf(irc.me.toLowerCase()) === 0) {
 				highlight = true;
 			}
 		});


### PR DESCRIPTION
Assuming `nick` is the nick of the current user:

1. `nick` triggers a highlight
2. `@nick` triggers a highlight, even though starting with `@` prevents the auto-complete to show up
3. `@@nick` does not trigger a highlight
4. `nicki-minaj-is-my-hero`... does trigger a highlight...

This PR removes the second case. I don't see a value in highlighting `@nick`, unless we want to give a GitHub look-and-feel, in which case we should also enable in auto-complete, ... Not sure we want that, after all this is not how IRC deals with nicks, as opposed to, say, GitHub and Twitter.

But maybe I'm very wrong, let the caucus decide :-)