### PR TITLE
Do not display the sidebar on sign-in page

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -512,6 +512,10 @@ button,
 	top: 4px;
 }
 
+.signed-out #main {
+	left: 5px;
+}
+
 #header {
 	display: none;
 	height: 40px;

--- a/client/index.html
+++ b/client/index.html
@@ -23,7 +23,7 @@
 	<link rel="manifest" href="manifest.json">
 
 	</head>
-	<body class="<%= public ? "public" : "" %>">
+	<body class="signed-out <%= public ? "public" : "" %>">
 
 	<div id="wrap">
 	<div id="viewport">
@@ -60,9 +60,6 @@
 					</div>
 				</div>
 				<div id="sign-in" class="window">
-					<div class="header">
-						<button class="lt" aria-label="Toggle channel list"></button>
-					</div>
 					<form class="container" method="post" action="">
 						<div class="row">
 							<div class="col-xs-12">

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -77,14 +77,11 @@ $(function() {
 	});
 
 	socket.on("auth", function(data) {
-		var body = $("body");
 		var login = $("#sign-in");
 
 		login.find(".btn").prop("disabled", false);
 
 		if (!data.success) {
-			body.addClass("signed-out");
-
 			window.localStorage.removeItem("token");
 
 			var error = login.find(".error");


### PR DESCRIPTION
The sidebar is really useless on the authentication page. The settings page has no effect until logged, while icons to add a network and log out are purely wrong.
This is an attempt to make the sign-in page use the whole viewport:

The commit also:
- Removes burger menu icon on mobile version of sign-in page
- Adds the `.signed-out` class to the initial body instead of only when sign-in has failed
- Removes hiding connect and logout button icons, which was buggy and is now useless anyway

#### Result

<img width="400" alt="screen shot 2016-06-20 at 01 51 11" src="https://cloud.githubusercontent.com/assets/113730/16184420/3791f214-368a-11e6-9a89-0e8f51292527.png">

#### Current issues

- [x] ~~The sign-in icon is not even displayed anymore, and has no value, so I removed *most* of it. Because of how the client displays the sign-in form, I cannot simply remove it: when receiving the `auth` event, a click is emitted on the button that activates the right window, changes the page title, ... Not pretty. Any suggestion on improving this? I'm thinking of moving that logic to a different function that the click handler calls, and the `auth` event handler could call it without resorting to a click. Does that sound any better?~~ Scratch that, I'll tackle this in a further PR.

- [x] ~~Right now, there is no scrollbar on the sign-in page, which is a problem. I'll look into that issue, but if someone sees something obvious, please speak up :-)~~ Fixed along with implementing @xPaw's suggestion.

- [x] ~~The loading page looks gross with this. I should apply behavior of this PR to the loading page as well (no sidebar), and make sure the input field does not apply there either.~~ Thanks to @xPaw's suggestion, this PR also applies to the loading page \o/