### PR TITLE
Bump patch version of lodash to 4.11.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "event-stream": "3.3.2",
     "express": "4.13.4",
     "irc-framework": "1.0.10",
-    "lodash": "4.11.1",
+    "lodash": "4.11.2",
     "mkdirp": "0.5.1",
     "moment": "2.13.0",
     "read": "1.0.7",


### PR DESCRIPTION
Diff at https://github.com/lodash/lodash/compare/4.11.1...4.11.2.