### PR TITLE
Change default socket.io transports to use websocket over polling

### DIFF
--- a/defaults/config.js
+++ b/defaults/config.js
@@ -209,7 +209,7 @@ module.exports = {
 	// Set socket.io transports
 	//
 	// @type     array
-	// @default  ["polling', "websocket"]
+	// @default  ["polling", "websocket"]
 	//
 	transports: ["polling", "websocket"],
 

--- a/src/server.js
+++ b/src/server.js
@@ -25,7 +25,7 @@ module.exports = function(options) {
 	var protocol = https.enable ? "https" : "http";
 	var port = config.port;
 	var host = config.host;
-	var transports = config.transports || ["websocket", "polling"];
+	var transports = config.transports || ["polling", "websocket"];
 
 	if (!https.enable) {
 		server = require("http");


### PR DESCRIPTION
Since we chose to support modern browsers, we should be just fine defaulting to websockets, if the browser does not support them, it will fallback to http polling.

Code already defaults to this order here: https://github.com/thelounge/lounge/blob/f577da52a39d118c9f6256101a7cd3828dcfc67d/src/server.js#L28