### PR TITLE
Send user to lobby of deleted chan when parting from active chan

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -393,29 +393,15 @@ $(function() {
 	});
 
 	socket.on("part", function(data) {
-		var id = data.chan;
-		sidebar.find(".chan[data-id='" + id + "']").remove();
-		$("#chan-" + id).remove();
+		var chanMenuItem = sidebar.find(".chan[data-id='" + data.chan + "']");
 
-		var next = null;
-		var highest = -1;
-		chat.find(".chan").each(function() {
-			var self = $(this);
-			var z = parseInt(self.css("z-index"));
-			if (z > highest) {
-				highest = z;
-				next = self;
-			}
-		});
-
-		if (next !== null) {
-			id = next.data("id");
-			sidebar.find("[data-id=" + id + "]").click();
-		} else {
-			sidebar.find(".chan")
-				.eq(0)
-				.click();
+		// When parting from the active channel/query, jump to the network's lobby
+		if (chanMenuItem.hasClass("active")) {
+			chanMenuItem.parent(".network").find(".lobby").click();
 		}
+
+		chanMenuItem.remove();
+		$("#chan-" + data.chan).remove();
 	});
 
 	socket.on("quit", function(data) {


### PR DESCRIPTION
Closes #485.

Instead of always sending them back to the very first lobby on the app.

This fixes a bug introduced in recent layout change (#465) but **does not bring previous behavior back**: when closing active channel, user gets sent to lobby instead of previously visited channel.

Many ways (at least three) of bringing this back were discussed on the channel but: 1) fixing the bug to an acceptable state is priority, 2) usage might show it's not necessary. Trying this at first keeps the code simple, we'll see if necessary later.

I have done some quick tests but encourage the reviewer(s) to do some more :-)