### PR TITLE
Fix not being able to remove networks from user config

### DIFF
--- a/src/clientManager.js
+++ b/src/clientManager.js
@@ -101,7 +101,7 @@ ClientManager.prototype.updateUser = function(name, opts) {
 
 	try {
 		user = this.readUserConfig(name);
-		_.merge(user, opts);
+		_.assign(user, opts);
 		fs.writeFileSync(
 			path,
 			JSON.stringify(user, null, " ")


### PR DESCRIPTION
Fixes #211, a bug introduced by #57.

Previously it used to simply override entire `networks` object, but #57 made it use `merge` method, which makes it impossible to remove disconnected networks. This PR changes it to `assign` which works similarly to `merge`, but only on root keys, which overrides the `networks` object just fine.

http://stackoverflow.com/a/33247597/2200891