### PR TITLE
Add "The Lounge" label to the landing pages

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -69,7 +69,7 @@
 					<form class="container" method="post" action="">
 						<div class="row">
 							<div class="col-xs-12">
-								<h1 class="title">Sign in</h1>
+								<h1 class="title">Sign in to The Lounge</h1>
 							</div>
 							<div class="col-xs-12">
 								<label>
@@ -107,7 +107,10 @@
 					<form class="container" method="post" action="">
 						<div class="row">
 							<div class="col-sm-12">
-								<h1 class="title">Connect</h1>
+								<h1 class="title">
+									<%= public ? "The Lounge - " : "" %>
+									Connect
+								</h1>
 							</div>
 							<div <%= typeof(displayNetwork) !== "undefined" && !displayNetwork ? 'style="display: none;"' : ''%>>
 								<div class="col-sm-12">


### PR DESCRIPTION
This is a "better" attempt at displaying the app name on the landing page than #424.

This is not an ideal nor permanent solution, but it negatively affects the design less. It is somewhat temporary until I find the time to add a proper landing page that would:
- Load a sidebar-free page
- Have a "first-time landing" look (app name + maybe special framing, etc.)
- Display either a connect page on public mode or a sign in page in private mode

This will take some non-negligible time and I'll have to sync with @maxpoulin64 depending on what he wants to do regarding the window management, so until then, this PR will do the job just fine and does not compromise on the UI.