### PR TITLE
Make sure all close buttons in the sidebar have same weight

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -402,6 +402,7 @@ button,
 
 #sidebar .close:before {
 	font-size: 18px;
+	font-weight: normal;
 	display: inline-block;
 	line-height: 18px;
 	width: 18px;


### PR DESCRIPTION
Testing #184 locally made me realize that the close button, now being a character (&times;, while it used to be a picture) uses the same boldness than the text it is associated to. This PR makes sure they all have the same boldness.

Before | After
--- | ---
<img width="517" alt="screen shot 2016-03-14 at 00 32 01" src="https://cloud.githubusercontent.com/assets/113730/13735190/f8be7d46-e97c-11e5-8d30-a370d6e383de.png"> | <img width="518" alt="screen shot 2016-03-14 at 00 32 28" src="https://cloud.githubusercontent.com/assets/113730/13735191/f8bf6da0-e97c-11e5-8c82-f86b065c2747.png">
