### PR TITLE
Fix sending messages starting with a space

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -267,7 +267,7 @@ Client.prototype.setPassword = function(hash) {
 
 Client.prototype.input = function(data) {
 	var client = this;
-	var text = data.text.trim();
+	var text = data.text;
 	var target = client.find(data.target);
 
 	// This is either a normal message or a command escaped with a leading '/'

--- a/src/plugins/inputs/msg.js
+++ b/src/plugins/inputs/msg.js
@@ -1,19 +1,11 @@
 exports.commands = ["msg", "say"];
 
 exports.input = function(network, chan, cmd, args) {
-	if (args.length === 0 || args[0] === "") {
-		return true;
-	}
-
 	var irc = network.irc;
-	var target = "";
-	if (cmd === "msg") {
-		target = args.shift();
-		if (args.length === 0) {
-			return true;
-		}
-	} else {
-		target = chan.name;
+	var target = cmd === "msg" ? args.shift() : chan.name;
+
+	if (args.length === 0 || !target) {
+		return true;
 	}
 
 	var msg = args.join(" ");


### PR DESCRIPTION
There really is no need to trim apart bringing more situations like this. If I want to put spaces in front of my message (say, for alignment purposes), then I should be able to.

Fixes #319