### PR TITLE
Switch the Send button to a paper plane icon

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1161,7 +1161,6 @@ button,
 	font: 12px Consolas, Menlo, Monaco, "Lucida Console", "DejaVu Sans Mono", "Courier New", monospace;
 	left: 0;
 	height: 34px;
-	margin-right: 64px;
 	position: relative;
 }
 
@@ -1188,24 +1187,30 @@ button,
 	border-radius: 2px;
 	height: 100%;
 	outline: none;
-	padding: 0 10px;
+	padding: 0 34px 0 10px;
 	-webkit-appearance: none;
 	width: 100%;
 }
 
 #form #submit {
-	background: #f4f4f4;
-	background-image: linear-gradient(#f4f4f4, #ececec);
-	border: 1px solid #d7d7d7;
-	border-bottom-color: #b7b7b7;
-	border-radius: 2px;
-	font: 12px Lato, sans-serif;
-	color: #555;
+	color: #9ca5b4;
 	height: 34px;
+	line-height: 34px;
 	position: absolute;
 	right: 0;
 	transition: opacity .3s;
-	width: 58px;
+	width: 34px;
+}
+
+#form #submit:before {
+	font: 14px FontAwesome;
+	content: "\f1d8";
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+}
+
+#form #submit:hover {
+	opacity: .6;
 }
 
 #context-menu-container {

--- a/client/index.html
+++ b/client/index.html
@@ -312,11 +312,9 @@
 			</div>
 			<form id="form" method="post" action="">
 				<div class="inner">
-					<button id="submit" type="submit">
-						Send
-					</button>
 					<div class="input">
 						<label for="input" id="nick"></label>
+						<button id="submit" type="submit" title="Send"></button>
 						<input id="input" class="mousetrap">
 					</div>
 				</div>


### PR DESCRIPTION
This is mostly to add consistency between the Send button and the other icon buttons (Settings, user list, ...) of the app.
It has the other benefit to add a tiny bit of estate for the message input, which is nice on mobile.
It's more discreet on desktops but not used very often on them, more useful on mobile, where lots of apps are doing the same so we won't confuse users.

**Before:**
<img width="399" alt="screen shot 2016-03-11 at 01 48 45" src="https://cloud.githubusercontent.com/assets/113730/13695325/8825e900-e72b-11e5-91bc-77ee0b47e411.png">

**After:**
<img width="403" alt="screen shot 2016-03-11 at 01 53 50" src="https://cloud.githubusercontent.com/assets/113730/13695395/350c8b7e-e72c-11e5-9787-0a2237f667a6.png">
