### PR TITLE
Do not display incorrect nick when switching to a non connected network

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1157,6 +1157,7 @@ button,
 	font: inherit;
 	font-size: 11px;
 	margin: 5px;
+	margin-right: 10px;
 	line-height: 26px;
 	height: 24px;
 	padding: 0 9px;
@@ -1165,6 +1166,14 @@ button,
 	-moz-user-select: none;
 	-ms-user-select: none;
 	user-select: none;
+}
+
+#form #nick:empty {
+	visibility: hidden;
+}
+
+#form #nick:after {
+	content: ":";
 }
 
 #form #input {

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -667,12 +667,7 @@ $(function() {
 		document.title = title;
 
 		if (self.hasClass("chan")) {
-			var nick = self
-				.closest(".network")
-				.data("nick");
-			if (nick) {
-				setNick(nick);
-			}
+			setNick(self.closest(".network").data("nick"));
 		}
 
 		if (chan.data("needsNamesRefresh") === true) {
@@ -1069,12 +1064,9 @@ $(function() {
 
 	function setNick(nick) {
 		var width = $("#nick")
-			.html(nick + ":")
-			.width();
-		if (width) {
-			width += 31;
-			input.css("padding-left", width);
-		}
+			.html(nick)
+			.outerWidth(true);
+		input.css("padding-left", width);
 	}
 
 	function move(array, old_index, new_index) {


### PR DESCRIPTION
Previously it only called `setNick` if the network had a nick, so it would keep displaying the nick from the  network you switched from, this PR fixes that.

- It also removes the magic `31` margin number, and calculates the margin correctly.
- Moves <kbd>:</kbd> to be appended with CSS.
- Hides `#nick` panel if the network has no nick (e.g. while lauching lounge or connecting)