### PR TITLE
Disallow /query on non-nicks

### DIFF
--- a/src/plugins/inputs/query.js
+++ b/src/plugins/inputs/query.js
@@ -14,6 +14,11 @@ exports.input = function(network, chan, cmd, args) {
 		return;
 	}
 
+	// If target doesn't start with an allowed character, ignore
+	if (!/^[a-zA-Z_\\\[\]{}^`|]/.test(target)) {
+		return;
+	}
+
 	var newChan = new Chan({
 		type: Chan.Type.QUERY,
 		name: target


### PR DESCRIPTION
Quickfix of #218 until `framework-irc` probably makes us solve that differently anyway.
At least it avoids going into a weird state that cannot be easily recovered.