### PR TITLE
Fix derp in new logger

### DIFF
--- a/src/log.js
+++ b/src/log.js
@@ -14,7 +14,7 @@ function timestamp(type, messageArgs) {
 	return messageArgs;
 }
 
-exports.err = function() {
+exports.error = function() {
 	console.error.apply(console, timestamp(colors.red("[ERROR]"), arguments));
 };
 


### PR DESCRIPTION
Chose to rename to `error` as that's what's used everywhere and what the `console` object would expose, so it's more of a drop-in replacement.