### PR TITLE
Add a red dot to the mobile menu icon when being notified

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -209,6 +209,29 @@ button {
 	-moz-osx-font-smoothing: grayscale;
 }
 
+#viewport .lt {
+	position: relative;
+}
+
+/* Notification dot on the top right corner of the menu icon */
+#viewport .lt:after {
+	content: "";
+	position: absolute;
+	top: 9px;
+	right: 7px;
+	background-color: #e74c3c;
+	width: 10px;
+	height: 10px;
+	border-radius: 50%;
+	border: 2px solid white;
+	opacity: 0;
+	transition: opacity .2s;
+}
+
+#viewport .lt.notified:after {
+	opacity: 1;
+}
+
 #viewport .rt:before {
 	font: 14px FontAwesome;
 	content: "\f0c0";

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -158,7 +158,7 @@ $(function() {
 			confirmExit();
 
 			if (sidebar.find(".highlight").length) {
-				toggleFaviconNotification(true);
+				toggleNotificationMarkers(true);
 			}
 		}
 
@@ -769,7 +769,7 @@ $(function() {
 			.empty();
 
 		if (sidebar.find(".highlight").length === 0) {
-			toggleFaviconNotification(false);
+			toggleNotificationMarkers(false);
 		}
 
 		viewport.removeClass("lt");
@@ -879,7 +879,7 @@ $(function() {
 				if (options.notification) {
 					pop.play();
 				}
-				toggleFaviconNotification(true);
+				toggleNotificationMarkers(true);
 
 				if (options.desktopNotifications && Notification.permission === "granted") {
 					var title;
@@ -1188,20 +1188,24 @@ $(function() {
 		return array;
 	}
 
-	function toggleFaviconNotification(newState) {
+	function toggleNotificationMarkers(newState) {
+		// Toggles the favicon to red when there are unread notifications
 		if (favicon.data("toggled") !== newState) {
 			var old = favicon.attr("href");
 			favicon.attr("href", favicon.data("other"));
 			favicon.data("other", old);
 			favicon.data("toggled", newState);
 		}
+
+		// Toggles a dot on the menu icon when there are unread notifications
+		$("#viewport .lt").toggleClass("notified", newState);
 	}
 
 	document.addEventListener(
 		"visibilitychange",
 		function() {
 			if (sidebar.find(".highlight").length === 0) {
-				toggleFaviconNotification(false);
+				toggleNotificationMarkers(false);
 			}
 		}
 	);

--- a/client/themes/morning.css
+++ b/client/themes/morning.css
@@ -175,6 +175,11 @@ body {
 	color: #99a2b4;
 }
 
+/* Notification dot on the top right corner of the menu icon */
+#viewport .lt:after {
+	border-color: #333c4a;
+}
+
 #chat .unread-marker {
 	opacity: 1;
 }

--- a/client/themes/zenburn.css
+++ b/client/themes/zenburn.css
@@ -202,6 +202,11 @@ body {
 	color: #d2d39b;
 }
 
+/* Notification dot on the top right corner of the menu icon */
+#viewport .lt:after {
+	border-color: #3f3f3f;
+}
+
 #chat .unread-marker {
 	opacity: 1;
 }


### PR DESCRIPTION
On mobile, there is no favicon to toggle, so nothing shows up when a new notification arrives.
This commit changes this by adding a marker on the burger menu icon, visible on all channels.

#### Result

Browser on the left has the addition: look at the menu icon when browser on the right sends a message.

![notification_menu](https://cloud.githubusercontent.com/assets/113730/16715951/bd4d983a-46bc-11e6-880b-7f5d942ac5b6.gif)

#### Themes

Morning | Crypto | Zenburn
--- | --- | ---
<img width="121" alt="morning" src="https://cloud.githubusercontent.com/assets/113730/16715956/c889c430-46bc-11e6-894d-7e3c51140b97.png"> | <img width="118" alt="crypto" src="https://cloud.githubusercontent.com/assets/113730/16715957/cbe8fb78-46bc-11e6-83f7-f1d0d88f8105.png"> | <img width="120" alt="zenburn" src="https://cloud.githubusercontent.com/assets/113730/16715958/cbf23828-46bc-11e6-9970-89f7ddd77bd2.png">
