### PR TITLE
Only increase unread counter for whitelisted actions

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -807,14 +807,12 @@ $(function() {
 			return;
 		}
 
-		var ignore = [
-			"join",
-			"part",
-			"quit",
-			"nick",
-			"mode",
+		var whitelistedActions = [
+			"message",
+			"notice",
+			"action",
 		];
-		if ($.inArray(msg.type, ignore) !== -1) {
+		if (whitelistedActions.indexOf(msg.type) === -1) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #271. Only three actions whitelisted because only these actions increase the unread counter on the server, and we must follow the exact same rules.