### PR TITLE
Add support for HTTP2

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "read": "1.0.7",
     "request": "2.69.0",
     "slate-irc": "0.8.1",
-    "socket.io": "1.4.5"
+    "socket.io": "1.4.5",
+    "spdy": "3.2.3"
   },
   "devDependencies": {
     "stylelint": "4.3.3",

--- a/src/server.js
+++ b/src/server.js
@@ -31,7 +31,7 @@ module.exports = function(options) {
 		server = require("http");
 		server = server.createServer(app).listen(port, host);
 	} else {
-		server = require("https");
+		server = require("spdy");
 		server = server.createServer({
 			key: fs.readFileSync(https.key),
 			cert: fs.readFileSync(https.certificate)


### PR DESCRIPTION
> With this module you can create HTTP2 / SPDY servers in node.js with natural http module interface and fallback to regular https (for browsers that don't support neither HTTP2, nor SPDY yet).

`http2` module does not work with Express. Closes #173.