### PR TITLE
client: fix focusing input when clicking chat container

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -637,7 +637,7 @@ $(function() {
 		}
 	});
 
-	chat.on("click", ".messages", function() {
+	chat.on("click", ".chat", function() {
 		setTimeout(function() {
 			var text = "";
 			if (window.getSelection) {


### PR DESCRIPTION
Not sure why it delegates events to the `.messages` container.