### PR TITLE
Add self info to TOGGLE messages to prevent unread marker to render for oneself

### DIFF
--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -32,6 +32,7 @@ module.exports = function(irc, network) {
 		}
 
 		var msg = new Msg({
+			self: data.nick === irc.user.nick,
 			type: Msg.Type.TOGGLE,
 		});
 		chan.pushMessage(client, msg);


### PR DESCRIPTION
Fixes #466.

Marking as `second review needed` **but** I would really like @MaxLeiter to test this as well.

I checked other places on the client where we were relying on `self` to be set to `true`, [here](https://github.com/thelounge/lounge/blob/ab609389f3f1af8ead58d356c0bdb282b487e332/client/js/lounge.js#L227), [here](https://github.com/thelounge/lounge/blob/ab609389f3f1af8ead58d356c0bdb282b487e332/client/js/lounge.js#L340), and [here](https://github.com/thelounge/lounge/blob/ab609389f3f1af8ead58d356c0bdb282b487e332/client/js/lounge.js#L872), but I didn't see anything alarming. The last link is of course the most likely to be an issue among the 3.