### PR TITLE
Fix notifications in query windows

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -868,9 +868,9 @@ button,
 
 #chat .error,
 #chat .error .from,
-#chat .highlight .from,
-#chat .highlight .text,
-#chat .highlight .user {
+#chat .channel .highlight .from,
+#chat .channel .highlight .text,
+#chat .channel .highlight .user {
 	color: #f00;
 }
 

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -827,8 +827,7 @@ $(function() {
 			}
 		}
 
-		button = button.filter(":not(.active)");
-		if (button.length === 0) {
+		if (button.hasClass("active")) {
 			return;
 		}
 

--- a/client/themes/morning.css
+++ b/client/themes/morning.css
@@ -163,8 +163,8 @@ QUIT #d0907d
 
 #chat .error,
 #chat .error .from,
-#chat .highlight,
-#chat .highlight .from {
+#chat .channel .highlight,
+#chat .channel .highlight .from {
 	color: #f92772;
 }
 

--- a/client/themes/zenburn.css
+++ b/client/themes/zenburn.css
@@ -193,8 +193,8 @@ body {
 
 #chat .error,
 #chat .error .from,
-#chat .highlight,
-#chat .highlight .from {
+#chat .channel .highlight,
+#chat .channel .highlight .from {
 	color: #bc6c4c;
 }
 

--- a/src/plugins/irc-events/message.js
+++ b/src/plugins/irc-events/message.js
@@ -46,7 +46,6 @@ module.exports = function(irc, network) {
 				if (data.type === Msg.Type.NOTICE) {
 					chan = network.channels[0];
 				} else {
-					highlight = !self;
 					chan = new Chan({
 						type: Chan.Type.QUERY,
 						name: target
@@ -58,10 +57,14 @@ module.exports = function(irc, network) {
 					});
 				}
 			}
+
+			// Query messages (unless self) always highlight
+			if (chan.type === Chan.Type.QUERY) {
+				highlight = !self;
+			}
 		}
 
-		// Query messages (unless self) always highlight
-		// Self messages are never highlighted
+		// Self messages in channels are never highlighted
 		// Non-self messages are highlighted as soon as the nick is detected
 		if (!highlight && !self) {
 			highlight = network.highlightRegex.test(data.message);


### PR DESCRIPTION
Fixes #333 with a little trickery.

Makes notifications always appear for query messages. Also makes `highlight` class to be never applied in query windows (even if your nick is mentioned).