### PR TITLE
Don't send completely empty messages

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -604,11 +604,18 @@ $(function() {
 	form.on("submit", function(e) {
 		e.preventDefault();
 		var text = input.val();
+
+		if (text.length === 0) {
+			return;
+		}
+
 		input.val("");
+
 		if (text.indexOf("/clear") === 0) {
 			clear();
 			return;
 		}
+
 		socket.emit("input", {
 			target: chat.data("id"),
 			text: text

--- a/src/plugins/inputs/msg.js
+++ b/src/plugins/inputs/msg.js
@@ -9,6 +9,11 @@ exports.input = function(network, chan, cmd, args) {
 	}
 
 	var msg = args.join(" ");
+
+	if (msg.length === 0) {
+		return true;
+	}
+
 	irc.say(target, msg);
 
 	if (!network.irc.network.cap.isEnabled("echo-message")) {


### PR DESCRIPTION
Little oops due to #320, sending white space is fine but sending completely empty messages isn't. Fixing both on the server and the client to prevent unneeded spamming of the server if something is holding the key and key repeat kicks in.

Bug pointed out by @MaxLeiter on IRC.