### PR TITLE
Do not parse link titles for IRC formatting

### DIFF
--- a/client/views/toggle.tpl
+++ b/client/views/toggle.tpl
@@ -9,7 +9,7 @@
 			{{#if thumb}}
 				<img src="{{thumb}}" class="thumb">
 			{{/if}}
-			<div class="head">{{{parse head}}}</div>
+			<div class="head">{{head}}</div>
 			<div class="body">
 				{{body}}
 			</div>


### PR DESCRIPTION
This was supposed to be an XSS fix in 7ef2da0c832175cea1776a651a3c14051468fdc2, but the proper fix would be to simply escape it, instead of running IRC formatter on it.