### PR TITLE
Add a very basic test for Network#export

### DIFF
--- a/test/models/network.js
+++ b/test/models/network.js
@@ -1,0 +1,30 @@
+"use strict";
+
+var expect = require("chai").expect;
+
+var Chan = require("../../src/models/chan");
+var Network = require("../../src/models/network");
+
+describe("Network", function() {
+	describe("#export()", function() {
+
+		it("should produce an valid object", function() {
+			var network = new Network({name: "networkName"});
+			network.channels.push(new Chan({name: "#thelounge"}));
+			network.channels.push(new Chan({name: "&foobar"}));
+
+			expect(network.export()).to.deep.equal({
+				name: "networkName",
+				host: "",
+				port: 6667,
+				tls: false,
+				password: "",
+				username: "",
+				realname: "",
+				commands: [],
+				nick: undefined,
+				join: "#thelounge,&foobar",
+			});
+		});
+	});
+});


### PR DESCRIPTION
This is a very basic, naive test but my plan was to have the minimal possible coverage rather than an extensive test suite. Will improve over time.

Btw, CI will pass after #197 is merged and this PR is rebased off master.