### PR TITLE
Update irc-framework to 2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "event-stream": "3.3.2",
     "express": "4.13.4",
     "fs-extra": "0.30.0",
-    "irc-framework": "2.0.0",
+    "irc-framework": "2.3.0",
     "lodash": "4.11.2",
     "moment": "2.13.0",
     "read": "1.0.7",

--- a/src/client.js
+++ b/src/client.js
@@ -231,6 +231,8 @@ Client.prototype.connect = function(args) {
 		localAddress: config.bind,
 		rejectUnauthorized: false,
 		auto_reconnect: true,
+		auto_reconnect_wait: 10000 + Math.floor(Math.random() * 1000), // If multiple users are connected to the same network, randomize their reconnections a little
+		auto_reconnect_max_retries: 360, // At least one hour (plus timeouts) worth of reconnections
 		webirc: webirc,
 	});
 

--- a/src/plugins/irc-events/connection.js
+++ b/src/plugins/irc-events/connection.js
@@ -47,7 +47,7 @@ module.exports = function(irc, network) {
 
 	irc.on("close", function() {
 		network.channels[0].pushMessage(client, new Msg({
-			text: "Disconnected from the network, and will not reconnect."
+			text: "Disconnected from the network, and will not reconnect. Use /connect to reconnect again."
 		}));
 	});
 
@@ -69,23 +69,26 @@ module.exports = function(irc, network) {
 		});
 	}
 
+	irc.on("debug", function(message) {
+		log.debug("[" + client.name + " on " + network.host + ":" + network.port + "]", message);
+	});
+
 	irc.on("socket error", function(err) {
-		log.debug("IRC socket error", err);
 		network.channels[0].pushMessage(client, new Msg({
 			type: Msg.Type.ERROR,
 			text: "Socket error: " + err
 		}));
 	});
 
-	irc.on("reconnecting", function() {
+	irc.on("reconnecting", function(data) {
 		network.channels[0].pushMessage(client, new Msg({
-			text: "Disconnected from the network. Reconnecting..."
+			text: "Disconnected from the network. Reconnecting in " + Math.round(data.wait / 1000) + " seconds… (Attempt " + data.attempt + " of " + data.max_retries + ")"
 		}));
 	});
 
 	irc.on("ping timeout", function() {
 		network.channels[0].pushMessage(client, new Msg({
-			text: "Ping timeout, disconnecting..."
+			text: "Ping timeout, disconnecting…"
 		}));
 	});
 


### PR DESCRIPTION
Fixes colon bug.

This PR exposes irc-fw debug messages to hopefully help us catching the `write after end` error. This debug stuff should be removed in the final release. (or keep it if it's useful, we don't use CLI for anything anyway).