### PR TITLE
Fix breaking layout when switching portrait/landscape modes

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -713,11 +713,14 @@ button {
 }
 
 #chat .messages {
+	display: table;
+	table-layout: fixed;
 	width: 100%;
 	padding: 10px 0;
-	overflow-wrap: break-word;
+}
+
+#chat .msg {
 	word-wrap: break-word;
-	word-break: break-word;
 }
 
 #chat .unread-marker {
@@ -768,7 +771,7 @@ button {
 #chat .time {
 	color: #ddd;
 	text-align: right;
-	width: 46px;
+	max-width: 46px;
 	min-width: 46px;
 }
 


### PR DESCRIPTION
This re-adds the table layout in CSS removed in 3cddbbce6eca34843c7cc4b876a9ecb12602672e, https://github.com/thelounge/lounge/pull/332.

The essential difference between #332 and this, in the end, is that `display: table-row` was removed from `#chat .msg`. That difference is what makes the unread marker possible.
I don't know by which sorcery this is possible, but it works. This requires testing though! I tried different scenario, window size and resize, ...

@williamboman, could you give a try at this PR since you originally mentioned that issue on the IRC channel?