### PR TITLE
Fix message and topic text wrapping

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -607,6 +607,7 @@ button,
 #windows .header .topic {
 	color: #777;
 	margin-left: 8px;
+	word-break: break-all;
 }
 
 #windows .window .header {
@@ -699,6 +700,7 @@ button,
 
 #chat .messages {
 	display: table;
+	table-layout: fixed;
 	width: 100%;
 	padding: 10px 0;
 }
@@ -752,14 +754,6 @@ button,
 #chat .text {
 	padding-left: 10px;
 	padding-right: 6px;
-}
-
-#chat .wrap,
-#chat .text a {
-	font-style: normal;
-	word-break: break-all;
-	word-wrap: break-word;
-	display: inline-block;
 }
 
 #chat .self .text {

--- a/client/js/libs/handlebars/parse.js
+++ b/client/js/libs/handlebars/parse.js
@@ -1,28 +1,12 @@
 Handlebars.registerHelper(
 	"parse", function(text) {
-		var wrap = wraplong(text);
 		text = Handlebars.Utils.escapeExpression(text);
 		text = colors(text);
 		text = channels(text);
 		text = uri(text);
-		if (wrap) {
-			return "<i class='wrap'>" + text + "</i>";
-		} else {
-			return text;
-		}
+		return text;
 	}
 );
-
-function wraplong(text) {
-	var wrap = false;
-	var split = text.split(" ");
-	for (var i in split) {
-		if (split[i].length > 40) {
-			wrap = true;
-		}
-	}
-	return wrap;
-}
 
 function uri(text) {
 	return URI.withinString(text, function(url, start, end, source) {


### PR DESCRIPTION
This makes topics not disappear due to wonky wrapping, and this also removes the need of having a special `.wrap` class for long words in chat.

See http://stackoverflow.com/a/1883702/2200891