### PR TITLE
Remove design-specific nickname colors from base system style

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -746,45 +746,6 @@ button,
 	color: #50a656;
 }
 
-/* Nicknames */
-
-#chat .user {
-	color: #50a656;
-}
-
-#chat.colored-nicks .user.color-1 { color: #1396cf; }
-#chat.colored-nicks .user.color-2 { color: #ffcf89; }
-#chat.colored-nicks .user.color-3 { color: #00dc5f; }
-#chat.colored-nicks .user.color-4 { color: #ff5bc8; }
-#chat.colored-nicks .user.color-5 { color: #ff0e1b; }
-#chat.colored-nicks .user.color-6 { color: #000094; }
-#chat.colored-nicks .user.color-7 { color: #006441; }
-#chat.colored-nicks .user.color-8 { color: #00566e; }
-#chat.colored-nicks .user.color-9 { color: #ff0078; }
-#chat.colored-nicks .user.color-10 { color: #15d5a3; }
-#chat.colored-nicks .user.color-11 { color: #006b3b; }
-#chat.colored-nicks .user.color-12 { color: #00c5ba; }
-#chat.colored-nicks .user.color-13 { color: #00465b; }
-#chat.colored-nicks .user.color-14 { color: #ffafce; }
-#chat.colored-nicks .user.color-15 { color: #ff3b12; }
-#chat.colored-nicks .user.color-16 { color: #16cc6a; }
-#chat.colored-nicks .user.color-17 { color: #ff0072; }
-#chat.colored-nicks .user.color-18 { color: #ff5877; }
-#chat.colored-nicks .user.color-19 { color: #ff1753; }
-#chat.colored-nicks .user.color-20 { color: #007a56; }
-#chat.colored-nicks .user.color-21 { color: #095092; }
-#chat.colored-nicks .user.color-22 { color: #000bde; }
-#chat.colored-nicks .user.color-23 { color: #00bca9; }
-#chat.colored-nicks .user.color-24 { color: #00367d; }
-#chat.colored-nicks .user.color-25 { color: #009ec4; }
-#chat.colored-nicks .user.color-26 { color: #006119; }
-#chat.colored-nicks .user.color-27 { color: #008bb8; }
-#chat.colored-nicks .user.color-28 { color: #469c00; }
-#chat.colored-nicks .user.color-29 { color: #ff0f95; }
-#chat.colored-nicks .user.color-30 { color: #ff7615; }
-#chat.colored-nicks .user.color-31 { color: #ff4846; }
-#chat.colored-nicks .user.color-32 { color: #ff199b; }
-
 #chat .text {
 	padding-left: 10px;
 	padding-right: 6px;

--- a/client/themes/crypto.css
+++ b/client/themes/crypto.css
@@ -125,6 +125,53 @@ a:hover,
 	color: #666;
 }
 
+/**
+ * Nickname colors
+ */
+
+/* Single color used for all nicknames when colored nicknames are disabled */
+#chat .user {
+	color: #50a656;
+}
+
+/* Color palette used when colored nicknames are enabled */
+#chat.colored-nicks .user.color-1 { color: #1396cf; }
+#chat.colored-nicks .user.color-2 { color: #ffcf89; }
+#chat.colored-nicks .user.color-3 { color: #00dc5f; }
+#chat.colored-nicks .user.color-4 { color: #ff5bc8; }
+#chat.colored-nicks .user.color-5 { color: #ff0e1b; }
+#chat.colored-nicks .user.color-6 { color: #000094; }
+#chat.colored-nicks .user.color-7 { color: #006441; }
+#chat.colored-nicks .user.color-8 { color: #00566e; }
+#chat.colored-nicks .user.color-9 { color: #ff0078; }
+#chat.colored-nicks .user.color-10 { color: #15d5a3; }
+#chat.colored-nicks .user.color-11 { color: #006b3b; }
+#chat.colored-nicks .user.color-12 { color: #00c5ba; }
+#chat.colored-nicks .user.color-13 { color: #00465b; }
+#chat.colored-nicks .user.color-14 { color: #ffafce; }
+#chat.colored-nicks .user.color-15 { color: #ff3b12; }
+#chat.colored-nicks .user.color-16 { color: #16cc6a; }
+#chat.colored-nicks .user.color-17 { color: #ff0072; }
+#chat.colored-nicks .user.color-18 { color: #ff5877; }
+#chat.colored-nicks .user.color-19 { color: #ff1753; }
+#chat.colored-nicks .user.color-20 { color: #007a56; }
+#chat.colored-nicks .user.color-21 { color: #095092; }
+#chat.colored-nicks .user.color-22 { color: #000bde; }
+#chat.colored-nicks .user.color-23 { color: #00bca9; }
+#chat.colored-nicks .user.color-24 { color: #00367d; }
+#chat.colored-nicks .user.color-25 { color: #009ec4; }
+#chat.colored-nicks .user.color-26 { color: #006119; }
+#chat.colored-nicks .user.color-27 { color: #008bb8; }
+#chat.colored-nicks .user.color-28 { color: #469c00; }
+#chat.colored-nicks .user.color-29 { color: #ff0f95; }
+#chat.colored-nicks .user.color-30 { color: #ff7615; }
+#chat.colored-nicks .user.color-31 { color: #ff4846; }
+#chat.colored-nicks .user.color-32 { color: #ff199b; }
+
+/**
+ * END Nickname colors
+ */
+
 @media (max-width: 768px) {
 	#main {
 		left: 0;

--- a/client/themes/example.css
+++ b/client/themes/example.css
@@ -1,7 +1,54 @@
 /**
- * This is just an empty theme.
+ * This is The Lounge's default theme.
  */
 
 body {
 	margin: 0;
 }
+
+/**
+ * Nickname colors
+ */
+
+/* Single color used for all nicknames when colored nicknames are disabled */
+#chat .user {
+	color: #50a656;
+}
+
+/* Color palette used when colored nicknames are enabled */
+#chat.colored-nicks .user.color-1 { color: #1396cf; }
+#chat.colored-nicks .user.color-2 { color: #ffcf89; }
+#chat.colored-nicks .user.color-3 { color: #00dc5f; }
+#chat.colored-nicks .user.color-4 { color: #ff5bc8; }
+#chat.colored-nicks .user.color-5 { color: #ff0e1b; }
+#chat.colored-nicks .user.color-6 { color: #000094; }
+#chat.colored-nicks .user.color-7 { color: #006441; }
+#chat.colored-nicks .user.color-8 { color: #00566e; }
+#chat.colored-nicks .user.color-9 { color: #ff0078; }
+#chat.colored-nicks .user.color-10 { color: #15d5a3; }
+#chat.colored-nicks .user.color-11 { color: #006b3b; }
+#chat.colored-nicks .user.color-12 { color: #00c5ba; }
+#chat.colored-nicks .user.color-13 { color: #00465b; }
+#chat.colored-nicks .user.color-14 { color: #ffafce; }
+#chat.colored-nicks .user.color-15 { color: #ff3b12; }
+#chat.colored-nicks .user.color-16 { color: #16cc6a; }
+#chat.colored-nicks .user.color-17 { color: #ff0072; }
+#chat.colored-nicks .user.color-18 { color: #ff5877; }
+#chat.colored-nicks .user.color-19 { color: #ff1753; }
+#chat.colored-nicks .user.color-20 { color: #007a56; }
+#chat.colored-nicks .user.color-21 { color: #095092; }
+#chat.colored-nicks .user.color-22 { color: #000bde; }
+#chat.colored-nicks .user.color-23 { color: #00bca9; }
+#chat.colored-nicks .user.color-24 { color: #00367d; }
+#chat.colored-nicks .user.color-25 { color: #009ec4; }
+#chat.colored-nicks .user.color-26 { color: #006119; }
+#chat.colored-nicks .user.color-27 { color: #008bb8; }
+#chat.colored-nicks .user.color-28 { color: #469c00; }
+#chat.colored-nicks .user.color-29 { color: #ff0f95; }
+#chat.colored-nicks .user.color-30 { color: #ff7615; }
+#chat.colored-nicks .user.color-31 { color: #ff4846; }
+#chat.colored-nicks .user.color-32 { color: #ff199b; }
+
+/**
+ * END Nickname colors
+ */

--- a/client/themes/morning.css
+++ b/client/themes/morning.css
@@ -91,7 +91,11 @@ QUIT #d0907d
 	color: #fefefe;
 }
 
-/* Nicknames */
+/**
+ * Nickname colors
+ */
+
+/* Single color used for all nicknames when colored nicknames are disabled */
 #chat .user {
 	color: #b0bacf;
 }
@@ -100,6 +104,7 @@ QUIT #d0907d
 	color: #fefefe;
 }
 
+/* Color palette used when colored nicknames are enabled */
 #chat.colored-nicks .user.color-1 { color: #f7adf7; }
 #chat.colored-nicks .user.color-2 { color: #abf99f; }
 #chat.colored-nicks .user.color-3 { color: #86efdc; }
@@ -132,6 +137,10 @@ QUIT #d0907d
 #chat.colored-nicks .user.color-30 { color: #9676e2; }
 #chat.colored-nicks .user.color-31 { color: #f2a4eb; }
 #chat.colored-nicks .user.color-32 { color: #85f27d; }
+
+/**
+ * END Nickname colors
+ */
 
 #chat a {
 	color: #428bca;

--- a/client/themes/zenburn.css
+++ b/client/themes/zenburn.css
@@ -121,7 +121,11 @@ body {
 	color: #dcdccc;
 }
 
-/* Nicknames */
+/**
+ * Nickname colors
+ */
+
+/* Single color used for all nicknames when colored nicknames are disabled */
 #chat .user {
 	color: #bc8cbc;
 }
@@ -130,6 +134,7 @@ body {
 	color: #dcdccc;
 }
 
+/* Color palette used when colored nicknames are enabled */
 #chat.colored-nicks .user.color-1 { color: #f7adf7; }
 #chat.colored-nicks .user.color-2 { color: #abf99f; }
 #chat.colored-nicks .user.color-3 { color: #86efdc; }
@@ -162,6 +167,10 @@ body {
 #chat.colored-nicks .user.color-30 { color: #9676e2; }
 #chat.colored-nicks .user.color-31 { color: #f2a4eb; }
 #chat.colored-nicks .user.color-32 { color: #85f27d; }
+
+/**
+ * END Nickname colors
+ */
 
 #chat a {
 	color: #8c8cbc;


### PR DESCRIPTION
Because I should have done that in #325 directly.

Base style should be system-specific and not design specific, so this is one step towards that.

When all themes are independent from the base style, it will be easier to create new ones, maintain overall compatibility with the existing ones, export the current ones into theme repos, etc.