### PR TITLE
Remove navigator.standalone detection

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -126,10 +126,6 @@ button,
 	padding: 0;
 }
 
-.web-app-mode {
-	padding-top: 20px;
-}
-
 .btn {
 	border: 2px solid #84ce88;
 	border-radius: 3px;

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -34,10 +34,6 @@ $(function() {
 	var sidebar = $("#sidebar, #footer");
 	var chat = $("#chat");
 
-	if (navigator.standalone) {
-		$("html").addClass("web-app-mode");
-	}
-
 	var pop;
 	try {
 		pop = new Audio();


### PR DESCRIPTION
It was added in b3b7d126be11177c22e6165ffd6c65b81575886e to apparently work around an iOS bug which was fixed in 8.3.

https://discussions.apple.com/thread/6557230?start=0&tstart=0
https://discussions.apple.com/message/28059603#28059603
