### PR TITLE
Keep track of highlights when user is offline

### DIFF
--- a/client/views/chan.tpl
+++ b/client/views/chan.tpl
@@ -1,6 +1,6 @@
 {{#each channels}}
 <div data-id="{{id}}" data-target="#chan-{{id}}" data-title="{{name}}" class="chan {{type}}">
-	<span class="badge" data-count="{{unread}}">{{#if unread}}{{unread}}{{/if}}</span>
+	<span class="badge{{#if highlight}} highlight{{/if}}" data-count="{{unread}}">{{#if unread}}{{unread}}{{/if}}</span>
 	<span class="close"></span>
 	<span class="name" title="{{name}}">{{name}}</span>
 </div>

--- a/src/client.js
+++ b/src/client.js
@@ -320,6 +320,7 @@ Client.prototype.open = function(data) {
 	var target = this.find(data);
 	if (target) {
 		target.chan.unread = 0;
+		target.chan.highlight = false;
 		this.activeChannel = target.chan.id;
 	}
 };

--- a/src/models/chan.js
+++ b/src/models/chan.js
@@ -18,6 +18,7 @@ function Chan(attr) {
 		topic: "",
 		type: Chan.Type.CHANNEL,
 		unread: 0,
+		highlight: false,
 		users: []
 	}, attr));
 }

--- a/src/plugins/irc-events/message.js
+++ b/src/plugins/irc-events/message.js
@@ -46,6 +46,10 @@ module.exports = function(irc, network) {
 
 		if (chan.id !== client.activeChannel) {
 			chan.unread++;
+
+			if (highlight) {
+				chan.highlight = true;
+			}
 		}
 
 		var name = data.from;


### PR DESCRIPTION
If user is offline and channel gets a lot of messages, when the user comes back online, the unread counter badge won't be white even if the user was mentioned in that channel, that's because badge only turns white if any message in current buffer contains a highlight.