### PR TITLE
Implement WEBIRC

### DIFF
--- a/defaults/config.js
+++ b/defaults/config.js
@@ -36,6 +36,15 @@ module.exports = {
 	bind: undefined,
 
 	//
+	// Sets whether the server is behind a reverse proxy and should honor the
+	// X-Forwarded-For header or not.
+	//
+	// @type     boolean
+	// @default  false
+	//
+	reverseProxy: false,
+
+	//
 	// Set the default theme.
 	//
 	// @type     string
@@ -96,6 +105,25 @@ module.exports = {
 	// @default  false
 	//
 	lockNetwork: false,
+
+	//
+	// WEBIRC support
+	//
+	// If enabled, The Lounge will pass the connecting user's host and IP to the
+	// IRC server. Note that this requires to obtain a password from the IRC network
+	// The Lounge will be connecting to and generally involves a lot of trust from the
+	// network you are connecting to.
+	//
+	// Format (standard): {"irc.example.net": "hunter1", "irc.example.org": "passw0rd"}
+	// Format (function):
+	//   {"irc.example.net": function(client, args, trusted) {
+	//       // here, we return a webirc object fed directly to `irc-framework`
+	//       return {password: "hunter1", address: args.ip, hostname: "webirc/"+args.hostname};
+	//   }}
+	//
+	// @type     string | function(client, args):object(webirc)
+	// @default  null
+	webirc: null,
 
 	//
 	// Log settings

--- a/src/models/network.js
+++ b/src/models/network.js
@@ -16,6 +16,8 @@ function Network(attr) {
 		username: "",
 		realname: "",
 		channels: [],
+		ip: null,
+		hostname: null,
 		id: id++,
 		irc: null,
 		serverOptions: {
@@ -45,7 +47,9 @@ Network.prototype.export = function() {
 		"password",
 		"username",
 		"realname",
-		"commands"
+		"commands",
+		"ip",
+		"hostname"
 	]);
 	network.nick = (this.irc && this.irc.user.nick) || "";
 	network.join = _.map(

--- a/src/server.js
+++ b/src/server.js
@@ -19,8 +19,6 @@ module.exports = function(options) {
 		.use(index)
 		.use(express.static("client"));
 
-	app.enable("trust proxy");
-
 	var server = null;
 	var https = config.https || {};
 	var protocol = https.enable ? "https" : "http";

--- a/test/models/network.js
+++ b/test/models/network.js
@@ -24,6 +24,8 @@ describe("Network", function() {
 				commands: [],
 				nick: "",
 				join: "#thelounge,&foobar",
+				ip: null,
+				hostname: null
 			});
 		});
 	});


### PR DESCRIPTION
It's finally ready!

Features:
* Works in both public/private mode
* Supports DNS resolution (without the possible race condition of the original PR)
* Configurable hostname prefix to mark the web client
* In private mode, uses the IP of the client creating the new network (and is saved to JSON for server restarts)
* IP/hostname can be overriden *per user* in the user's JSON
* IP/hostname can be overriden *per network* in the user's JSON
* Gracefully falls back to a standard connection of the client IP can't be obtained and issue a warning to the console. (Should only happen when editing the JSON files manually)

Overall, if enabled in the `config.js`, it should do what an admin would expect both in public and private mode. However, admins that wants more control can override settings as needed per user, or per user network.

EDIT: [An irc-framework version](https://github.com/maxpoulin64/lounge/tree/webirc-irc-fw) to make rebasing easier or in case irc-fw gets merged first.