### PR TITLE
Keep autocompletion sort whenever user list updates

### DIFF
--- a/client/views/chat.tpl
+++ b/client/views/chat.tpl
@@ -18,9 +18,7 @@
 		<div class="messages"></div>
 	</div>
 	<aside class="sidebar">
-		<div class="users">
-			{{partial "user"}}
-		</div>
+		<div class="users"></div>
 	</aside>
 </div>
 {{/each}}

--- a/src/client.js
+++ b/src/client.js
@@ -340,7 +340,7 @@ Client.prototype.names = function(data) {
 	}
 
 	client.emit("names", {
-		chan: target.chan.id,
+		id: target.chan.id,
 		users: target.chan.users
 	});
 };


### PR DESCRIPTION
~~This solution is not ideal for two reasons:
1. Users that leave *(or change name)* are left in auto completion
2. Users that change name in case sensitive manner are not updated~~

~~I didn't fix these two because it would get rather expensive to do a lot of manipulation on the arrays. Perhaps we should take names list from the server and merely sort it based on the old users array client has, probably would need to invert the users array so that nicks become order.~~

Fixes #92

This PR keeps previous order whenever user list is updated, newly joined users are pushed to the bottom, quit users are removed from the list.