### PR TITLE
Settings overhaul

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1078,23 +1078,76 @@ button,
 	margin-top: 30px;
 }
 
+/**
+ * Settings
+ */
 #settings .title {
-	margin-bottom: -10px;
+	margin-bottom: 20px;
 }
 
-#settings .opt {
+table.settings {
+	margin: 20px 15px;
+	width: calc(100% - 30px);
+	table-layout: fixed;
+	border-collapse: collapse;
+}
+
+table.settings th:first-child,
+table.settings td:first-child {
+	text-align: left;
+}
+
+.public table.settings th:last-child,
+.public table.settings td:last-child {
+	display: none;
+}
+
+table.settings th,
+table.settings td {
+	padding: 6px 0;
+	text-align: center;
+}
+
+table.settings th {
+	color: #7f8c8d;
+	border-bottom: #eee 1px solid;
+}
+
+table.settings th.section-title {
+	font: inherit;
+	font-size: 22px;
+}
+
+table.settings td {
+	color: #555;
+	border-bottom: #f5f5f5 1px solid;
+}
+
+table.settings .icon,
+#settings .sync-header .icon {
+	width: 32px;
+	font: 16px "FontAwesome";
+}
+
+table.settings input[type="checkbox"],
+#settings .sync-header input[type="checkbox"] {
+	width: 16px;
+	height: 16px;
+	vertical-align: middle;
+}
+
+#settings .sync-header {
 	display: block;
-	padding: 5px 0 10px 1px;
-}
-
-#settings .opt input {
-	float: left;
-	margin: 4px 10px 0 0;
+	float: right;
 }
 
 #settings .about,
 #settings #play {
 	color: #7f8c8d;
+}
+
+#settings #play {
+	font-size: 14px;
 }
 
 #settings .about small {
@@ -1105,10 +1158,9 @@ button,
 	opacity: .8;
 }
 
-#settings #play:before {
+#settings #play .icon:after {
 	content: "\f028";
 	font: 14px FontAwesome;
-	margin-right: 9px;
 }
 
 #settings .about {
@@ -1133,6 +1185,12 @@ button,
 #settings .error {
 	color: #e74c3c;
 	margin-top: .2em;
+}
+
+#settings textarea#user-specified-css-input {
+	font-family: monospace;
+	font-size: 12px;
+	height: 200px;
 }
 
 #form {

--- a/client/index.html
+++ b/client/index.html
@@ -169,143 +169,126 @@
 						<button class="lt"></button>
 					</div>
 					<div class="container">
-						<div class="row">
-							<div class="col-sm-12">
-								<h1 class="title">Settings</h1>
-							</div>
-							<div class="col-sm-12">
-								<h2>Messages</h2>
-							</div>
-							<div class="col-sm-6">
-								<label class="opt">
-									<input type="checkbox" name="setting:join">
-									Show joins
-								</label>
-							</div>
-							<div class="col-sm-6">
-								<label class="opt">
-									<input type="checkbox" name="setting:motd">
-									Show motd
-								</label>
-							</div>
-							<div class="col-sm-6">
-								<label class="opt">
-									<input type="checkbox" name="setting:part">
-									Show parts
-								</label>
-							</div>
-							<div class="col-sm-6">
-								<label class="opt">
-									<input type="checkbox" name="setting:nick">
-									Show nick changes
-								</label>
-							</div>
-							<div class="col-sm-6">
-								<label class="opt">
-									<input type="checkbox" name="setting:mode">
-									Show mode
-								</label>
-							</div>
-							<div class="col-sm-6">
-								<label class="opt">
-									<input type="checkbox" name="setting:quit">
-									Show quits
-								</label>
-							</div>
-							<div class="col-sm-12">
-								<h2>Visual Aids</h2>
-							</div>
-							<div class="col-sm-12">
-								<label class="opt">
-									<input type="checkbox" name="setting:colors">
-									Enable colored nicknames
-								</label>
-							</div>
+						<div class="col-sm-12">
+							<h1 class="title">Settings</h1>
+						</div>
+						
+						<table class="settings">
+							<tr>
+								<th class="section-title">Messages</th>
+								<th class="icon" title="Enabled"> &#xf046; </th>
+								<th class="icon" title="Synchronize to server"> &#xf0c2; </th>
+							</tr>
+							<tr>
+								<td> <label for="setting:motd">Show motd</label> </td>
+								<td> <input type="checkbox" id="setting:motd" name="setting:motd"> </td>
+								<td> <input type="checkbox" id="sync:motd"    name="sync:motd"> </td>
+							</tr>
+							<tr>
+								<td> <label for="setting:join">Show joins</label> </td>
+								<td> <input type="checkbox" id="setting:join" name="setting:join"> </td>
+								<td> <input type="checkbox" id="sync:join"    name="sync:join"> </td>
+							</tr>
+							<tr>
+								<td> <label for="setting:part">Show parts</label> </td>
+								<td> <input type="checkbox" id="setting:part" name="setting:part"> </td>
+								<td> <input type="checkbox" id="sync:part"    name="sync:part"> </td>
+							</tr>
+							<tr>
+								<td> <label for="setting:quit">Show quits</label> </td>
+								<td> <input type="checkbox" id="setting:quit" name="setting:quit"> </td>
+								<td> <input type="checkbox" id="sync:quit"    name="sync:quit"> </td>
+							</tr>
+							<tr>
+								<td> <label for="setting:nick">Show nick changes</label> </td>
+								<td> <input type="checkbox" id="setting:nick" name="setting:nick"> </td>
+								<td> <input type="checkbox" id="sync:nick"    name="sync:nick"> </td>
+							</tr>
+							<tr>
+								<td> <label for="setting:mode">Show mode changes</label> </td>
+								<td> <input type="checkbox" id="setting:mode" name="setting:mode"> </td>
+								<td> <input type="checkbox" id="sync:mode"    name="sync:mode"> </td>
+							</tr>
+						</table>
+						
+						<table class="settings">
+							<tr>
+								<th class="section-title">Visual Aids</th>
+								<th class="icon"></th>
+								<th class="icon"></th>
+							</tr>
+							<tr>
+								<td> <label for="setting:colors">Enable colored nicknames</label> </td>
+								<td> <input type="checkbox" id="setting:colors" name="setting:colors"> </td>
+								<td> <input type="checkbox" id="sync:colors"    name="sync:colors"> </td>
+							</tr>
 							<% if (typeof prefetch === "undefined" || prefetch !== false) { %>
-							<div class="col-sm-12">
-								<h2>Links and URLs</h2>
-							</div>
-							<div class="col-sm-6">
-								<label class="opt">
-									<input type="checkbox" name="setting:thumbnails">
-									Auto-expand thumbnails
-								</label>
-							</div>
-							<div class="col-sm-6">
-								<label class="opt">
-									<input type="checkbox" name="setting:links">
-									Auto-expand links
-								</label>
-							</div>
+							<tr>
+								<td> <label for="setting:thumbnails">Auto-expand thumbnails</label> </td>
+								<td> <input type="checkbox" id="setting:thumbnails" name="setting:thumbnails"> </td>
+								<td> <input type="checkbox" id="sync:thumbnails"    name="sync:thumbnails"> </td>
+							</tr>
+							<tr>
+								<td> <label for="setting:links">Auto-expand links</label> </td>
+								<td> <input type="checkbox" id="setting:links" name="setting:links"> </td>
+								<td> <input type="checkbox" id="sync:links"    name="sync:links"> </td>
+							</tr>
 							<% } %>
-							<div class="col-sm-12">
-								<h2>Notifications</h2>
-							</div>
-							<div class="col-sm-12">
-								<label class="opt">
-								<input id="desktopNotifications" type="checkbox" name="setting:desktopNotifications">
-								Enable desktop notifications<br>
-								<div class="error" id="warnDisabledDesktopNotifications"><strong>Warning</strong>: Desktop notifications are blocked by your web browser</div>
-								</label>
-							</div>
-							<div class="col-sm-12">
-								<label class="opt">
-								<input type="checkbox" name="setting:notification">
-								Enable notification sound
-								</label>
-							</div>
-							<div class="col-sm-12">
-								<div class="opt">
-									<button id="play">Play sound</button>
-								</div>
-							</div>
-
-							<div class="col-sm-12">
-								<label class="opt">
-									<input type="checkbox" name="setting:notifyAllMessages">
-									Enable notification for all messages
-								</label>
-							</div>
-							<% if (!public) { %>
-							<div id="change-password">
-								<form action="" method="post">
-									<div class="col-sm-12">
-										<h2>Change password</h2>
+						</table>
+						
+						<table class="settings">
+							<tr>
+								<th class="section-title">Notifications</th>
+								<th class="icon"></th>
+								<th class="icon"></th>
+							</tr>
+							<tr>
+								<td>
+									<label for="setting:desktopNotifications">Enable desktop notifications</label>
+									<div class="error" id="warnDisabledDesktopNotifications">
+										<strong>Warning</strong>: Desktop notifications are blocked by your web browser
 									</div>
-									<div class="col-sm-12">
-										<label for="old_password_input" class="sr-only">Enter current password</label>
-										<input type="password" id="old_password_input" name="old_password" class="input" placeholder="Enter current password">
-									</div>
-									<div class="col-sm-12">
-										<label for="new_password_input" class="sr-only">Enter desired new password</label>
-										<input type="password" id="new_password_input" name="new_password" class="input" placeholder="Enter desired new password">
-									</div>
-									<div class="col-sm-12">
-										<label for="verify_password_input" class="sr-only">Repeat new password</label>
-										<input type="password" id="verify_password_input" name="verify_password" class="input" placeholder="Repeat new password">
-									</div>
-									<div class="col-sm-12 feedback"></div>
-									<div class="col-sm-12">
-										<button type="submit" class="btn">Change password</button>
-									</div>
-								</form>
-							</div>
-							<% } %>
-							<div class="col-sm-12">
-								<h2>Custom Stylesheet</h2>
-							</div>
-							<div class="col-sm-12">
-								<textarea class="input" name="setting:userStyles" id="user-specified-css-input" placeholder="You can override any style with CSS here"></textarea>
-							</div>
-							<div class="col-sm-12">
-								<h2>About The Lounge</h2>
-							</div>
-							<div class="col-sm-12">
-								<p class="about">
-									You're currently running version <%= version %><br>
-									<a href="https://github.com/thelounge/lounge/blob/master/CHANGELOG.md#readme" target="_blank">View the change log</a>
-								</p>
-							</div>
+								</td>
+								<td> <input type="checkbox" id="setting:desktopNotifications" name="setting:desktopNotifications"> </td>
+								<td> <input type="checkbox" id="sync:desktopNotifications"    name="sync:desktopNotifications"> </td>
+							</tr>
+							<tr>
+								<td>
+									<label for="setting:notification">Enable notification sound</label>
+									<button id="play">(<span class="icon"></span> play sound)</button>
+								</td>
+								<td> <input type="checkbox" id="setting:notification" name="setting:notification"> </td>
+								<td> <input type="checkbox" id="sync:notification"    name="sync:notification"> </td>
+							</tr>
+							<tr>
+								<td> <label for="setting:notifyAllMessages">Enable notification for all messages</label> </td>
+								<td> <input type="checkbox" id="setting:notifyAllMessages" name="setting:notifyAllMessages"> </td>
+								<td> <input type="checkbox" id="sync:notifyAllMessages"    name="sync:notifyAllMessages"> </td>
+							</tr>
+						</table>
+						
+						<div class="col-sm-12">
+							<h2>
+								Custom Stylesheet
+								<% if (!public) { %>
+								<span class="sync-header">
+									<input type="checkbox" id="sync:userStyles" name="sync:userStyles">
+									<span class="icon" title="Synchronize to server"> &#xf0c2; </span>
+								</span>
+								<% } %>
+							</h2>
+						</div>
+						<div class="col-sm-12">
+							<textarea class="input" name="setting:userStyles" id="user-specified-css-input" placeholder="You can override any style with CSS here"></textarea>
+						</div>
+						<div class="col-sm-12">
+							<h2>About The Lounge</h2>
+						</div>
+						<div class="col-sm-12">
+							<p class="about">
+								You're currently running version <%= version %><br>
+								<a href="https://github.com/thelounge/lounge/blob/master/CHANGELOG.md#readme" target="_blank">View the change log</a>
+							</p>
 						</div>
 					</div>
 				</div>

--- a/client/index.html
+++ b/client/index.html
@@ -178,37 +178,37 @@
 							</div>
 							<div class="col-sm-6">
 								<label class="opt">
-									<input type="checkbox" name="join">
+									<input type="checkbox" name="setting:join">
 									Show joins
 								</label>
 							</div>
 							<div class="col-sm-6">
 								<label class="opt">
-									<input type="checkbox" name="motd">
+									<input type="checkbox" name="setting:motd">
 									Show motd
 								</label>
 							</div>
 							<div class="col-sm-6">
 								<label class="opt">
-									<input type="checkbox" name="part">
+									<input type="checkbox" name="setting:part">
 									Show parts
 								</label>
 							</div>
 							<div class="col-sm-6">
 								<label class="opt">
-									<input type="checkbox" name="nick">
+									<input type="checkbox" name="setting:nick">
 									Show nick changes
 								</label>
 							</div>
 							<div class="col-sm-6">
 								<label class="opt">
-									<input type="checkbox" name="mode">
+									<input type="checkbox" name="setting:mode">
 									Show mode
 								</label>
 							</div>
 							<div class="col-sm-6">
 								<label class="opt">
-									<input type="checkbox" name="quit">
+									<input type="checkbox" name="setting:quit">
 									Show quits
 								</label>
 							</div>
@@ -217,7 +217,7 @@
 							</div>
 							<div class="col-sm-12">
 								<label class="opt">
-									<input type="checkbox" name="colors">
+									<input type="checkbox" name="setting:colors">
 									Enable colored nicknames
 								</label>
 							</div>
@@ -227,13 +227,13 @@
 							</div>
 							<div class="col-sm-6">
 								<label class="opt">
-									<input type="checkbox" name="thumbnails">
+									<input type="checkbox" name="setting:thumbnails">
 									Auto-expand thumbnails
 								</label>
 							</div>
 							<div class="col-sm-6">
 								<label class="opt">
-									<input type="checkbox" name="links">
+									<input type="checkbox" name="setting:links">
 									Auto-expand links
 								</label>
 							</div>
@@ -243,14 +243,14 @@
 							</div>
 							<div class="col-sm-12">
 								<label class="opt">
-								<input id="desktopNotifications" type="checkbox" name="desktopNotifications">
+								<input id="desktopNotifications" type="checkbox" name="setting:desktopNotifications">
 								Enable desktop notifications<br>
 								<div class="error" id="warnDisabledDesktopNotifications"><strong>Warning</strong>: Desktop notifications are blocked by your web browser</div>
 								</label>
 							</div>
 							<div class="col-sm-12">
 								<label class="opt">
-								<input type="checkbox" name="notification">
+								<input type="checkbox" name="setting:notification">
 								Enable notification sound
 								</label>
 							</div>
@@ -262,7 +262,7 @@
 
 							<div class="col-sm-12">
 								<label class="opt">
-									<input type="checkbox" name="notifyAllMessages">
+									<input type="checkbox" name="setting:notifyAllMessages">
 									Enable notification for all messages
 								</label>
 							</div>
@@ -295,7 +295,7 @@
 								<h2>Custom Stylesheet</h2>
 							</div>
 							<div class="col-sm-12">
-								<textarea class="input" name="userStyles" id="user-specified-css-input" placeholder="You can override any style with CSS here"></textarea>
+								<textarea class="input" name="setting:userStyles" id="user-specified-css-input" placeholder="You can override any style with CSS here"></textarea>
 							</div>
 							<div class="col-sm-12">
 								<h2>About The Lounge</h2>

--- a/client/themes/morning.css
+++ b/client/themes/morning.css
@@ -40,6 +40,10 @@ QUIT #d0907d
 	color: #ccc;
 }
 
+table.settings td {
+	color: inherit;
+}
+
 #chat .count {
 	background-color: #2e3642;
 }
@@ -58,7 +62,8 @@ QUIT #d0907d
 #chat .from,
 #windows .header,
 #chat .user-mode:before,
-#chat .sidebar {
+#chat .sidebar,
+table.settings td {
 	border-color: #2a323d;
 }
 

--- a/client/themes/zenburn.css
+++ b/client/themes/zenburn.css
@@ -40,18 +40,14 @@ body {
 
 #settings,
 #sign-in,
-#connect {
-	color: #dcdccc;
-}
-
-#settings,
-#sign-in,
 #connect .title {
 	color: #88b090;
 }
 
-#settings,
-#sign-in,
+table.settings td {
+	color: inherit;
+}
+
 #connect .opt {
 	color: #dcdccc;
 }
@@ -88,7 +84,8 @@ body {
 #chat .from,
 #windows .header,
 #chat .user-mode:before,
-#chat .sidebar {
+#chat .sidebar,
+table.settings td {
 	border-color: #333;
 }
 

--- a/src/client.js
+++ b/src/client.js
@@ -6,6 +6,7 @@ var Msg = require("./models/msg");
 var Network = require("./models/network");
 var ircFramework = require("irc-framework");
 var Helper = require("./helper");
+var Settings = require("./clientSettings");
 
 module.exports = Client;
 
@@ -60,7 +61,8 @@ function Client(manager, name, config) {
 		name: name,
 		networks: [],
 		sockets: manager.sockets,
-		manager: manager
+		manager: manager,
+		settings: new Settings(),
 	});
 	var client = this;
 	crypto.randomBytes(48, function(err, buf) {
@@ -74,7 +76,13 @@ function Client(manager, name, config) {
 			}, delay);
 			delay += 1000;
 		});
+
+		if ("settings" in config) {
+			this.settings.replace(config.settings);
+		}
 	}
+
+	this.settings.bindToClient(this);
 }
 
 Client.prototype.emit = function(event, data) {

--- a/src/clientSettings.js
+++ b/src/clientSettings.js
@@ -1,0 +1,86 @@
+var EventEmitter = require("events").EventEmitter;
+var util = require("util");
+
+function Settings(def) {
+	var self = this;
+	EventEmitter.call(this);
+
+	this.options = def || {};
+
+	this.on("change", function(key, value) {
+		self.emit("change:" + key, value, key);
+	});
+	this.on("unset", function(key) {
+		self.emit("unset:" + key, key);
+	});
+}
+
+util.inherits(Settings, EventEmitter);
+
+Settings.prototype.get = function(key, def) {
+	if (key in this.options) {
+		return this.options[key];
+	}
+	else {
+		return def;
+	}
+};
+
+Settings.prototype.set = function(key, value) {
+	this.options[key] = value;
+	this.emit("change", key, value);
+};
+
+Settings.prototype.unset = function(key) {
+	delete this.options[key];
+	this.emit("unset", key);
+};
+
+Settings.prototype.merge = function(data) {
+	// Remove all gone settings
+	for (var key in this.options) {
+		if (!(key in data)) {
+			this.unset(key);
+		}
+	}
+
+	// Apply all new options
+	for (key in data) {
+		this.set(key, data[key]);
+	}
+};
+
+Settings.prototype.bindToClient = function(client) {
+	var settings = this;
+	var save = function() {};
+
+	if (client.name) {
+		save = function() {
+			client.manager.updateUser(client.name, {settings: settings.options});
+		};
+	}
+
+	settings.on("change", function(key, value) {
+		client.emit("settings:set", {key: key, value: value});
+		save();
+	});
+
+	settings.on("unset", function(key) {
+		client.emit("settings:unset", {key: key});
+		save();
+	});
+};
+
+Settings.prototype.bindToSocket = function(socket) {
+	var settings = this;
+
+	socket.on("settings:set", function(data) {
+		settings.set(data.key, data.value);
+	});
+
+	socket.on("settings:unset", function(data) {
+		settings.unset(data.key);
+	});
+};
+
+module.exports = Settings;

--- a/src/server.js
+++ b/src/server.js
@@ -173,8 +173,11 @@ function init(socket, client, token) {
 		socket.emit("init", {
 			active: client.activeChannel,
 			networks: client.networks,
-			token: token || ""
+			token: token || "",
+			settings: client.settings.options,
 		});
+
+		client.settings.bindToSocket(socket);
 	}
 }
 


### PR DESCRIPTION
This redoes pretty much everything related to client-side settings and unties them from the DOM. Most of the action happens in the `Settings` class in preparation for a future client-side API, which makes listening to setting changes a lot easier. Setting handlers never touches or sees the DOM.

It also makes the binding glue between the settings and the DOM work the other way, so invisible settings are possible and can be tied to multiple controls or sources at once. This could be used later, for example, by a `/set` command or for any other reason.

Communication with the server is also made separate for good measures, so the settings are usable without any active socket.

A similar API is exposed on the server through `client.settings`, with the same separation of concerns, and will update all clients. These settings can be further used by the server to save preferences server-side, such as an highlight word list, auto away on/off, and many other things.

Obviously, it comes with a new settings page on the client.

---

This doesn't exactly solve #85 as the focus of this PR wasn't to fix the settings UI, but to provide the backend infrastructure for server settings so we're not stuck waiting for design just to implement features. It just happened that I had to redo the frontend to both to avoid unnecessary pain plugging it back in, as well as showcase the thing in action.

---

Suggestions welcome. I think it's really pretty good so far, and allows for a lot of future customization.

![capture d ecran_2016-04-24_23-16-49](https://cloud.githubusercontent.com/assets/5481612/14773011/a3ce6bb8-0a72-11e6-834d-14902b1f37ac.png)

Demo video: https://d.max-p.me/irc/settings.mp4
