### PR TITLE
Don't check for existing password emptyness

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -137,12 +137,6 @@ function init(socket, client, token) {
 					var old = data.old_password;
 					var p1 = data.new_password;
 					var p2 = data.verify_password;
-					if (typeof old === "undefined" || old === "") {
-						socket.emit("change-password", {
-							error: "Please enter your current password"
-						});
-						return;
-					}
 					if (typeof p1 === "undefined" || p1 === "") {
 						socket.emit("change-password", {
 							error: "Please enter a new password"


### PR DESCRIPTION
Pointed out by @PugaBear, it's possible for a user to have an empty password. There isn't really a need to check for password emptyness, it will simply fail with wrong old password instead. This allows users with an empty password to be created and allows them to set a password.

While I think a temporary password should be used instead, we allow creating a user with no password so we should also handle it.