### PR TITLE
Add config option to limit in-memory history size

### DIFF
--- a/defaults/config.js
+++ b/defaults/config.js
@@ -125,6 +125,17 @@ module.exports = {
 	},
 
 	//
+	// Maximum number of history lines per channel
+	//
+	// Defines the maximum number of history lines that will be kept in
+	// memory per channel/query, in order to reduce the memory usage of
+	// the server. Negative means unlimited.
+	//
+	// @type     integer
+	// @default  -1
+	maxHistory: -1,
+
+	//
 	// Default values for the 'Connect' form.
 	//
 	// @type     object

--- a/src/plugins/irc-events/message.js
+++ b/src/plugins/irc-events/message.js
@@ -1,9 +1,12 @@
 var _ = require("lodash");
 var Chan = require("../../models/chan");
 var Msg = require("../../models/msg");
+var Helper = require("../../helper");
 
 module.exports = function(irc, network) {
 	var client = this;
+	var config = Helper.getConfig();
+
 	irc.on("message", function(data) {
 		if (data.message.indexOf("\u0001") === 0 && data.message.substring(0, 7) !== "\u0001ACTION") {
 			// Hide ctcp messages.
@@ -62,6 +65,11 @@ module.exports = function(irc, network) {
 			highlight: highlight
 		});
 		chan.messages.push(msg);
+
+		if (config.maxHistory >= 0 && chan.messages.length > config.maxHistory) {
+			chan.messages.splice(0, chan.messages.length - config.maxHistory);
+		}
+
 		client.emit("msg", {
 			chan: chan.id,
 			msg: msg


### PR DESCRIPTION
This adds a (temporary?) config option to limit the amount of messages stored per channel to avoid the server's memory usage to grow as channels fills up with messages.

This is the same patch that I had originally made for Shout, but it was obsoleted by another PR that offered persistent storage. However, since we're already over 4 months later and people's instances still crashes regularly, I'm bringing it back at least as a temporary measure.