### PR TITLE
Make sure npm test script gets run on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,6 +17,7 @@ install:
 test_script:
   - node --version
   - npm --version
+  - npm test
   - npm run test:mocha
   - npm run lint:js
   - npm run lint:css


### PR DESCRIPTION
Yes, this duplicates tests, but the whole point (at least for now) of AppVeyor for us is to make sure we do not break the dev environment, `npm install`, `npm run build` and `npm test`.

The source of truth is still Travis CI, so if the output on AppVeyor is less digestible, it's not too much of a big deal.

In terms of speed, `npm test` is a few seconds long, very much negligible compared to the 5-to-15-minute latency it takes for AppVeyor to wake up.