### PR TITLE
Add tab complete on mobile when tapping our nick

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -595,6 +595,12 @@ $(function() {
 		.history()
 		.tab(complete, {hint: false});
 
+	$("#nick").on("touchstart", function(e) {
+		e.type = "keydown.tabcomplete";
+		e.which = 9;
+		input.triggerHandler(e);
+	});
+
 	var form = $("#form");
 
 	form.on("submit", function(e) {


### PR DESCRIPTION
Not exactly the most intuitive thing, but it was an easy fix at least for now and feels like the most obvious place to place it.

I had to trigger it that way because the tab complete plugin binds directly to the keyboard on the element, so there's no way to trigger it externally.