### PR TITLE
Auto complete fix for nicks

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -948,7 +948,14 @@ $(function() {
 	}
 
 	function complete(word) {
-		var words = commands.slice();
+
+		var firstWord=$("#input").val().lastIndexOf(word) === 0;
+		var words;
+		if (firstWord){
+			words = commands.slice();
+		} else {
+			words = [];
+		}
 		var users = chat.find(".active").find(".users");
 		var nicks = users.data("nicks");
 
@@ -962,7 +969,11 @@ $(function() {
 		}
 
 		for (var i in nicks) {
-			words.push(nicks[i]);
+			if (firstWord){
+				words.push(nicks[i]+": ");
+			} else {
+				words.push(nicks[i]+" ");
+			}
 		}
 
 		sidebar.find(".chan")


### PR DESCRIPTION
Change so if you try to auto complete nick in start of line it completet to "nick: " from before "nick" and if it is in the middle of a text  "nick" is change to "nick ". And commands ex /msg only auto completets if is in the start of the line.