### PR TITLE
Prevent the app from crashing when no theme is specified

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -15,7 +15,7 @@
 
 	<link rel="stylesheet" href="css/bootstrap.css">
 	<link rel="stylesheet" href="css/style.css">
-	<link id="theme" rel="stylesheet" href="<%= theme %>">
+	<link id="theme" rel="stylesheet" href="<%= typeof(theme) !== "undefined" ? theme : "themes/example.css" %>">
 	<style id="user-specified-css"></style>
 
 	<link rel="shortcut icon" href="img/favicon.png" data-other="img/favicon-notification.png" data-toggled="false" id="favicon">


### PR DESCRIPTION
`defaults/config.js` says:

```js
	// @default  "themes/example.css"
```

However, without this fix, not setting a theme makes the app crash with:

```js
lodash.templateSources[0]:10
((__t = ( theme ? theme : "themes/example.css" )) == null ? '' : __t) +
          ^

ReferenceError: theme is not defined
    at eval (lodash.templateSources[0]:10:11)
    at /Users/jeremie/Perso/lounge/src/server.js:103:11
    at FSReqWrap.readFileAfterClose [as oncomplete] (fs.js:380:3)
```

We have been setting default inline like this in other places. Even though it's not optimal, it's better than crashing :-)