### PR TITLE
Fix unread counter not being formatted on page load

### DIFF
--- a/client/js/libs/handlebars/roundBadgeNumber.js
+++ b/client/js/libs/handlebars/roundBadgeNumber.js
@@ -1,0 +1,9 @@
+Handlebars.registerHelper(
+	"roundBadgeNumber", function(count) {
+		if (count < 1000) {
+			return count;
+		}
+
+		return (count / 1000).toFixed(2).slice(0, -1) + "k";
+	}
+);

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -670,7 +670,7 @@ $(function() {
 		self.addClass("active")
 			.find(".badge")
 			.removeClass("highlight")
-			.data("count", "")
+			.data("count", 0)
 			.empty();
 
 		if (sidebar.find(".highlight").length === 0) {
@@ -845,7 +845,7 @@ $(function() {
 		if (badge.length !== 0) {
 			var i = (badge.data("count") || 0) + 1;
 			badge.data("count", i);
-			badge.html(i > 999 ? (i / 1000).toFixed(1) + "k" : i);
+			badge.html(Handlebars.helpers.roundBadgeNumber(i));
 			if (msg.highlight) {
 				badge.addClass("highlight");
 			}

--- a/client/views/chan.tpl
+++ b/client/views/chan.tpl
@@ -1,6 +1,6 @@
 {{#each channels}}
 <div data-id="{{id}}" data-target="#chan-{{id}}" data-title="{{name}}" class="chan {{type}}">
-	<span class="badge{{#if highlight}} highlight{{/if}}" data-count="{{unread}}">{{#if unread}}{{unread}}{{/if}}</span>
+	<span class="badge{{#if highlight}} highlight{{/if}}" data-count="{{unread}}">{{#if unread}}{{roundBadgeNumber unread}}{{/if}}</span>
 	<button class="close" aria-label="Close"></button>
 	<span class="name" title="{{name}}">{{name}}</span>
 </div>


### PR DESCRIPTION
This also fixes `1666` being formatted as `1.7k` instead of `1.6k`.