### PR TITLE
Update travis config 

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -38,7 +38,7 @@
 		"function-parentheses-newline-inside": "always-multi-line",
 		"function-parentheses-space-inside": "never-single-line",
 		"function-whitespace-after": "always",
-		"function-url-quotes": "double",
+		"function-url-quotes": "always",
 		"indentation": "tab",
 		"max-empty-lines": 1,
 		"media-feature-colon-space-after": "always",
@@ -53,7 +53,7 @@
 		"no-missing-eof-newline": true,
 		"number-leading-zero": "never",
 		"number-no-trailing-zeros": true,
-		"number-zero-length-no-unit": true,
+		"length-zero-no-unit": true,
 		"declaration-block-no-duplicate-properties": true,
 		"declaration-block-no-shorthand-property-overrides": true,
 		"rule-non-nested-empty-line-before": ["always-multi-line", {

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,23 @@
 language: node_js
 node_js:
-- '6'
-- '5'
-- '4'
-- '4.2.0'
+- 6
+- 4
+
+matrix:
+  fast_finish: true
+  include:
+  - os: osx
+    node_js: 4
+
+cache:
+  directories:
+    - node_modules
+
 notifications:
   email:
     on_success: never
     on_failure: always
+
 deploy:
   provider: npm
   email:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,6 @@ test_script:
 # cache npm modules
 cache:
   - node_modules
-  - '%APPDATA%\npm-cache'
 
 # Don't actually build
 build: off

--- a/package.json
+++ b/package.json
@@ -66,6 +66,6 @@
     "handlebars": "4.0.5",
     "mocha": "2.4.5",
     "npm-run-all": "2.1.1",
-    "stylelint": "6.2.2"
+    "stylelint": "6.6.0"
   }
 }


### PR DESCRIPTION
- Adds `node_modules` cache
- Adds testing on OSX (that's what the stylelint update is for)
- Removes node5 testing as it is no longer stable
- Only test latest node4 version
