### PR TITLE
Perform node version check as soon as possible

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,13 @@
 #!/usr/bin/env node
 process.chdir(__dirname);
+
+// Perform node version check before loading any other files or modules
+// Doing this check as soon as possible allows us to avoid ES6 parser errors or other issues
+var pkg = require("./package.json");
+if (!require("semver").satisfies(process.version, pkg.engines.node)) {
+	console.error("=== WARNING!");
+	console.error("=== The oldest supported Node.js version is", pkg.engines.node);
+	console.error("=== We strongly encourage you to upgrade, see https://nodejs.org/en/download/package-manager/ for more details\n");
+}
+
 require("./src/command-line");

--- a/src/server.js
+++ b/src/server.js
@@ -65,11 +65,6 @@ module.exports = function(options) {
 	log.info("The Lounge v" + pkg.version + " is now running on", protocol + "://" + config.host + ":" + config.port + "/");
 	log.info("Press ctrl-c to stop\n");
 
-	if (!require("semver").satisfies(process.version, pkg.engines.node)) {
-		log.warn("The oldest supported Node.js version is ", pkg.engines.node);
-		log.warn("We strongly encourage you to upgrade, see https://nodejs.org/en/download/package-manager/ for more details\n");
-	}
-
 	if (!config.public) {
 		manager.loadUsers();
 		if (config.autoload) {


### PR DESCRIPTION
Allows us to print a message before crashing when loading irc-fw