### PR TITLE
Make sure app does not crash when webirc is not defined in the configuration

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -172,7 +172,7 @@ Client.prototype.connect = function(args) {
 		return;
 	}
 
-	if (config.webirc !== null && network.host in config.webirc) {
+	if (config.webirc && network.host in config.webirc) {
 		args.ip = args.ip || (client.config && client.config.ip) || client.ip;
 		args.hostname = args.hostname || (client.config && client.config.hostname) || client.hostname || args.ip;
 


### PR DESCRIPTION
The check currently tests against `null`. When the configuration file does not even have `webirc`, its value is `undefined`, not `null`:

```js
/home/dusk/lounge/src/client.js:175
        if (config.webirc !== null && network.host in config.webirc) {
                                                            ^

TypeError: Cannot use 'in' operator to search for 'ocelot.link' in undefined
    at Client.connect ([...]/lounge/src/client.js:175:54)
    at Timeout._onTimeout ([...]/lounge/src/client.js:73:12)
    at tryOnTimeout (timers.js:224:11)
    at Timer.listOnTimeout (timers.js:198:5)
```

This PR also ensures smoother upgrades: when upgrading, if admins do not set `webirc` to `null` or something, it will just refuse to run.