### PR TITLE
Add code coverage

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,3 +5,5 @@ client/js/lounge.templates.js
 # third party
 client/js/libs/jquery/*.js
 client/js/libs/*.js
+
+coverage/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
+# Make sure to keep this file and .npmignore in sync
+
 node_modules/
 npm-debug.log
+
+coverage/
 
 # Built assets created at npm install/prepublish time
 # See https://docs.npmjs.com/misc/scripts

--- a/.istanbul.yml
+++ b/.istanbul.yml
@@ -1,0 +1,8 @@
+instrumentation:
+  include-all-sources: true
+  excludes:
+    - Gruntfile.js
+    - client/js/libs/*.js
+    - client/js/libs/jquery/*.js
+    - client/js/libs.min.js
+    - client/js/lounge.js

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,5 @@
 # This should match the .gitignore file without the generated assets
 # npm-debug.log and node_modules/ are ignored by default.
 # See https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package
+
+coverage/

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,6 +1,7 @@
 {
 	"ignoreFiles": [
-		"client/css/bootstrap.css"
+		"client/css/bootstrap.css",
+		"coverage/**/*.css"
 	],
 	"rules": {
 		"at-rule-empty-line-before": ["always", {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "homepage": "https://thelounge.github.io/",
   "scripts": {
+    "coverage": "istanbul cover node_modules/mocha/bin/_mocha -r test/fixtures/env.js test/**/*.js",
     "start": "node index",
     "build": "npm run build:font-awesome && npm run build:grunt && npm run build:handlebars",
     "build:font-awesome": "node scripts/build-fontawesome.js",
@@ -64,6 +65,7 @@
     "grunt-contrib-uglify": "1.0.1",
     "grunt-contrib-watch": "1.0.0",
     "handlebars": "4.0.5",
+    "istanbul": "0.4.3",
     "mocha": "2.4.5",
     "npm-run-all": "2.1.1",
     "stylelint": "6.6.0"


### PR DESCRIPTION
I had that in my working directory for a while, always showing in my `git status`, so I figured I should wrap it up and post it somewhere.

Not sure we want to make it a badge yet considering the number, but that's good information, and the coverage report, in HTML, can be helpful.

At the moment...

```
=============================================================================
Writing coverage object [/.../lounge/coverage/coverage.json]
Writing coverage reports at [/.../lounge/coverage]
=============================================================================

=============================== Coverage summary ===============================
Statements   : 9.44% ( 144/1526 )
Branches     : 1.79% ( 33/1845 )
Functions    : 9.82% ( 27/275 )
Lines        : 9.45% ( 144/1524 )
================================================================================
```