### PR TITLE
Adds kick, ban, and kickban to user context menus, closes #347

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1311,6 +1311,18 @@ button,
 	content: "\f0f6";
 }
 
+.context-menu-user-kick:before {
+	content: "\f112";
+}
+
+.context-menu-user-ban:before {
+	content: "\f05e";
+}
+
+.context-menu-user-kickban:before {
+	content: "\f235";
+}
+
 .context-menu-close:before {
 	content: "\f00d";
 }

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -559,6 +559,24 @@ $(function() {
 				text: target.text(),
 				data: target.data("name")
 			});
+			if (target.data("name") !== $("#nick").text()) {
+				output += render("contextmenu_divider");
+				output += render("contextmenu_item", {
+					class: "user-kick",
+					text: "Kick",
+					data: target.data("name")
+				});
+				output += render("contextmenu_item", {
+					class: "user-ban",
+					text: "Ban",
+					data: target.data("name")
+				});
+				output += render("contextmenu_item", {
+					class: "user-kickban",
+					text: "Kickban",
+					data: target.data("name")
+				});
+			}
 		} else if (target.hasClass("chan")) {
 			output = render("contextmenu_item", {
 				class: "chan",
@@ -750,6 +768,10 @@ $(function() {
 		return false;
 	});
 
+	function applyCommandToUser(command) {
+		socket.emit("input", {target: chat.data("id"), text: command + " " + $(this).data("data")});
+	}
+
 	contextMenu.on("click", ".context-menu-item", function() {
 		switch ($(this).data("action")) {
 		case "close":
@@ -761,6 +783,15 @@ $(function() {
 		case "user":
 			$(".channel.active .users .user[data-name=" + $(this).data("data") + "]").click();
 			break;
+		case "user-ban":
+			applyCommandToUser("/mode +b");
+			break;
+		case "user-kick":
+			applyCommandToUser("/kick");
+			break;
+		case "user-kickban":
+			applyCommandToUser("/mode +b");
+			applyCommandToUser("/kick");
 		}
 	});
 


### PR DESCRIPTION
![image](https://sr.ht/igZQ.png)

Any suggestions on the icons? Should ban and kickban be the same?

As a note, `ban` simply sets `mode +b`  on the selected user. 

I'm not sure if it's worth including `applyCommandToUser`, but otherwise there would be a lot of code duplication (`socket.emit {}`...)