### PR TITLE
Minor enhancements of the context menu UI

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1244,6 +1244,8 @@ button,
 	font-family: FontAwesome;
 	width: 20px;
 	display: inline-block;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
 }
 
 .context-menu-user:before {
@@ -1255,7 +1257,7 @@ button,
 }
 
 .context-menu-close:before {
-	content: "\f057";
+	content: "\f00d";
 }
 
 /**

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1221,15 +1221,19 @@ button,
 	border-radius: 2px;
 }
 
-.context-menu-item:first-child {
-	border-bottom: 1px solid rgba(61, 70, 77, .1);
+.context-menu-divider {
+	height: 1px;
+	margin: 6px 0;
+	background-color: rgba(0, 0, 0, .1);
 }
 
 .context-menu-item {
 	cursor: pointer;
 	display: block;
-	padding: 6px 8px;
+	padding: 4px 8px;
 	color: #333;
+	margin-top: 6px;
+	margin-bottom: 6px;
 }
 
 .context-menu-item:hover {

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1216,8 +1216,9 @@ button,
 	min-width: 160px;
 	font-size: 14px;
 	background-color: #fff;
-	box-shadow: 0 1px 2px rgba(0, 0, 0, .1);
-	border: 1px solid rgba(61, 70, 77, .1);
+	box-shadow: 0 3px 12px rgba(0, 0, 0, .15);
+	border: 1px solid rgba(0, 0, 0, .15);
+	border-radius: 2px;
 }
 
 .context-menu-item:first-child {

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -533,6 +533,7 @@ $(function() {
 				text: target.data("title"),
 				data: target.data("target")
 			});
+			output += render("contextmenu_divider");
 			output += render("contextmenu_item", {
 				class: "close",
 				text: target.hasClass("lobby") ? "Disconnect" : target.hasClass("query") ? "Close" : "Leave",

--- a/client/views/contextmenu_divider.tpl
+++ b/client/views/contextmenu_divider.tpl
@@ -1,0 +1,1 @@
+<li class="context-menu-divider" />


### PR DESCRIPTION
- Blur the shadow around the context menu box
- Add a 2px radius to the context menu box
- Add a divider to allow for margin around it, and prepare future item additions
- Add margins at the top and bottom of the context menu, as well as around the divider, to replicate common context menu behavior
- Use a white background <kbd>X</kbd> Font Awesome icon to close a chat (not <kbd>&times;</kbd> `&times` on purpose because it doesn't look as nice on white background, but we can improve if necessary)
- Smooth icons of context menu items

Ideally, I would like to find a nice contrasted color for the `:hover`, allowing us to invert text/icon colors when highlighting an item, but I couldn't find a nice one. Any suggestion? 

Before | After
--- | ---
<img width="318" alt="screen shot 2016-03-20 at 17 28 09" src="https://cloud.githubusercontent.com/assets/113730/13907286/436d801e-eec1-11e5-92f7-a51ce9907ae3.png"> | <img width="328" alt="screen shot 2016-03-20 at 17 25 49" src="https://cloud.githubusercontent.com/assets/113730/13907288/437921f8-eec1-11e5-8143-c46d55f17828.png">
<img width="241" alt="screen shot 2016-03-20 at 17 31 04" src="https://cloud.githubusercontent.com/assets/113730/13907311/a1bf5f84-eec1-11e5-90dd-99c4b15a49d9.png"> | <img width="242" alt="screen shot 2016-03-20 at 17 25 58" src="https://cloud.githubusercontent.com/assets/113730/13907289/43797a40-eec1-11e5-8bff-aefceed168bc.png">