### PR TITLE
Dockerfile: don't use -onbuild tag, more explicit directives

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+
+# Built assets created at npm install/prepublish time
+# See https://docs.npmjs.com/misc/scripts
+client/js/libs.min.js.map
+client/js/libs.min.js
+client/js/lounge.templates.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,4 @@
-#
-# Thanks to @Xe for the Dockerfile template
-# https://github.com/Shuo-IRC/Shuo/pull/87/files
-#
-
-FROM node:4.0-onbuild
+FROM node:4
 
 # Create a non-root user for lounge to run in.
 RUN useradd --create-home lounge
@@ -13,13 +8,23 @@ ENV HOME /home/lounge
 
 # Customize this to specify where The Lounge puts its data.
 # To link a data container, have it expose /home/lounge/data
-ENV LOUNGE_HOME /home/lounge/data
+ENV LOUNGE_HOME ${HOME}/data
+ENV LOUNGE_SRC ${HOME}/src
 
-# Expose HTTP
-EXPOSE 9000
+RUN mkdir -p ${LOUNGE_SRC}
+WORKDIR ${LOUNGE_SRC}
+
+COPY . ${LOUNGE_SRC}
+
+RUN chown -R lounge:lounge ${LOUNGE_SRC}
 
 # Drop root.
 USER lounge
+RUN npm install
+
+# Expose HTTP
+ENV PORT 9000
+EXPOSE ${PORT}
 
 # Don't use an entrypoint here. It makes debugging difficult.
 CMD node index.js --home $LOUNGE_HOME


### PR DESCRIPTION
Right now it assumes you have run `$ npm run build` before building the image.

edit: retroactively added a `.dockerignore` as well