### PR TITLE
Restrict access to the home directory by default

### DIFF
--- a/src/command-line/index.js
+++ b/src/command-line/index.js
@@ -23,7 +23,7 @@ if (program.home) {
 
 var config = Helper.HOME + "/config.js";
 if (!fs.existsSync(config)) {
-	mkdirp.sync(Helper.HOME);
+	mkdirp.sync(Helper.HOME, {mode: "0700"});
 	fs.writeFileSync(
 		config,
 		fs.readFileSync(__dirname + "/../../defaults/config.js")


### PR DESCRIPTION
As discussed in #165, this PR restricts the permissions on the entire home directory, making it secure by default without being instrusive for sysadmins.