### PR TITLE
Improve tests execution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,9 @@ deploy:
     node: '4'
     tags: true
     repo: thelounge/lounge
+
+script:
+- npm run test:mocha
+- npm run lint:js
+- npm run lint:css
+

--- a/package.json
+++ b/package.json
@@ -12,9 +12,14 @@
   },
   "scripts": {
     "start": "node index",
-    "build": "grunt && handlebars client/views/ -e tpl -f client/js/lounge.templates.js",
-    "test": "HOME=test/fixtures mocha test/**/*.js && npm run lint",
-    "lint": "eslint . && stylelint \"**/*.css\"",
+    "build": "npm run build:grunt && npm run build:handlebars",
+    "build:grunt": "grunt",
+    "build:handlebars": "handlebars client/views/ -e tpl -f client/js/lounge.templates.js",
+    "test": "npm run test:mocha; npm run lint",
+    "test:mocha": "mocha -r test/fixtures/env.js test/**/*.js",
+    "lint": "npm run lint:js; npm run lint:css",
+    "lint:js": "eslint .",
+    "lint:css": "stylelint \"**/*.css\"",
     "prepublish": "npm run build"
   },
   "keywords": [

--- a/test/fixtures/env.js
+++ b/test/fixtures/env.js
@@ -1,0 +1,1 @@
+process.env.HOME = "test/fixtures";


### PR DESCRIPTION
As explained in #259, the current way of running the linters makes it so that if one of them errors out, then the next one is never ran. This causes the situation where you are forced to fix all eslint errors before you can see stylelint errors.

This migrates both to mocha tests, so we now have one single test command to run to deal with everything.