### PR TITLE
Add support for echo-message and znc.in/self-message caps

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -761,8 +761,7 @@ $(function() {
 
 	chat.on("msg", ".messages", function(e, target, msg) {
 		var button = sidebar.find(".chan[data-target='" + target + "']");
-		var isQuery = button.hasClass("query");
-		if (msg.type === "invite" || msg.highlight || isQuery || (options.notifyAllMessages && msg.type === "message")) {
+		if (msg.highlight || (options.notifyAllMessages && msg.type === "message")) {
 			if (!document.hasFocus() || !$(target).hasClass("active")) {
 				if (options.notification) {
 					pop.play();
@@ -778,7 +777,7 @@ $(function() {
 						body = msg.from + " invited you to " + msg.channel;
 					} else {
 						title = msg.from;
-						if (!isQuery) {
+						if (!button.hasClass("query")) {
 							title += " (" + button.data("title").trim() + ")";
 						}
 						title += " says:";
@@ -823,7 +822,7 @@ $(function() {
 			var i = (badge.data("count") || 0) + 1;
 			badge.data("count", i);
 			badge.html(i > 999 ? (i / 1000).toFixed(1) + "k" : i);
-			if (msg.highlight || isQuery) {
+			if (msg.highlight) {
 				badge.addClass("highlight");
 			}
 		}

--- a/src/client.js
+++ b/src/client.js
@@ -174,6 +174,10 @@ Client.prototype.connect = function(args) {
 	}
 
 	network.irc = new ircFramework.Client();
+	network.irc.requestCap([
+		"echo-message",
+		"znc.in/self-message",
+	]);
 	network.irc.connect({
 		host: network.host,
 		port: network.port,

--- a/src/plugins/inputs/action.js
+++ b/src/plugins/inputs/action.js
@@ -16,11 +16,15 @@ exports.input = function(network, chan, cmd, args) {
 		text = text || args.join(" ");
 
 		irc.say(chan.name, "\u0001ACTION " + text + "\u0001");
-		irc.emit("action", {
-			nick: irc.user.nick,
-			target: chan.name,
-			message: text
-		});
+
+		if (!network.irc.network.cap.isEnabled("echo-message")) {
+			irc.emit("action", {
+				nick: irc.user.nick,
+				target: chan.name,
+				message: text
+			});
+		}
+
 		break;
 	}
 

--- a/src/plugins/inputs/msg.js
+++ b/src/plugins/inputs/msg.js
@@ -19,13 +19,15 @@ exports.input = function(network, chan, cmd, args) {
 	var msg = args.join(" ");
 	irc.say(target, msg);
 
-	var channel = network.getChannel(target);
-	if (typeof channel !== "undefined") {
-		irc.emit("privmsg", {
-			nick: irc.user.nick,
-			target: channel.name,
-			message: msg
-		});
+	if (!network.irc.network.cap.isEnabled("echo-message")) {
+		var channel = network.getChannel(target);
+		if (typeof channel !== "undefined") {
+			irc.emit("privmsg", {
+				nick: irc.user.nick,
+				target: channel.name,
+				message: msg
+			});
+		}
 	}
 
 	return true;

--- a/src/plugins/inputs/notice.js
+++ b/src/plugins/inputs/notice.js
@@ -15,11 +15,13 @@ exports.input = function(network, chan, cmd, args) {
 		targetChan = chan;
 	}
 
-	irc.emit("notice", {
-		nick: irc.user.nick,
-		target: targetChan.name,
-		message: message
-	});
+	if (!network.irc.network.cap.isEnabled("echo-message")) {
+		irc.emit("notice", {
+			nick: irc.user.nick,
+			target: targetChan.name,
+			message: message
+		});
+	}
 
 	return true;
 };

--- a/src/plugins/irc-events/invite.js
+++ b/src/plugins/irc-events/invite.js
@@ -14,6 +14,7 @@ module.exports = function(irc, network) {
 			from: data.nick,
 			invited: data.invited,
 			channel: data.channel,
+			highlight: true,
 			invitedYou: data.invited === irc.user.nick
 		});
 		chan.messages.push(msg);

--- a/src/plugins/irc-events/message.js
+++ b/src/plugins/irc-events/message.js
@@ -28,6 +28,9 @@ module.exports = function(irc, network) {
 	});
 
 	function handleMessage(data) {
+		var highlight = false;
+		var self = data.nick === irc.user.nick;
+
 		// Server messages go to server window, no questions asked
 		if (data.from_server) {
 			chan = network.channels[0];
@@ -45,6 +48,7 @@ module.exports = function(irc, network) {
 				if (data.type === Msg.Type.NOTICE) {
 					chan = network.channels[0];
 				} else {
+					highlight = !self;
 					chan = new Chan({
 						type: Chan.Type.QUERY,
 						name: target
@@ -58,13 +62,14 @@ module.exports = function(irc, network) {
 			}
 		}
 
-		var self = data.nick === irc.user.nick;
-
+		// Query messages (unless self) always highlight
 		// Self messages are never highlighted
 		// Non-self messages are highlighted as soon as the nick is detected
-		var highlight = !self && data.message.split(" ").some(function(w) {
-			return (w.replace(/^@/, "").toLowerCase().indexOf(irc.user.nick.toLowerCase()) === 0);
-		});
+		if (!highlight && !self) {
+			highlight = data.message.split(" ").some(function(w) {
+				return (w.replace(/^@/, "").toLowerCase().indexOf(irc.user.nick.toLowerCase()) === 0);
+			});
+		}
 
 		if (chan.id !== client.activeChannel) {
 			chan.unread++;


### PR DESCRIPTION
- Add support for `echo-message` and `znc.in/self-message` caps.
 - `znc.in/self-message` because latest znc version still does not have `echo-message`, and people often don't upgrade their ZNC for a long time
- Moved query/invite highlight logic from the client to the server
 - Fixes self messages received in query windows triggering a highlight

Fixes #269 and #74