### PR TITLE
Fix Send button style on Zenburn and Morning themes

### DIFF
--- a/client/themes/morning.css
+++ b/client/themes/morning.css
@@ -127,9 +127,12 @@ QUIT #d0907d
 	color: #ccc;
 }
 
+#form #submit:hover {
+	opacity: 1;
+}
+
 /* Buttons */
 #chat .show-more-button,
-#form #submit,
 #windows .header .button {
 	background: #2e3642;
 	border-color: #242a33;
@@ -137,7 +140,6 @@ QUIT #d0907d
 }
 
 #chat .show-more-button:hover,
-#form #submit:hover,
 #windows .header .button:hover {
 	color: #fff;
 }

--- a/client/themes/zenburn.css
+++ b/client/themes/zenburn.css
@@ -157,9 +157,12 @@ body {
 	color: #dcdccc;
 }
 
+#form #submit:hover {
+	opacity: 1;
+}
+
 /* Buttons */
 #chat .show-more-button,
-#form #submit,
 #windows .header .button {
 	background: #434443;
 	border-color: #101010;
@@ -167,7 +170,6 @@ body {
 }
 
 #chat .show-more-button:hover,
-#form #submit:hover,
 #windows .header .button:hover {
 	color: #fff;
 }


### PR DESCRIPTION
@xPaw pointed out that I forgot to update themes in #182. Crypto doesn't need fixing.

**Zenburn:**

<img width="403" alt="screen shot 2016-03-12 at 19 30 06" src="https://cloud.githubusercontent.com/assets/113730/13726158/8ef4691e-e889-11e5-83c3-8dc0a6fee182.png">

**Morning:**

<img width="403" alt="screen shot 2016-03-12 at 19 32 32" src="https://cloud.githubusercontent.com/assets/113730/13726159/8ef6d7c6-e889-11e5-9edd-324ff25e2b16.png">
