### PR TITLE
Enable auto reconnection

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -36,6 +36,7 @@ var inputs = [
 	"part",
 	"action",
 	"connect",
+	"disconnect",
 	"invite",
 	"kick",
 	"mode",

--- a/src/client.js
+++ b/src/client.js
@@ -211,7 +211,7 @@ Client.prototype.connect = function(args) {
 		tls: network.tls,
 		localAddress: config.bind,
 		rejectUnauthorized: false,
-		auto_reconnect: false, // TODO: Enable auto reconnection
+		auto_reconnect: true,
 		webirc: webirc,
 	});
 

--- a/src/plugins/inputs/connect.js
+++ b/src/plugins/inputs/connect.js
@@ -1,8 +1,24 @@
+var Msg = require("../../models/msg");
+
 exports.commands = ["connect", "server"];
 exports.allowDisconnected = true;
 
 exports.input = function(network, chan, cmd, args) {
 	if (args.length === 0) {
+		if (!network.irc || !network.irc.connection) {
+			return;
+		}
+
+		if (network.irc.connection.connected) {
+			chan.pushMessage(this, new Msg({
+				type: Msg.Type.ERROR,
+				text: "You are already connected."
+			}));
+			return;
+		}
+
+		network.irc.connection.connect();
+
 		return;
 	}
 

--- a/src/plugins/inputs/disconnect.js
+++ b/src/plugins/inputs/disconnect.js
@@ -1,0 +1,7 @@
+exports.commands = ["disconnect"];
+
+exports.input = function(network, chan, cmd, args) {
+	var quitMessage = args[0] ? args.join(" ") : "";
+
+	network.irc.quit(quitMessage);
+};

--- a/src/plugins/inputs/quit.js
+++ b/src/plugins/inputs/quit.js
@@ -1,6 +1,6 @@
 var _ = require("lodash");
 
-exports.commands = ["quit", "disconnect"];
+exports.commands = ["quit"];
 exports.allowDisconnected = true;
 
 exports.input = function(network, chan, cmd, args) {

--- a/src/plugins/irc-events/connection.js
+++ b/src/plugins/irc-events/connection.js
@@ -19,9 +19,9 @@ module.exports = function(irc, network) {
 		}));
 	});
 
-	irc.on("socket close", function() {
+	irc.on("close", function() {
 		network.channels[0].pushMessage(client, new Msg({
-			text: "Disconnected from the network."
+			text: "Disconnected from the network, and will not reconnect."
 		}));
 	});
 
@@ -35,7 +35,7 @@ module.exports = function(irc, network) {
 
 	irc.on("reconnecting", function() {
 		network.channels[0].pushMessage(client, new Msg({
-			text: "Reconnecting..."
+			text: "Disconnected from the network. Reconnecting..."
 		}));
 	});
 


### PR DESCRIPTION
:tada: irc-fw has prepared us for this moment! Closes #18.

We should be reconnecting just fine without any problems. Client already prints all the necessary messages (connecting, reconnecting, socket errors, etc). Server prevents you from sending commands while you are not connected.