### PR TITLE
Add information on the About section of the client

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -326,6 +326,10 @@
 								<p class="about">
 									The Lounge is in version <strong><%= version %></strong>
 									(<a href="https://github.com/thelounge/lounge/releases/tag/v<%= version %>" target="_blank">See release notes</a>).<br>
+
+									<a href="https://thelounge.github.io/" target="_blank">Website</a><br>
+									<a href="https://thelounge.github.io/docs/" target="_blank">Documentation</a><br>
+									<a href="https://github.com/thelounge/lounge/issues/new" target="_blank">Report a bug</a>
 								</p>
 							</div>
 						</div>

--- a/client/index.html
+++ b/client/index.html
@@ -324,8 +324,13 @@
 							</div>
 							<div class="col-sm-12">
 								<p class="about">
-									The Lounge is in version <strong><%= version %></strong>
-									(<a href="https://github.com/thelounge/lounge/releases/tag/v<%= version %>" target="_blank">See release notes</a>).<br>
+									<% if (gitCommit) { %>
+										The Lounge is running from source
+										(<a href="https://github.com/thelounge/lounge/tree/<%= gitCommit %>" target="_blank"><code><%= gitCommit %></code></a>).<br>
+									<% } else { %>
+										The Lounge is in version <strong><%= version %></strong>
+										(<a href="https://github.com/thelounge/lounge/releases/tag/v<%= version %>" target="_blank">See release notes</a>).<br>
+									<% } %>
 
 									<a href="https://thelounge.github.io/" target="_blank">Website</a><br>
 									<a href="https://thelounge.github.io/docs/" target="_blank">Documentation</a><br>

--- a/client/index.html
+++ b/client/index.html
@@ -324,8 +324,8 @@
 							</div>
 							<div class="col-sm-12">
 								<p class="about">
-									You're currently running version <%= version %><br>
-									<a href="https://github.com/thelounge/lounge/blob/master/CHANGELOG.md#readme" target="_blank">View the change log</a>
+									The Lounge is in version <strong><%= version %></strong>
+									(<a href="https://github.com/thelounge/lounge/releases/tag/v<%= version %>" target="_blank">See release notes</a>).<br>
 								</p>
 							</div>
 						</div>

--- a/src/server.js
+++ b/src/server.js
@@ -80,6 +80,16 @@ function allRequests(req, res, next) {
 	return next();
 }
 
+// Information to populate the About section in UI, either from npm or from git
+try {
+	var gitCommit = require("child_process")
+		.execSync("git rev-parse --short HEAD") // Returns hash of current commit
+		.toString()
+		.trim();
+} catch (e) {
+	// Not a git repository or git is not installed: treat it as npm release
+}
+
 function index(req, res, next) {
 	if (req.url.split("?")[0] !== "/") {
 		return next();
@@ -90,6 +100,7 @@ function index(req, res, next) {
 			pkg,
 			Helper.config
 		);
+		data.gitCommit = gitCommit;
 		var template = _.template(file);
 		res.setHeader("Content-Security-Policy", "default-src *; style-src * 'unsafe-inline'; script-src 'self'; child-src 'none'; object-src 'none'; form-action 'none'; referrer no-referrer;");
 		res.setHeader("Content-Type", "text/html");


### PR DESCRIPTION
This rewords current version string, adds useful links to the user, and displays whether the instance is running from a release or from the git repo.
This last piece will be very helpful to debug when users come asking help on the IRC channel.

From a release | From source
--- | ---
<img width="451" alt="screen shot 2016-07-13 at 03 03 48" src="https://cloud.githubusercontent.com/assets/113730/16795135/b7071002-48a9-11e6-8c8f-aa812096a1ea.png"> | <img width="445" alt="screen shot 2016-07-13 at 03 03 19" src="https://cloud.githubusercontent.com/assets/113730/16795136/b73be5de-48a9-11e6-8814-f4f92f8f1da1.png">
