### PR TITLE
Create a single helper function to write messages

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -147,13 +147,10 @@ Client.prototype.connect = function(args) {
 	if (config.lockNetwork) {
 		// This check is needed to prevent invalid user configurations
 		if (args.host && args.host.length > 0 && args.host !== config.defaults.host) {
-			client.emit("msg", {
-				chan: network.channels[0].id,
-				msg: new Msg({
-					type: Msg.Type.ERROR,
-					text: "Hostname you specified is not allowed."
-				})
-			});
+			network.channels[0].pushMessage(client, new Msg({
+				type: Msg.Type.ERROR,
+				text: "Hostname you specified is not allowed."
+			}));
 			return;
 		}
 
@@ -163,13 +160,10 @@ Client.prototype.connect = function(args) {
 	}
 
 	if (network.host.length === 0) {
-		client.emit("msg", {
-			chan: network.channels[0].id,
-			msg: new Msg({
-				type: Msg.Type.ERROR,
-				text: "You must specify a hostname to connect."
-			})
-		});
+		network.channels[0].pushMessage(client, new Msg({
+			type: Msg.Type.ERROR,
+			text: "You must specify a hostname to connect."
+		}));
 		return;
 	}
 
@@ -264,13 +258,10 @@ Client.prototype.input = function(data) {
 	}
 
 	if (!connected) {
-		this.emit("msg", {
-			chan: target.chan.id,
-			msg: new Msg({
-				type: Msg.Type.ERROR,
-				text: "You are not connected to the IRC network, unable to send your command."
-			})
-		});
+		target.chan.pushMessage(this, new Msg({
+			type: Msg.Type.ERROR,
+			text: "You are not connected to the IRC network, unable to send your command."
+		}));
 	}
 };
 

--- a/src/command-line/index.js
+++ b/src/command-line/index.js
@@ -8,14 +8,6 @@ program.version(pkg.version, "-v, --version");
 program.option("");
 program.option("    --home <path>" , "home path");
 
-require("./start");
-require("./config");
-require("./list");
-require("./add");
-require("./remove");
-require("./reset");
-require("./edit");
-
 var argv = program.parseOptions(process.argv);
 if (program.home) {
 	Helper.HOME = program.home;
@@ -31,6 +23,14 @@ if (!fs.existsSync(config)) {
 	console.log("Config created:");
 	console.log(config);
 }
+
+require("./start");
+require("./config");
+require("./list");
+require("./add");
+require("./remove");
+require("./reset");
+require("./edit");
 
 program.parse(argv.args);
 

--- a/src/models/chan.js
+++ b/src/models/chan.js
@@ -1,4 +1,5 @@
 var _ = require("lodash");
+var Helper = require("../helper");
 
 module.exports = Chan;
 
@@ -9,6 +10,7 @@ Chan.Type = {
 };
 
 var id = 0;
+var config = Helper.getConfig();
 
 function Chan(attr) {
 	_.merge(this, _.extend({
@@ -22,6 +24,19 @@ function Chan(attr) {
 		users: []
 	}, attr));
 }
+
+Chan.prototype.pushMessage = function(client, msg) {
+	this.messages.push(msg);
+
+	if (config.maxHistory >= 0 && this.messages.length > config.maxHistory) {
+		this.messages.splice(0, this.messages.length - config.maxHistory);
+	}
+
+	client.emit("msg", {
+		chan: this.id,
+		msg: msg
+	});
+};
 
 Chan.prototype.sortUsers = function(irc) {
 	var userModeSortPriority = {};

--- a/src/models/chan.js
+++ b/src/models/chan.js
@@ -26,16 +26,22 @@ function Chan(attr) {
 }
 
 Chan.prototype.pushMessage = function(client, msg) {
+	client.emit("msg", {
+		chan: this.id,
+		msg: msg
+	});
+
+	// Never store messages in public mode as the session
+	// is completely destroyed when the page gets closed
+	if (config.public) {
+		return;
+	}
+
 	this.messages.push(msg);
 
 	if (config.maxHistory >= 0 && this.messages.length > config.maxHistory) {
 		this.messages.splice(0, this.messages.length - config.maxHistory);
 	}
-
-	client.emit("msg", {
-		chan: this.id,
-		msg: msg
-	});
 };
 
 Chan.prototype.sortUsers = function(irc) {

--- a/src/plugins/inputs/part.js
+++ b/src/plugins/inputs/part.js
@@ -6,13 +6,10 @@ exports.allowDisconnected = true;
 
 exports.input = function(network, chan, cmd, args) {
 	if (chan.type === "lobby") {
-		this.emit("msg", {
-			chan: chan.id,
-			msg: new Msg({
-				type: Msg.Type.ERROR,
-				text: "You can not part from networks, use /quit instead."
-			})
-		});
+		chan.pushMessage(this, new Msg({
+			type: Msg.Type.ERROR,
+			text: "You can not part from networks, use /quit instead."
+		}));
 		return;
 	}
 

--- a/src/plugins/inputs/query.js
+++ b/src/plugins/inputs/query.js
@@ -17,25 +17,19 @@ exports.input = function(network, chan, cmd, args) {
 
 	var char = target[0];
 	if (network.irc.network.options.CHANTYPES && network.irc.network.options.CHANTYPES.indexOf(char) !== -1) {
-		this.emit("msg", {
-			chan: chan.id,
-			msg: new Msg({
-				type: Msg.Type.ERROR,
-				text: "You can not open query windows for channels, use /join instead."
-			})
-		});
+		chan.pushMessage(this, new Msg({
+			type: Msg.Type.ERROR,
+			text: "You can not open query windows for channels, use /join instead."
+		}));
 		return;
 	}
 
 	for (var i = 0; i < network.irc.network.options.PREFIX.length; i++) {
 		if (network.irc.network.options.PREFIX[i].symbol === char) {
-			this.emit("msg", {
-				chan: chan.id,
-				msg: new Msg({
-					type: Msg.Type.ERROR,
-					text: "You can not open query windows for names starting with a user prefix."
-				})
-			});
+			chan.pushMessage(this, new Msg({
+				type: Msg.Type.ERROR,
+				text: "You can not open query windows for names starting with a user prefix."
+			}));
 			return;
 		}
 	}

--- a/src/plugins/irc-events/connection.js
+++ b/src/plugins/irc-events/connection.js
@@ -5,53 +5,44 @@ var Msg = require("../../models/msg");
 module.exports = function(irc, network) {
 	var client = this;
 
-	client.emit("msg", {
-		chan: network.channels[0].id,
-		msg: new Msg({
-			text: "Network created, connecting to " + network.host + ":" + network.port + "..."
-		})
-	});
+	network.channels[0].pushMessage(client, new Msg({
+		text: "Network created, connecting to " + network.host + ":" + network.port + "..."
+	}));
 
 	irc.on("raw socket connected", function() {
 		identd.hook(irc.connection.socket, network.username);
 	});
 
 	irc.on("socket connected", function() {
-		client.emit("msg", {
-			chan: network.channels[0].id,
-			msg: new Msg({
-				text: "Connected to the network."
-			})
-		});
+		network.channels[0].pushMessage(client, new Msg({
+			text: "Connected to the network."
+		}));
 	});
 
 	irc.on("socket close", function() {
-		client.emit("msg", {
-			chan: network.channels[0].id,
-			msg: new Msg({
-				text: "Disconnected from the network."
-			})
-		});
+		network.channels[0].pushMessage(client, new Msg({
+			text: "Disconnected from the network."
+		}));
 	});
 
 	irc.on("socket error", function(err) {
 		console.log(err);
-		client.emit("msg", {
-			chan: network.channels[0].id,
-			msg: new Msg({
-				type: Msg.Type.ERROR,
-				text: "Socket error: " + err
-			})
-		});
+		network.channels[0].pushMessage(client, new Msg({
+			type: Msg.Type.ERROR,
+			text: "Socket error: " + err
+		}));
 	});
 
 	irc.on("reconnecting", function() {
-		client.emit("msg", {
-			chan: network.channels[0].id,
-			msg: new Msg({
-				text: "Reconnecting..."
-			})
-		});
+		network.channels[0].pushMessage(client, new Msg({
+			text: "Reconnecting..."
+		}));
+	});
+
+	irc.on("ping timeout", function() {
+		network.channels[0].pushMessage(client, new Msg({
+			text: "Ping timeout, disconnecting..."
+		}));
 	});
 
 	irc.on("server options", function(data) {

--- a/src/plugins/irc-events/ctcp.js
+++ b/src/plugins/irc-events/ctcp.js
@@ -17,11 +17,7 @@ module.exports = function(irc, network) {
 			ctcpType: data.type,
 			ctcpMessage: data.message
 		});
-		chan.messages.push(msg);
-		client.emit("msg", {
-			chan: chan.id,
-			msg: msg
-		});
+		chan.pushMessage(client, msg);
 	});
 
 	irc.on("ctcp request", function(data) {

--- a/src/plugins/irc-events/error.js
+++ b/src/plugins/irc-events/error.js
@@ -20,10 +20,7 @@ module.exports = function(irc, network) {
 			type: Msg.Type.ERROR,
 			text: text,
 		});
-		client.emit("msg", {
-			chan: lobby.id,
-			msg: msg
-		});
+		lobby.pushMessage(client, msg);
 	});
 
 	irc.on("nick in use", function(data) {
@@ -32,10 +29,7 @@ module.exports = function(irc, network) {
 			type: Msg.Type.ERROR,
 			text: data.nick + ": " + (data.reason || "Nickname is already in use."),
 		});
-		client.emit("msg", {
-			chan: lobby.id,
-			msg: msg
-		});
+		lobby.pushMessage(client, msg);
 
 		if (irc.connection.registered === false) {
 			var random = (data.nick || irc.user.nick) + Math.floor(10 + (Math.random() * 89));
@@ -49,10 +43,7 @@ module.exports = function(irc, network) {
 			type: Msg.Type.ERROR,
 			text: data.nick + ": " + (data.reason || "Nickname is invalid."),
 		});
-		client.emit("msg", {
-			chan: lobby.id,
-			msg: msg
-		});
+		lobby.pushMessage(client, msg);
 
 		if (irc.connection.registered === false) {
 			var random = "i" + Math.random().toString(36).substr(2, 10); // 'i' so it never begins with a number

--- a/src/plugins/irc-events/invite.js
+++ b/src/plugins/irc-events/invite.js
@@ -16,10 +16,6 @@ module.exports = function(irc, network) {
 			channel: data.channel,
 			invitedYou: data.invited === irc.user.nick
 		});
-		chan.messages.push(msg);
-		client.emit("msg", {
-			chan: chan.id,
-			msg: msg
-		});
+		chan.pushMessage(client, msg);
 	});
 };

--- a/src/plugins/irc-events/join.js
+++ b/src/plugins/irc-events/join.js
@@ -29,10 +29,6 @@ module.exports = function(irc, network) {
 			type: Msg.Type.JOIN,
 			self: data.nick === irc.user.nick
 		});
-		chan.messages.push(msg);
-		client.emit("msg", {
-			chan: chan.id,
-			msg: msg
-		});
+		chan.pushMessage(client, msg);
 	});
 };

--- a/src/plugins/irc-events/kick.js
+++ b/src/plugins/irc-events/kick.js
@@ -29,10 +29,6 @@ module.exports = function(irc, network) {
 			highlight: data.kicked === irc.user.nick,
 			self: data.nick === irc.user.nick
 		});
-		chan.messages.push(msg);
-		client.emit("msg", {
-			chan: chan.id,
-			msg: msg
-		});
+		chan.pushMessage(client, msg);
 	});
 };

--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -35,11 +35,7 @@ module.exports = function(irc, network) {
 		var msg = new Msg({
 			type: Msg.Type.TOGGLE,
 		});
-		chan.messages.push(msg);
-		client.emit("msg", {
-			chan: chan.id,
-			msg: msg
-		});
+		chan.pushMessage(client, msg);
 
 		var link = escapeHeader(links[0]);
 		fetch(link, function(res) {

--- a/src/plugins/irc-events/message.js
+++ b/src/plugins/irc-events/message.js
@@ -1,10 +1,8 @@
 var Chan = require("../../models/chan");
 var Msg = require("../../models/msg");
-var Helper = require("../../helper");
 
 module.exports = function(irc, network) {
 	var client = this;
-	var config = Helper.getConfig();
 
 	irc.on("notice", function(data) {
 		// Some servers send notices without any nickname
@@ -83,15 +81,6 @@ module.exports = function(irc, network) {
 			self: self,
 			highlight: highlight
 		});
-		chan.messages.push(msg);
-
-		if (config.maxHistory >= 0 && chan.messages.length > config.maxHistory) {
-			chan.messages.splice(0, chan.messages.length - config.maxHistory);
-		}
-
-		client.emit("msg", {
-			chan: chan.id,
-			msg: msg
-		});
+		chan.pushMessage(client, msg);
 	}
 };

--- a/src/plugins/irc-events/mode.js
+++ b/src/plugins/irc-events/mode.js
@@ -38,11 +38,7 @@ module.exports = function(irc, network) {
 				text: text,
 				self: data.nick === irc.user.nick
 			});
-			targetChan.messages.push(msg);
-			client.emit("msg", {
-				chan: targetChan.id,
-				msg: msg,
-			});
+			targetChan.pushMessage(client, msg);
 		}
 
 		if (usersUpdated) {

--- a/src/plugins/irc-events/motd.js
+++ b/src/plugins/irc-events/motd.js
@@ -11,11 +11,7 @@ module.exports = function(irc, network) {
 					type: Msg.Type.MOTD,
 					text: text
 				});
-				lobby.messages.push(msg);
-				client.emit("msg", {
-					chan: lobby.id,
-					msg: msg
-				});
+				lobby.pushMessage(client, msg);
 			});
 		}
 
@@ -24,11 +20,7 @@ module.exports = function(irc, network) {
 				type: Msg.Type.MOTD,
 				text: data.error
 			});
-			lobby.messages.push(msg);
-			client.emit("msg", {
-				chan: lobby.id,
-				msg: msg
-			});
+			lobby.pushMessage(client, msg);
 		}
 	});
 };

--- a/src/plugins/irc-events/nick.js
+++ b/src/plugins/irc-events/nick.js
@@ -10,11 +10,7 @@ module.exports = function(irc, network) {
 			var msg = new Msg({
 				text: "You're now known as " + data.new_nick,
 			});
-			lobby.messages.push(msg);
-			client.emit("msg", {
-				chan: lobby.id,
-				msg: msg
-			});
+			lobby.pushMessage(client, msg);
 			self = true;
 			client.save();
 			client.emit("nick", {
@@ -41,11 +37,7 @@ module.exports = function(irc, network) {
 				new_nick: data.new_nick,
 				self: self
 			});
-			chan.messages.push(msg);
-			client.emit("msg", {
-				chan: chan.id,
-				msg: msg
-			});
+			chan.pushMessage(client, msg);
 		});
 	});
 };

--- a/src/plugins/irc-events/part.js
+++ b/src/plugins/irc-events/part.js
@@ -29,11 +29,7 @@ module.exports = function(irc, network) {
 				hostmask: data.ident + "@" + data.hostname,
 				from: from
 			});
-			chan.messages.push(msg);
-			client.emit("msg", {
-				chan: chan.id,
-				msg: msg
-			});
+			chan.pushMessage(client, msg);
 		}
 	});
 };

--- a/src/plugins/irc-events/quit.js
+++ b/src/plugins/irc-events/quit.js
@@ -22,11 +22,7 @@ module.exports = function(irc, network) {
 				hostmask: data.ident + "@" + data.hostname,
 				from: from
 			});
-			chan.messages.push(msg);
-			client.emit("msg", {
-				chan: chan.id,
-				msg: msg
-			});
+			chan.pushMessage(client, msg);
 		});
 	});
 };

--- a/src/plugins/irc-events/topic.js
+++ b/src/plugins/irc-events/topic.js
@@ -16,11 +16,7 @@ module.exports = function(irc, network) {
 			text: data.topic,
 			self: data.nick === irc.user.nick
 		});
-		chan.messages.push(msg);
-		client.emit("msg", {
-			chan: chan.id,
-			msg: msg
-		});
+		chan.pushMessage(client, msg);
 
 		chan.topic = data.topic;
 		client.emit("topic", {
@@ -42,10 +38,6 @@ module.exports = function(irc, network) {
 			when: new Date(data.when * 1000),
 			self: data.nick === irc.user.nick
 		});
-		chan.messages.push(msg);
-		client.emit("msg", {
-			chan: chan.id,
-			msg: msg
-		});
+		chan.pushMessage(client, msg);
 	});
 };

--- a/src/plugins/irc-events/welcome.js
+++ b/src/plugins/irc-events/welcome.js
@@ -8,11 +8,7 @@ module.exports = function(irc, network) {
 		var msg = new Msg({
 			text: "You're now known as " + data.nick
 		});
-		lobby.messages.push(msg);
-		client.emit("msg", {
-			chan: lobby.id,
-			msg: msg
-		});
+		lobby.pushMessage(client, msg);
 		client.save();
 		client.emit("nick", {
 			network: network.id,

--- a/src/plugins/irc-events/whois.js
+++ b/src/plugins/irc-events/whois.js
@@ -30,10 +30,6 @@ module.exports = function(irc, network) {
 			});
 		}
 
-		chan.messages.push(msg);
-		client.emit("msg", {
-			chan: chan.id,
-			msg: msg
-		});
+		chan.pushMessage(client, msg);
 	});
 };

--- a/test/util.js
+++ b/test/util.js
@@ -3,6 +3,7 @@ var util = require("util");
 var _ = require("lodash");
 var express = require("express");
 var Network = require("../src/models/network");
+var Chan = require("../src/models/chan");
 
 function MockClient(opts) {
 	this.user = {nick: "test-user"};
@@ -30,10 +31,9 @@ module.exports = {
 	createNetwork: function() {
 		return new Network({
 			host: "example.com",
-			channels: [{
-				name: "#test-channel",
-				messages: []
-			}]
+			channels: [new Chan({
+				name: "#test-channel"
+			})]
 		});
 	},
 	createWebserver: function() {


### PR DESCRIPTION
This solves a couple of issues:

- Certain messages were not stored in memory, so reloading the page would not print them on the client (e.g. connection related messages)
- `maxHistory` is *always* applied, not just when receiving messages in channels
- Fixes #232: Do not store messages in memory when running in public mode
- Single consistent function increases readability (and less boilerplate code)
