### PR TITLE
Display network name on Connect page when network is locked and info is hidden

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -110,6 +110,7 @@
 								<h1 class="title">
 									<%= public ? "The Lounge - " : "" %>
 									Connect
+									<%= !displayNetwork && lockNetwork ? "to " + defaults.name : "" %>
 								</h1>
 							</div>
 							<div <%= typeof(displayNetwork) !== "undefined" && !displayNetwork ? 'style="display: none;"' : ''%>>


### PR DESCRIPTION
Would this add any value?

<img width="483" alt="screen shot 2016-07-10 at 21 30 31" src="https://cloud.githubusercontent.com/assets/113730/16717562/908d10c2-46e5-11e6-9b41-67500e3f7b23.png">
