### PR TITLE
Improve font icon management, sizing and sharpness

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -186,12 +186,7 @@ button {
 #footer .icon,
 #chat .count:before,
 #settings #play:before,
-#form #submit:before {
-	font: 14px FontAwesome;
-	-webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
-}
-
+#form #submit:before,
 #chat .invite .from:before,
 #chat .join .from:before,
 #chat .kick .from:before,
@@ -204,7 +199,8 @@ button {
 #chat .nick .from:before,
 #chat .action .from:before,
 .context-menu-item:before {
-	font-family: FontAwesome;
+	font: normal normal normal 14px/1 FontAwesome;
+	font-size: inherit; /* Can't have font-size inherit on line above, so need to override */
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
 }
@@ -229,7 +225,8 @@ button {
 	color: #ccc;
 	display: none;
 	float: left;
-	line-height: 40px;
+	font-size: 14px;
+	line-height: 1;
 	height: 36px;
 	margin: 6px 12px 0 -12px;
 	width: 36px;
@@ -489,6 +486,7 @@ button {
 	bottom: 4px;
 	height: 48px;
 	left: 5px;
+	font-size: 14px;
 	line-height: 48px;
 	position: absolute;
 	text-align: center;
@@ -1064,6 +1062,7 @@ button {
 	content: "\f002"; /* http://fontawesome.io/icon/search/ */
 	position: absolute;
 	right: 18px;
+	font-size: 14px;
 	line-height: 50px;
 	transition: color .2s;
 	z-index: 0;
@@ -1214,6 +1213,10 @@ button {
 	margin-left: 2px;
 }
 
+#settings #play {
+	font-size: 14px;
+}
+
 #settings #play:hover {
 	opacity: .8;
 }
@@ -1309,8 +1312,8 @@ button {
 
 #form #submit {
 	color: #9ca5b4;
+	font-size: 14px;
 	height: 34px;
-	line-height: 34px;
 	transition: opacity .3s;
 	width: 34px;
 	flex: 0 0 auto;

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -176,6 +176,39 @@ button {
 	color: rgba(0, 0, 0, .35) !important;
 }
 
+/* Icons */
+
+#viewport .lt:before,
+#viewport .rt:before,
+#chat button.menu:before,
+#sidebar .chan:before,
+#chat .title:before,
+#footer .icon,
+#chat .count:before,
+#settings #play:before,
+#form #submit:before {
+	font: 14px FontAwesome;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+}
+
+#chat .invite .from:before,
+#chat .join .from:before,
+#chat .kick .from:before,
+#chat .part .from:before,
+#chat .quit .from:before,
+#chat .topic .from:before,
+#chat .mode .from:before,
+#chat .ctcp .from:before,
+#chat .whois .from:before,
+#chat .nick .from:before,
+#chat .action .from:before,
+.context-menu-item:before {
+	font-family: FontAwesome;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+}
+
 #wrap {
 	height: 100%;
 	overflow: hidden;
@@ -203,10 +236,7 @@ button {
 }
 
 #viewport .lt:before {
-	font: 14px FontAwesome;
-	content: "\f0c9";
-	-webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
+	content: "\f0c9"; /* http://fontawesome.io/icon/bars/ */
 }
 
 #viewport .lt {
@@ -233,17 +263,11 @@ button {
 }
 
 #viewport .rt:before {
-	font: 14px FontAwesome;
-	content: "\f0c0";
-	-webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
+	content: "\f0c0"; /* http://fontawesome.io/icon/users/ */
 }
 
 #chat button.menu:before {
-	font: 14px FontAwesome;
-	content: "\f142";
-	-webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
+	content: "\f142"; /* http://fontawesome.io/icon/ellipsis-v/ */
 }
 
 #viewport .rt {
@@ -340,11 +364,9 @@ button {
 
 #sidebar .chan:before,
 #chat .title:before {
-	font: 14px FontAwesome;
 	float: left;
 	margin-top: 3px;
 	margin-right: 12px;
-	width: 14px;
 	text-align: center;
 }
 
@@ -360,17 +382,17 @@ button {
 
 #sidebar .chan.lobby:before,
 #chat .lobby .title:before {
-	content: "\f0a0";
+	content: "\f0a0"; /* http://fontawesome.io/icon/hdd-o/ */
 }
 
 #sidebar .chan.query:before,
 #chat .query .title:before {
-	content: "\f0e6";
+	content: "\f0e6"; /* http://fontawesome.io/icon/comments-o/ */
 }
 
 #sidebar .chan.channel:before,
 #chat .channel .title:before {
-	content: "\f0f6";
+	content: "\f0f6"; /* http://fontawesome.io/icon/file-text-o/ */
 }
 
 #sidebar .chan .name {
@@ -480,7 +502,6 @@ button {
 #footer .icon {
 	color: #9ca5b4;
 	display: inline-block;
-	font: 14px FontAwesome;
 	line-height: 34px;
 	padding: 0 12px;
 }
@@ -504,19 +525,19 @@ button {
 }
 
 #footer .sign-in:before {
-	content: "\f023";
+	content: "\f023"; /* http://fontawesome.io/icon/lock/ */
 }
 
 #footer .connect:before {
-	content: "\f067";
+	content: "\f067"; /* http://fontawesome.io/icon/plus/ */
 }
 
 #footer .settings:before {
-	content: "\f013";
+	content: "\f013"; /* http://fontawesome.io/icon/cog/ */
 }
 
 #footer .sign-out:before {
-	content: "\f011";
+	content: "\f011"; /* http://fontawesome.io/icon/power-off/ */
 }
 
 #main {
@@ -884,8 +905,7 @@ button {
 }
 
 #chat .invite .from:before {
-	font-family: FontAwesome;
-	content: "\f003";
+	content: "\f003"; /* http://fontawesome.io/icon/envelope-o/ */
 	color: #2ecc40;
 }
 
@@ -901,52 +921,44 @@ button {
 }
 
 #chat .join .from:before {
-	font-family: FontAwesome;
-	content: "\f090";
+	content: "\f090"; /* http://fontawesome.io/icon/sign-in/ */
 	color: #2ecc40;
 }
 
 #chat .kick .from:before {
-	font-family: FontAwesome;
-	content: "\f05e";
+	content: "\f05e"; /* http://fontawesome.io/icon/ban/ */
 	color: #ff4136;
 }
 
 #chat .part .from:before,
 #chat .quit .from:before {
-	font-family: FontAwesome;
-	content: "\f08b";
+	content: "\f08b"; /* http://fontawesome.io/icon/sign-out/ */
 	color: #ff4136;
 	display: inline-block;
 	transform: rotate(180deg);
 }
 
 #chat .topic .from:before {
-	font-family: FontAwesome;
-	content: "\f0a1";
+	content: "\f0a1"; /* http://fontawesome.io/icon/bullhorn/ */
 	color: #2ecc40;
 }
 
 #chat .mode .from:before {
-	font-family: FontAwesome;
-	content: "\f05a";
+	content: "\f05a"; /* http://fontawesome.io/icon/info-circle/ */
 	color: #2ecc40;
 }
 
 #chat .ctcp .from:before {
-	font-family: FontAwesome;
-	content: "\f0f6";
+	content: "\f0f6"; /* http://fontawesome.io/icon/file-text-o/ */
 }
 
 #chat .whois .from:before {
-	font-family: FontAwesome;
-	content: "\f007";
+	content: "\f007"; /* http://fontawesome.io/icon/user/ */
 	color: #2ecc40;
 }
 
 #chat .nick .from:before {
-	font-family: FontAwesome;
-	content: "\f007";
+	content: "\f007"; /* http://fontawesome.io/icon/user/ */
 	color: #2ecc40;
 }
 
@@ -957,8 +969,7 @@ button {
 }
 
 #chat .action .from:before {
-	font-family: FontAwesome;
-	content: "\f005";
+	content: "\f005"; /* http://fontawesome.io/icon/star/ */
 }
 
 #chat .notice .time,
@@ -1050,8 +1061,7 @@ button {
 
 #chat .count:before {
 	color: #cfcfcf;
-	font: 14px FontAwesome;
-	content: "\f002";
+	content: "\f002"; /* http://fontawesome.io/icon/search/ */
 	position: absolute;
 	right: 18px;
 	line-height: 50px;
@@ -1209,8 +1219,7 @@ button {
 }
 
 #settings #play:before {
-	content: "\f028";
-	font: 14px FontAwesome;
+	content: "\f028"; /* http://fontawesome.io/icon/volume-up/ */
 	margin-right: 9px;
 }
 
@@ -1308,10 +1317,7 @@ button {
 }
 
 #form #submit:before {
-	font: 14px FontAwesome;
-	content: "\f1d8";
-	-webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
+	content: "\f1d8"; /* http://fontawesome.io/icon/paper-plane/ */
 }
 
 #form #submit:hover {
@@ -1362,23 +1368,20 @@ button {
 }
 
 .context-menu-item:before {
-	font-family: FontAwesome;
 	width: 20px;
 	display: inline-block;
-	-webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
 }
 
 .context-menu-user:before {
-	content: "\f007";
+	content: "\f007"; /* http://fontawesome.io/icon/user/ */
 }
 
 .context-menu-chan:before {
-	content: "\f0f6";
+	content: "\f0f6"; /* http://fontawesome.io/icon/file-text-o/ */
 }
 
 .context-menu-close:before {
-	content: "\f00d";
+	content: "\f00d"; /* http://fontawesome.io/icon/times/ */
 }
 
 /**

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -205,6 +205,97 @@ button {
 	-moz-osx-font-smoothing: grayscale;
 }
 
+#viewport .lt:before { content: "\f0c9"; /* http://fontawesome.io/icon/bars/ */ }
+#viewport .rt:before { content: "\f0c0"; /* http://fontawesome.io/icon/users/ */ }
+#chat button.menu:before { content: "\f142"; /* http://fontawesome.io/icon/ellipsis-v/ */ }
+
+.context-menu-user:before { content: "\f007"; /* http://fontawesome.io/icon/user/ */ }
+.context-menu-chan:before { content: "\f0f6"; /* http://fontawesome.io/icon/file-text-o/ */ }
+.context-menu-close:before { content: "\f00d"; /* http://fontawesome.io/icon/times/ */ }
+
+#sidebar .chan.lobby:before,
+#chat .lobby .title:before { content: "\f0a0"; /* http://fontawesome.io/icon/hdd-o/ */ }
+
+#sidebar .chan.query:before,
+#chat .query .title:before { content: "\f0e6"; /* http://fontawesome.io/icon/comments-o/ */ }
+
+#sidebar .chan.channel:before,
+#chat .channel .title:before { content: "\f0f6"; /* http://fontawesome.io/icon/file-text-o/ */ }
+
+#footer .sign-in:before { content: "\f023"; /* http://fontawesome.io/icon/lock/ */ }
+#footer .connect:before { content: "\f067"; /* http://fontawesome.io/icon/plus/ */ }
+#footer .settings:before { content: "\f013"; /* http://fontawesome.io/icon/cog/ */ }
+#footer .sign-out:before { content: "\f011"; /* http://fontawesome.io/icon/power-off/ */ }
+
+#form #submit:before { content: "\f1d8"; /* http://fontawesome.io/icon/paper-plane/ */ }
+
+#chat .invite .from:before {
+	content: "\f003"; /* http://fontawesome.io/icon/envelope-o/ */
+	color: #2ecc40;
+}
+
+#chat .part .from:before,
+#chat .quit .from:before {
+	content: "\f08b"; /* http://fontawesome.io/icon/sign-out/ */
+	color: #ff4136;
+	display: inline-block;
+	transform: rotate(180deg);
+}
+
+#chat .topic .from:before {
+	content: "\f0a1"; /* http://fontawesome.io/icon/bullhorn/ */
+	color: #2ecc40;
+}
+
+#chat .mode .from:before {
+	content: "\f05a"; /* http://fontawesome.io/icon/info-circle/ */
+	color: #2ecc40;
+}
+
+#chat .ctcp .from:before {
+	content: "\f0f6"; /* http://fontawesome.io/icon/file-text-o/ */
+}
+
+#chat .whois .from:before {
+	content: "\f007"; /* http://fontawesome.io/icon/user/ */
+	color: #2ecc40;
+}
+
+#chat .nick .from:before {
+	content: "\f007"; /* http://fontawesome.io/icon/user/ */
+	color: #2ecc40;
+}
+
+#chat .join .from:before {
+	content: "\f090"; /* http://fontawesome.io/icon/sign-in/ */
+	color: #2ecc40;
+}
+
+#chat .kick .from:before {
+	content: "\f05e"; /* http://fontawesome.io/icon/ban/ */
+	color: #ff4136;
+}
+
+#chat .action .from:before {
+	content: "\f005"; /* http://fontawesome.io/icon/star/ */
+}
+
+#chat .count:before {
+	color: #cfcfcf;
+	content: "\f002"; /* http://fontawesome.io/icon/search/ */
+	position: absolute;
+	right: 18px;
+	font-size: 14px;
+	line-height: 50px;
+}
+
+#settings #play:before {
+	content: "\f028"; /* http://fontawesome.io/icon/volume-up/ */
+	margin-right: 9px;
+}
+
+/* End icons */
+
 #wrap {
 	height: 100%;
 	overflow: hidden;
@@ -232,10 +323,6 @@ button {
 	width: 36px;
 }
 
-#viewport .lt:before {
-	content: "\f0c9"; /* http://fontawesome.io/icon/bars/ */
-}
-
 #viewport .lt {
 	position: relative;
 }
@@ -257,14 +344,6 @@ button {
 
 #viewport .lt.notified:after {
 	opacity: 1;
-}
-
-#viewport .rt:before {
-	content: "\f0c0"; /* http://fontawesome.io/icon/users/ */
-}
-
-#chat button.menu:before {
-	content: "\f142"; /* http://fontawesome.io/icon/ellipsis-v/ */
 }
 
 #viewport .rt {
@@ -375,21 +454,6 @@ button {
 
 #chat .title:before {
 	margin-top: 17px;
-}
-
-#sidebar .chan.lobby:before,
-#chat .lobby .title:before {
-	content: "\f0a0"; /* http://fontawesome.io/icon/hdd-o/ */
-}
-
-#sidebar .chan.query:before,
-#chat .query .title:before {
-	content: "\f0e6"; /* http://fontawesome.io/icon/comments-o/ */
-}
-
-#sidebar .chan.channel:before,
-#chat .channel .title:before {
-	content: "\f0f6"; /* http://fontawesome.io/icon/file-text-o/ */
 }
 
 #sidebar .chan .name {
@@ -520,22 +584,6 @@ button {
 
 #footer .sign-in {
 	display: none;
-}
-
-#footer .sign-in:before {
-	content: "\f023"; /* http://fontawesome.io/icon/lock/ */
-}
-
-#footer .connect:before {
-	content: "\f067"; /* http://fontawesome.io/icon/plus/ */
-}
-
-#footer .settings:before {
-	content: "\f013"; /* http://fontawesome.io/icon/cog/ */
-}
-
-#footer .sign-out:before {
-	content: "\f011"; /* http://fontawesome.io/icon/power-off/ */
 }
 
 #main {
@@ -902,11 +950,6 @@ button {
 	display: none !important;
 }
 
-#chat .invite .from:before {
-	content: "\f003"; /* http://fontawesome.io/icon/envelope-o/ */
-	color: #2ecc40;
-}
-
 #chat .join .text,
 #chat .kick .text,
 #chat .mode .text,
@@ -918,56 +961,10 @@ button {
 	color: #999;
 }
 
-#chat .join .from:before {
-	content: "\f090"; /* http://fontawesome.io/icon/sign-in/ */
-	color: #2ecc40;
-}
-
-#chat .kick .from:before {
-	content: "\f05e"; /* http://fontawesome.io/icon/ban/ */
-	color: #ff4136;
-}
-
-#chat .part .from:before,
-#chat .quit .from:before {
-	content: "\f08b"; /* http://fontawesome.io/icon/sign-out/ */
-	color: #ff4136;
-	display: inline-block;
-	transform: rotate(180deg);
-}
-
-#chat .topic .from:before {
-	content: "\f0a1"; /* http://fontawesome.io/icon/bullhorn/ */
-	color: #2ecc40;
-}
-
-#chat .mode .from:before {
-	content: "\f05a"; /* http://fontawesome.io/icon/info-circle/ */
-	color: #2ecc40;
-}
-
-#chat .ctcp .from:before {
-	content: "\f0f6"; /* http://fontawesome.io/icon/file-text-o/ */
-}
-
-#chat .whois .from:before {
-	content: "\f007"; /* http://fontawesome.io/icon/user/ */
-	color: #2ecc40;
-}
-
-#chat .nick .from:before {
-	content: "\f007"; /* http://fontawesome.io/icon/user/ */
-	color: #2ecc40;
-}
-
 #chat .action .from,
 #chat .action .text,
 #chat .action .user {
 	color: #f39c12;
-}
-
-#chat .action .from:before {
-	content: "\f005"; /* http://fontawesome.io/icon/star/ */
 }
 
 #chat .notice .time,
@@ -1055,16 +1052,6 @@ button {
 	position: absolute;
 	right: 0;
 	top: 0;
-}
-
-#chat .count:before {
-	color: #cfcfcf;
-	content: "\f002"; /* http://fontawesome.io/icon/search/ */
-	position: absolute;
-	right: 18px;
-	font-size: 14px;
-	line-height: 50px;
-	z-index: 0;
 }
 
 #chat .search {
@@ -1221,11 +1208,6 @@ button {
 	opacity: .8;
 }
 
-#settings #play:before {
-	content: "\f028"; /* http://fontawesome.io/icon/volume-up/ */
-	margin-right: 9px;
-}
-
 #settings .about {
 	font-size: 14px;
 	padding-top: 2px;
@@ -1319,10 +1301,6 @@ button {
 	flex: 0 0 auto;
 }
 
-#form #submit:before {
-	content: "\f1d8"; /* http://fontawesome.io/icon/paper-plane/ */
-}
-
 #form #submit:hover {
 	opacity: .6;
 }
@@ -1373,18 +1351,6 @@ button {
 .context-menu-item:before {
 	width: 20px;
 	display: inline-block;
-}
-
-.context-menu-user:before {
-	content: "\f007"; /* http://fontawesome.io/icon/user/ */
-}
-
-.context-menu-chan:before {
-	content: "\f0f6"; /* http://fontawesome.io/icon/file-text-o/ */
-}
-
-.context-menu-close:before {
-	content: "\f00d"; /* http://fontawesome.io/icon/times/ */
 }
 
 /**

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1064,7 +1064,6 @@ button {
 	right: 18px;
 	font-size: 14px;
 	line-height: 50px;
-	transition: color .2s;
 	z-index: 0;
 }
 
@@ -1215,6 +1214,7 @@ button {
 
 #settings #play {
 	font-size: 14px;
+	transition: opacity .2s;
 }
 
 #settings #play:hover {
@@ -1314,7 +1314,7 @@ button {
 	color: #9ca5b4;
 	font-size: 14px;
 	height: 34px;
-	transition: opacity .3s;
+	transition: opacity .2s;
 	width: 34px;
 	flex: 0 0 auto;
 }


### PR DESCRIPTION
I was hoping to make a dead-simple PR to fix the icon blurriness (well, at least on a Mac OS with Retina, not sure how it looks otherwise), but I ended up spending waaaay too much time on this and also improving sizing, management, and some transitions.

### Changes

From the commit messages:

1. Improve font icon rendering with font-smoothing
  This makes all icons look sharper, and reproduces [what is applied on the FontAwesome CSS](https://github.com/FortAwesome/Font-Awesome/blob/4213679/css/font-awesome.css#L19-L20)

1. Define icon font only once and fix sizing
  - This commit applies the following across the whole style:
    - `font` statement is now [the same as official FontAwesome CSS](https://github.com/FortAwesome/Font-Awesome/blob/4213679/css/font-awesome.css#L16-L17)
    - Ensure icons are never italic or bold or that other variants can be applied
    - Ensure font-size and line-height of icons are inherited from parent
    - font-family and font-smoothing is now defined only once
  - A few (mostly positive) side effects from these and related changes:
    - Header icons (main menu, context menu and user list) are now vertically centered!
    - Same applies to the Send icon, but it's more subtle there
    - Alignment of the footer icons are shifted a tiny bit
    - Server window icons are a wee bit bit bigger to match the server name font-size
    - The "Play sound" icon and text are now both 14px (was 14px / 16px)

1. Add/fix/remove some CSS transitions
  - Transition on the search icon was removed, because why was it even here?!
  - A transition was added to the "Play sound" button
  - Transition on the Send button is now consistent with the others

1. Centralize all icon definitions for better management

### Results

Note that these are are screenshots from Chrome 51 on Mac OS X El Cap with Retina, but I noticed extremely similar (if not identical) results with Firefox on the same machine.
Let me know if you see different results on other OS.

Le What | Before | After
--- | --- | ---
Sharpness | <img width="129" alt="screen shot 2016-07-12 at 02 13 53" src="https://cloud.githubusercontent.com/assets/113730/16757102/d2a0edf6-47d7-11e6-818c-e08f15365878.png"> | <img width="130" alt="screen shot 2016-07-12 at 02 14 02" src="https://cloud.githubusercontent.com/assets/113730/16757101/d2a0d46a-47d7-11e6-93d1-20cf68fed6a8.png">
Sharpness | <img width="117" alt="screen shot 2016-07-12 at 02 13 58" src="https://cloud.githubusercontent.com/assets/113730/16757111/e1fd989e-47d7-11e6-91e5-10e21fa2ee27.png"> | <img width="115" alt="screen shot 2016-07-12 at 02 14 09" src="https://cloud.githubusercontent.com/assets/113730/16757112/e1fe2ef8-47d7-11e6-926c-1190d7e7d976.png">
Sharpness | <img width="116" alt="screen shot 2016-07-12 at 02 14 20" src="https://cloud.githubusercontent.com/assets/113730/16757129/feb2c4e6-47d7-11e6-98bb-51d44fd76933.png"> | <img width="111" alt="screen shot 2016-07-12 at 02 14 25" src="https://cloud.githubusercontent.com/assets/113730/16757130/feb35334-47d7-11e6-9dbd-b280d91143ce.png">
Text/Icon alignment | <img width="200" alt="screen shot 2016-07-12 at 02 15 40" src="https://cloud.githubusercontent.com/assets/113730/16757150/2274b2ae-47d8-11e6-835e-ab246a556e35.png"> | <img width="200" alt="screen shot 2016-07-12 at 02 15 49" src="https://cloud.githubusercontent.com/assets/113730/16757149/227497a6-47d8-11e6-89b2-8187142b6e89.png">
Sizing | <img width="200" alt="screen shot 2016-07-12 at 02 14 36" src="https://cloud.githubusercontent.com/assets/113730/16757169/354f488a-47d8-11e6-8cff-23f2613cf34b.png"> | <img width="206" alt="screen shot 2016-07-12 at 02 14 49" src="https://cloud.githubusercontent.com/assets/113730/16757170/3551e964-47d8-11e6-80ab-e5d1cdb5ce2a.png">
