### PR TITLE
Hide options will now remove the row completely

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -760,11 +760,11 @@ button,
 	color: #999;
 }
 
-#chat.hide-join .join span,
-#chat.hide-mode .mode span,
-#chat.hide-motd .motd span,
-#chat.hide-nick .nick span,
-#chat.hide-part .part span,
+#chat.hide-join .join,
+#chat.hide-mode .mode,
+#chat.hide-motd .motd,
+#chat.hide-nick .nick,
+#chat.hide-part .part,
 #chat.hide-quit .quit {
 	display: none !important;
 }
@@ -1641,15 +1641,6 @@ button,
 
 	#chat .time {
 		display: none;
-	}
-
-	#chat.hide-join .join,
-	#chat.hide-mode .mode,
-	#chat.hide-motd .motd,
-	#chat.hide-nick .nick,
-	#chat.hide-part .part,
-	#chat.hide-quit .quit {
-		display: none !important;
 	}
 }
 


### PR DESCRIPTION
Fixes this: https://forum.cozy.io/uploads/default/original/1X/d75836720701429278ddaeebb35ddb3fab7656c4.PNG

1.4.1 uses fixed table layout, so incorrectly hiding rows revealed the bug.