### PR TITLE
Fix /part command

### DIFF
--- a/src/plugins/inputs/part.js
+++ b/src/plugins/inputs/part.js
@@ -17,10 +17,7 @@ exports.input = function(network, chan, cmd, args) {
 
 	if (chan.type === "channel") {
 		var irc = network.irc;
-		if (args.length === 0) {
-			args.push(chan.name);
-		}
-		irc.part(args);
+		irc.part(chan.name, args.join(" "));
 	}
 
 	network.channels = _.without(network.channels, chan);


### PR DESCRIPTION
Fixes the /part command closing the wrong window. The current implementation simply passes all arguments to slate, which ended up parting every arguments (and never sending the part message)

This changes the command to `/part message`, and always parts the current window. This will be fixed further once irc-framework is merged.