### PR TITLE
Minor wording changes for better clarity

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -179,7 +179,7 @@
 							<div class="col-sm-6">
 								<label class="opt">
 									<input type="checkbox" name="motd">
-									Show motd
+									Show <abbr title="Message Of The Day">MOTD</abbr>
 								</label>
 							</div>
 							<div class="col-sm-6">

--- a/client/views/chat.tpl
+++ b/client/views/chat.tpl
@@ -12,7 +12,7 @@
 	<div class="chat">
 		<div class="show-more {{#equal messages.length 100}}show{{/equal}}">
 			<button class="show-more-button" data-id="{{id}}">
-				Show more
+				Show older messages
 			</button>
 		</div>
 		<div class="messages"></div>


### PR DESCRIPTION
These 2 changes make text a tiny bit more explicit.
In particular, when using a screen reader (VoiceOver in my tests), "motd" is read as a word while "MOTD" is read letter-by-letter, and "Show more" is read without any context, making it difficult to understand "more what" we are talking about.