### PR TITLE
Fix default configuration for `host`.

### DIFF
--- a/defaults/config.js
+++ b/defaults/config.js
@@ -12,12 +12,12 @@ module.exports = {
 
 	//
 	// IP address or hostname for the web server to listen on.
-	// Setting this to "0.0.0.0" will listen on all interfaces.
+	// Setting this to undefined will listen on all interfaces.
 	//
 	// @type     string
-	// @default  "0.0.0.0"
+	// @default  undefined
 	//
-	host: "0.0.0.0",
+	host: undefined,
 
 	//
 	// Set the port to listen on.

--- a/src/server.js
+++ b/src/server.js
@@ -62,7 +62,7 @@ module.exports = function(options) {
 
 	manager.sockets = sockets;
 
-	log.info("The Lounge v" + pkg.version + " is now running on", protocol + "://" + config.host + ":" + config.port + "/");
+	log.info("The Lounge v" + pkg.version + " is now running on", protocol + "://" + (config.host || "*") + ":" + config.port + "/");
 	log.info("Press ctrl-c to stop\n");
 
 	if (!config.public) {


### PR DESCRIPTION
Similarly to kiwiirc/irc-framework#55, passing `undefined` there instead of `"0.0.0.0"` allows the OS to decide and use both IPv4 and IPv6.