### PR TITLE
Improve sticky scroll

### DIFF
--- a/client/js/libs/jquery/stickyscroll.js
+++ b/client/js/libs/jquery/stickyscroll.js
@@ -1,67 +1,34 @@
-/*!
- * stickyscroll
- * https://github.com/erming/stickyscroll
- * v2.2.0
- */
 (function($) {
+	$.fn.unsticky = function() {
+		return this.unbind(".sticky");
+	};
+
 	$.fn.sticky = function() {
-		if (this.size() > 1) {
-			return this.each(function() {
-				$(this).sticky(options);
-			});
-		}
-
-		var isBottom = false;
 		var self = this;
+		var stuckToBottom = true;
 
-		this.unbind(".sticky");
-		this.on("beforeAppend.sticky", function() {
-			isBottom = isScrollBottom.call(self);
-		});
+		self
+			.on("scroll.sticky", function(e) {
+				stuckToBottom = self.isScrollBottom();
+			})
+			.on("msg.sticky", function() {
+				if (stuckToBottom) {
+					self.scrollBottom();
+				}
+			})
+			.scrollBottom();
 
-		this.on("afterAppend.sticky", function() {
-			if (isBottom) {
-				self.scrollBottom();
-			}
-		});
-
-		var overflow = this.css("overflow-y");
-		if (overflow == "visible") {
-			overflow = "auto";
-		}
-		this.css({
-			"overflow-y": overflow
-		});
-
-		$(window).unbind(".sticky");
-		$(window).on("resize.sticky", function() {
-				self.scrollBottom();
-		});
-
-		this.scrollBottom();
-		return this;
+		return self;
 	};
 
 	$.fn.scrollBottom = function() {
-		return this.each(function() {
-			$(this).animate({scrollTop: this.scrollHeight}, 0);
-		});
-	};
-
-	$.fn.isScrollBottom = isScrollBottom;
-
-	function isScrollBottom() {
-		if ((this.scrollTop() + this.outerHeight() + 1) >= this.prop("scrollHeight")) {
-			return true;
-		} else {
-			return false;
-		}
-	};
-
-	var append = $.fn.append;
-	$.fn.append = function() {
-		this.trigger("beforeAppend");
-		append.apply(this, arguments).trigger("afterAppend")
+		var el = this[0];
+		this.scrollTop(el.scrollHeight);
 		return this;
+	};
+
+	$.fn.isScrollBottom = function() {
+		var el = this[0];
+		return el.scrollHeight - el.scrollTop - el.offsetHeight <= 30;
 	};
 })(jQuery);

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -656,15 +656,20 @@ $(function() {
 		}
 
 		viewport.removeClass("lt");
-		$("#windows .active").removeClass("active");
+		$("#windows .active")
+			.removeClass("active")
+			.find(".chat")
+			.unsticky();
 
 		var chan = $(target)
 			.addClass("active")
 			.trigger("show")
-			.css("z-index", top++)
-			.find(".chat")
-			.sticky()
-			.end();
+			.css("z-index", top++);
+
+		var chanChat = chan.find(".chat");
+		if (chanChat.length > 0) {
+			chanChat.sticky();
+		}
 
 		var title = "The Lounge";
 		if (chan.data("title")) {


### PR DESCRIPTION
- No longer overrides `$.fn.append`
- No longer jumps to bottom whenever resizing the window
 - *I tried making this keep the scroll position at lowest visible message, but there is no sane way of doing this*
- No longer sets the css with js, we already have it in our styles
- ~~Whenever you send the message, it will scroll to the bottom~~
- Gives 30 pixels of slack to keep the scroll at the bottom
- There's a `stuckToBottom` variable which can be used to display "More messages below" div in the future.