### PR TITLE
Fix unread marker disappearing when opacity set to 1

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -725,6 +725,7 @@ button {
 	text-align: center;
 	opacity: .5;
 	margin: 0 10px;
+	z-index: 0;
 }
 
 #chat .unread-marker:before {


### PR DESCRIPTION
Fixes #470.

`z-index` sorcery was removed [here](https://github.com/thelounge/lounge/pull/465/files#diff-e5178f7b74fe45f2cfe1baf9aa1ef6faL791), and the unread marker line, since showing with `z-index: -1`, actually needs a `0` reference.