### PR TITLE
irc-events/connection: increase join delay to 1000ms

### DIFF
--- a/src/plugins/irc-events/connection.js
+++ b/src/plugins/irc-events/connection.js
@@ -35,7 +35,7 @@ module.exports = function(irc, network) {
 			setTimeout(function() {
 				network.irc.join(chan.name);
 			}, delay);
-			delay += 100;
+			delay += 1000;
 		});
 	});
 


### PR DESCRIPTION
100ms easily bypasses the excess flood threshold with constant
reproducibility with >20 channels (Freenode).

I think d66e86dd introduced the issue.