### PR TITLE
Do not print user loaded message in public mode

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -81,9 +81,9 @@ function Client(manager, name, config) {
 			}, delay);
 			delay += 1000;
 		});
-	}
 
-	log.info("User '" + name + "' loaded");
+		log.info("User '" + name + "' loaded");
+	}
 }
 
 Client.prototype.emit = function(event, data) {


### PR DESCRIPTION
Similar to #413. This fixes `User "undefined" loaded` which was introduced somewhere in 2.0-pre.