### PR TITLE
Always run all tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "scripts": {
     "start": "node index",
     "build": "grunt && handlebars client/views/ -e tpl -f client/js/lounge.templates.js",
-    "test": "HOME=test/fixtures mocha test/**/*.js && npm run lint",
-    "lint": "eslint . && stylelint \"**/*.css\"",
+    "test": "node run-all HOME=test/fixtures mocha test/**/*.js + npm run lint",
+    "lint": "node run-all eslint . + stylelint '**/*.css'",
     "prepublish": "npm run build"
   },
   "keywords": [

--- a/run-all.js
+++ b/run-all.js
@@ -1,0 +1,39 @@
+var spawn = require("child_process").execSync;
+var commands = [];
+var status = false;
+
+// Parse commands
+(function() {
+	var parts = [];
+
+	for (var i = 2; i < process.argv.length; i++) {
+		var arg = process.argv[i];
+
+		if (arg === "\\+") {
+			parts.push("+");
+		}
+		else if (arg === "+") {
+			commands.push(parts.join(" "));
+			parts = [];
+		}
+		else {
+			parts.push(arg);
+		}
+	}
+
+	if (parts.length > 0) {
+		commands.push(parts.join(" "));
+	}
+})();
+
+commands.forEach(function(cmd) {
+	try {
+		console.log(">>", cmd);
+		spawn(cmd, {stdio: "inherit"});
+	}
+	catch (e) {
+		status = e.status;
+	}
+});
+
+process.exit(status);


### PR DESCRIPTION
Fixes a small annoyance that you don't know if, for example, stylelint would return any errors until eslint comes all clean. This makes it so all tests are ran, and only return failure at the end.

I had to add a small script because the only ways to make this work with normal shell commands is kinda ugly. This makes it so commands are simply separated by the `+` character, and in the event someone totally needs to use `+` in a command, `\+` can be used instead to insert a literal `+` in the command.