### PR TITLE
Turn favicon red on page load if there are highlights

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -157,6 +157,10 @@ $(function() {
 			);
 			channels.forEach(renderChannel);
 			confirmExit();
+
+			if (sidebar.find(".highlight").length) {
+				toggleFaviconNotification(true);
+			}
 		}
 
 		if (data.token) {


### PR DESCRIPTION
Fixes favicon not turning red on page load if user has unread highlights.