### PR TITLE
Fix wrong CSS for disabled colored nicknames on themes

### DIFF
--- a/client/themes/crypto.css
+++ b/client/themes/crypto.css
@@ -112,8 +112,8 @@ a:hover,
 	top: 48px;
 }
 
-#chat.no-colors .from button,
-#chat.no-colors .sidebar button {
+#chat.no-colors .from .user,
+#chat.no-colors .sidebar .user {
 	color: #000 !important;
 	font-weight: bold;
 }

--- a/client/themes/morning.css
+++ b/client/themes/morning.css
@@ -92,13 +92,13 @@ QUIT #d0907d
 }
 
 /* Nicknames */
-#chat.no-colors .from button,
-#chat.no-colors .sidebar button {
+#chat.no-colors .from .user,
+#chat.no-colors .sidebar .user {
 	color: #b0bacf !important;
 }
 
-#chat.no-colors .from button:hover,
-#chat.no-colors .sidebar button:hover {
+#chat.no-colors .from .user:hover,
+#chat.no-colors .sidebar .user:hover {
 	color: #fefefe !important;
 }
 

--- a/client/themes/zenburn.css
+++ b/client/themes/zenburn.css
@@ -122,13 +122,13 @@ body {
 }
 
 /* Nicknames */
-#chat.no-colors .from button,
-#chat.no-colors .sidebar button {
+#chat.no-colors .from .user,
+#chat.no-colors .sidebar .user {
 	color: #bc8cbc !important;
 }
 
-#chat.no-colors .from button:hover,
-#chat.no-colors .sidebar button:hover {
+#chat.no-colors .from .user:hover,
+#chat.no-colors .sidebar .user:hover {
 	color: #dcdccc !important;
 }
 


### PR DESCRIPTION
Nicknames on themes were keeping the default green color because we changed from `button`s to `a` links.

The fix matches [what we do on the `example.css` file](https://github.com/thelounge/lounge/blob/973fa0f4b29e953f91d1396f860ea7b7d46f516e/client/css/style.css#L749-L752).

(This will conflict with #317 when one gets merged, I'll rebase and resolve conflicts on whichever is not merged first.)