### PR TITLE
Remove unnecessary operation when sorting users

### DIFF
--- a/src/models/chan.js
+++ b/src/models/chan.js
@@ -27,14 +27,8 @@ Chan.prototype.sortUsers = function() {
 		this.users,
 		function(u) { return u.name.toLowerCase(); }
 	);
-	var modes = [
-		"~",
-		"&",
-		"@",
-		"%",
-		"+",
-	].reverse();
-	modes.forEach(function(mode) {
+
+	["+", "%", "@", "&", "~"].forEach(function(mode) {
 		this.users = _.remove(
 			this.users,
 			function(u) { return u.mode === mode; }


### PR DESCRIPTION
Maybe there was a good reason for this `.reverse()` but I can't admit I'm seeing it right now...
The entire method could probably use a rewrite but this is the least that can be done here.