### PR TITLE
Fix description of `host` and `bind` config options

### DIFF
--- a/defaults/config.js
+++ b/defaults/config.js
@@ -11,7 +11,8 @@ module.exports = {
 	public: true,
 
 	//
-	// Allow connections from this host.
+	// IP address or hostname for the web server to listen on.
+	// Setting this to "0.0.0.0" will listen on all interfaces.
 	//
 	// @type     string
 	// @default  "0.0.0.0"
@@ -27,8 +28,8 @@ module.exports = {
 	port: 9000,
 
 	//
-	// Set the local IP to bind to.
-	// To listen on all IPs, set to undefined.
+	// Set the local IP to bind to for outgoing connections. Leave to undefined
+	// to let the operating system pick its preferred one.
 	//
 	// @type     string
 	// @default  undefined


### PR DESCRIPTION
Commit da54263b8e14814378b193abaeef35f8ebd218fa introduced a totally wrong description for those options. This one describes better what exactly those options do.

@astorije: Do you have any idea how that commit made its way in? It doesn't seem to be tied to any PR, nor seem to have gone through any kind of review process. And apparently, it's not in Shout's repo.