### PR TITLE
client: fix chat not being stickied to the bottom when joining channel

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -788,11 +788,6 @@ $(function() {
 			.addClass("active")
 			.trigger("show");
 
-		var chanChat = chan.find(".chat");
-		if (chanChat.length > 0) {
-			chanChat.sticky();
-		}
-
 		var title = "The Lounge";
 		if (chan.data("title")) {
 			title = chan.data("title") + " — " + title;
@@ -802,6 +797,11 @@ $(function() {
 		if (self.hasClass("chan")) {
 			$("#chat-container").addClass("active");
 			setNick(self.closest(".network").data("nick"));
+		}
+
+		var chanChat = chan.find(".chat");
+		if (chanChat.length > 0) {
+			chanChat.sticky();
 		}
 
 		if (chan.data("needsNamesRefresh") === true) {


### PR DESCRIPTION
Closes #469.

26bf948fdc600ec0294094861f127e3d2360c095 is the offending commit.

The `.chat` element is not rendered until after [L803](https://github.com/thelounge/lounge/blob/28938be10d5f4340031ce6a7c7b8937100fe4b8a/client/js/lounge.js#L803), causing the sticky plugin to not function.