### PR TITLE
CI tool for Windows builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![#thelounge IRC channel on freenode](https://img.shields.io/badge/irc%20channel-%23thelounge%20on%20freenode-blue.svg)](https://avatar.playat.ch:1000/)
 [![npm version](https://img.shields.io/npm/v/thelounge.svg)](https://www.npmjs.org/package/thelounge)
-[![Build Status](https://travis-ci.org/thelounge/lounge.svg?branch=master)](https://travis-ci.org/thelounge/lounge)
+[![Travis CI Build Status](https://travis-ci.org/thelounge/lounge.svg?branch=master)](https://travis-ci.org/thelounge/lounge)
+[![AppVeyor Build status](https://ci.appveyor.com/api/projects/status/deymtp0lldq78s8t/branch/master?svg=true)](https://ci.appveyor.com/project/astorije/lounge/branch/master)
 [![Dependency Status](https://david-dm.org/thelounge/lounge.svg)](https://david-dm.org/thelounge/lounge)
 [![devDependency Status](https://david-dm.org/thelounge/lounge/dev-status.svg)](https://david-dm.org/thelounge/lounge#info=devDependencies)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,23 @@
+---
+# http://www.appveyor.com/docs/appveyor-yml
+
+# Build version format
+version: "{build}"
+
+# Do not build on tags (GitHub only)
+skip_tags: true
+
+environment:
+  nodejs_version: '4'
+
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - npm install
+
+test_script:
+  - node --version
+  - npm --version
+  - npm test
+
+# Don't actually build
+build: off


### PR DESCRIPTION
History has shown that we have broke our build/test environment on Windows before, see https://github.com/thelounge/lounge/pull/309.

This is just a smoke test to make sure we don't do this again. For example, things like #361 need that kind of things, otherwise we'll always have to ask "can someone test on Windows please?" :-)

Regarding Node version, I went for latest LTS. I know @maxpoulin64 is in favor of specifying latest. I don't have a preference, I'll go with whatever you guys want. Any of them is still better than none!
Note that AppVeyor does not parallelize and is rather super slow, so we should stick to one.

Also, you'll notice badge says `astorije/lounge`. That's because stupid AppVeyor doesn't reflect GitHub organizations, doh. If that's a huge deal for you, I'll find a way (like creating a secondary account, but what a pain), otherwise I think it's good enough for our needs.