### PR TITLE
Document supported node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: node_js
 node_js:
-- '5.6'
-- '4.3'
-- '0.12'
+- '6'
+- '5'
+- '4'
+- '4.2.0'
 notifications:
   email:
     on_success: never
@@ -14,6 +15,6 @@ deploy:
   api_key:
     secure: I9iN31GWI+Mz0xPw81N7qh1M6uidB+3BmiPUXt8QigX45zwp9EhvfZ0U/AIdUyQwzK2RK1zLRQSt+2/1jyeVi+U+AAsRRmaAUx8iqKaQPAkPnQtElolgRP04WSgo7fvNejfM7zS939bQNKG3RlSm04yPgu+ke2igf799p2bpFe2LtyoEeIiUfrUkBiMSpMguN9XF8a7jqCyIouTKjXHR24RmzJ9r7ZoMV27yQauS7XlD81bontzNRZxTytDKdJpZ+sxGIT9mbbtM4LUFX8MeNe3p/bjWavEhrO0ZIpkbOfS/L/w1375YDoNPXxCs288lnGUH+NbGNAEfn+BTz8cmUp7jI7QWR/kNACPeopdAX4OdZxT8wfQcfQZrfCuSpKciOMC7vGgPpQqjQ61t1RKcKs9VUnwC0SwWjyo8LlzkFKnP1ks0eDGYsSoPLdpC9+76UmePkQdxMhscO8TOgkOCcsTMLiyt6ABGOGKu2iE5SsjUYtPiSiRzSBAQENoO560+xBSVTKwqvvhzUAIt4AuAQSgsFjAylDdyzKoObHX12hBdALrqSOOSVwwIQ5/jTgNAsilURHo7KPD407PhRnLOsvumL0qg4sr9S1hjuUKnNla5dg9GY8FVjJ+b2t0A2vgfG1pR1e3vrJRXrpkfRorhmjvKAk2o5you5pQ1Itty7rM=
   on:
-    node: '5.6'
+    node: '4'
     tags: true
     repo: thelounge/lounge

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ the review process quicker and more streamlined.
 
 ## Install
 
+To use The Lounge you must have [Node.js](https://nodejs.org/en/download/) installed.
+The oldest Node.js version we support is 4.2.0.
+
+If you still use 0.10 or 0.12 we strongly advise you to upgrade before installing The Lounge.
+For more information on how to upgrade, read the [documentation](https://nodejs.org/en/download/package-manager/).
+
 ```
 sudo npm install -g thelounge
 ```

--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "server"
   ],
   "license": "MIT",
+  "engines": {
+    "node": ">=4.2.0"
+  },
   "dependencies": {
     "bcrypt-nodejs": "0.0.3",
     "cheerio": "0.20.0",
@@ -39,6 +42,7 @@
     "moment": "2.13.0",
     "read": "1.0.7",
     "request": "2.72.0",
+    "semver": "5.1.0",
     "socket.io": "1.4.5",
     "spdy": "3.3.2"
   },

--- a/src/server.js
+++ b/src/server.js
@@ -1,4 +1,5 @@
 var _ = require("lodash");
+var package = require("../package.json");
 var bcrypt = require("bcrypt-nodejs");
 var Client = require("./client");
 var ClientManager = require("./clientManager");
@@ -56,8 +57,13 @@ module.exports = function(options) {
 
 	manager.sockets = sockets;
 
-	log.info("The Lounge is now running on", protocol + "://" + config.host + ":" + config.port + "/");
-	log.info("Press ctrl-c to stop");
+	log.info("The Lounge v" + package.version + " is now running on", protocol + "://" + config.host + ":" + config.port + "/");
+	log.info("Press ctrl-c to stop\n");
+
+	if (!require("semver").satisfies(process.version, package.engines.node)) {
+		log.warn("The oldest supported Node.js version is ", package.engines.node);
+		log.warn("We strongly encourage you to upgrade, see https://nodejs.org/en/download/package-manager/ for more details\n");
+	}
 
 	if (!config.public) {
 		manager.loadUsers();
@@ -71,7 +77,7 @@ function index(req, res, next) {
 	if (req.url.split("?")[0] !== "/") return next();
 	return fs.readFile("client/index.html", "utf-8", function(err, file) {
 		var data = _.merge(
-			require("../package.json"),
+			package,
 			config
 		);
 		var template = _.template(file);


### PR DESCRIPTION
Fixes #231.

`engines` field only affects new installations, and only emits a warning like this:
```
npm WARN engine thelounge@1.5.0: wanted: {"node":">=8.2.0"} (current: {"node":"5.4.1","npm":"3.3.12"})
```

It does not block installation. I documented 4.2.0 because it's the lowest LTS version, as seen here: https://nodejs.org/en/download/releases/

It only took about a month to release 4.2.0 after 4.0.0, so it's not going to be a big problem.