### PR TITLE
Update eslint to 2.3.0 and add stricter rules

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -8,19 +8,26 @@ env:
   node: true
 
 rules:
+  block-spacing: [2, always]
   comma-dangle: 0
   curly: [2, multi-line]
   eqeqeq: 2
   indent: [2, tab]
+  keyword-spacing: [2, {before: true, after: true}]
   linebreak-style: [2, unix]
-  object-curly-spacing: [2, never]
-  semi: [2, always]
-  space-after-keywords: [2, always]
-  space-before-function-paren: [2, never]
-  spaced-comment: [2, always]
   no-console: 0
+  no-inner-declarations: 2
+  no-invalid-regexp: 2
+  no-irregular-whitespace: 2
   no-trailing-spaces: 2
+  no-unexpected-multiline: 2
+  no-unreachable: 2
+  object-curly-spacing: [2, never]
   quotes: [2, double, avoid-escape]
+  semi: [2, always]
+  space-before-blocks: 2
+  space-infix-ops: 2
+  spaced-comment: [2, always]
 
 globals:
   $: false

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -802,7 +802,7 @@ $(function() {
 			"nick",
 			"mode",
 		];
-		if ($.inArray(msg.type, ignore) !== -1){
+		if ($.inArray(msg.type, ignore) !== -1) {
 			return;
 		}
 
@@ -994,16 +994,16 @@ $(function() {
 		location.reload();
 	}
 
-	function updateDesktopNotificationStatus(){
+	function updateDesktopNotificationStatus() {
 		var checkbox = $("#desktopNotifications");
 		var warning = $("#warnDisabledDesktopNotifications");
 
-		if (Notification.permission === "denied"){
+		if (Notification.permission === "denied") {
 			checkbox.attr("disabled", true);
 			checkbox.attr("checked", false);
 			warning.show();
 		} else {
-			if (Notification.permission === "default" && checkbox.prop("checked")){
+			if (Notification.permission === "default" && checkbox.prop("checked")) {
 				checkbox.attr("checked", false);
 			}
 			checkbox.attr("disabled", false);

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "devDependencies": {
     "stylelint": "4.3.3",
-    "eslint": "^1.5.1",
+    "eslint": "2.3.0",
     "grunt": "0.4.5",
     "grunt-cli": "0.1.13",
     "grunt-contrib-uglify": "0.11.1",

--- a/src/server.js
+++ b/src/server.js
@@ -27,7 +27,7 @@ module.exports = function(options) {
 	var host = config.host;
 	var transports = config.transports || ["websocket", "polling"];
 
-	if (!https.enable){
+	if (!https.enable) {
 		server = require("http");
 		server = server.createServer(app).listen(port, host);
 	} else {


### PR DESCRIPTION
These stricter rules require more spacing, for example here: `var a="b";` should be `var a = "b";`