### PR TITLE
client: stop propagation when hiding the chat through click/tapping the chat

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -539,7 +539,8 @@ $(function() {
 		viewport.toggleClass(self.attr("class"));
 		if (viewport.is(".lt, .rt")) {
 			e.stopPropagation();
-			chat.find(".chat").one("click", function() {
+			chat.find(".chat").one("click", function(e) {
+				e.stopPropagation();
 				viewport.removeClass("lt");
 			});
 		}


### PR DESCRIPTION
This is really annoying on mobile. When I click the chat to hide the side menu 9 times out of 10 I hit a nickname.

![saddsad](https://cloud.githubusercontent.com/assets/6705160/16546256/d3550cb2-4144-11e6-96e1-cbb6d0e1f77a.gif)