### PR TITLE
Fix running multiple scripts on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "build": "npm run build:grunt && npm run build:handlebars",
     "build:grunt": "grunt",
     "build:handlebars": "handlebars client/views/ -e tpl -f client/js/lounge.templates.js",
-    "test": "npm run test:mocha; npm run lint",
+    "test": "(npm run test:mocha || true) && npm run lint",
     "test:mocha": "mocha -r test/fixtures/env.js test/**/*.js",
-    "lint": "npm run lint:js; npm run lint:css",
+    "lint": "(npm run lint:js || true) && (npm run lint:css || true)",
     "lint:js": "eslint .",
     "lint:css": "stylelint \"**/*.css\"",
     "prepublish": "npm run build"


### PR DESCRIPTION
There's basically no other way besides making a standalone script or writing JS code for it.