### PR TITLE
Add security headers to minimize XSS damage

### DIFF
--- a/client/js/libs/handlebars/parse.js
+++ b/client/js/libs/handlebars/parse.js
@@ -14,7 +14,7 @@ function uri(text) {
 			return url;
 		}
 		var split = url.split("<");
-		url = "<a href='" + split[0].replace(/^www/, "//www") + "' target='_blank'>" + split[0] + "</a>";
+		url = "<a href='" + split[0].replace(/^www/, "//www") + "' target='_blank' rel='noopener'>" + split[0] + "</a>";
 		if (split.length > 1) {
 			url += "<" + split.slice(1).join("<");
 		}

--- a/src/server.js
+++ b/src/server.js
@@ -17,6 +17,7 @@ module.exports = function(options) {
 	config = _.extend(config, options);
 
 	var app = express()
+		.use(allRequests)
 		.use(index)
 		.use(express.static("client"));
 
@@ -80,6 +81,11 @@ function getClientIp(req) {
 	}
 }
 
+function allRequests(req, res, next) {
+	res.setHeader("X-Content-Type-Options", "nosniff");
+	return next();
+}
+
 function index(req, res, next) {
 	if (req.url.split("?")[0] !== "/") {
 		return next();
@@ -91,6 +97,7 @@ function index(req, res, next) {
 			config
 		);
 		var template = _.template(file);
+		res.setHeader("Content-Security-Policy", "default-src *; style-src * 'unsafe-inline'; script-src 'self'; child-src 'none'; object-src 'none'; form-action 'none'; referrer no-referrer;");
 		res.setHeader("Content-Type", "text/html");
 		res.writeHead(200);
 		res.end(template(data));


### PR DESCRIPTION
This disallows execution of scripts from other domains, inline scripts and use of eval. Also adds `X-Content-Type-Options: nosniff` on all requests.