### PR TITLE
Ignore unnecessary files at release time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-# Make sure to keep this file and .npmignore in sync
-
 node_modules/
 npm-debug.log
 

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,19 @@
-# This should match the .gitignore file without the generated assets
+# This file must not contain generated assets listed in .gitignore.
 # npm-debug.log and node_modules/ are ignored by default.
 # See https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package
 
+client/views/
 coverage/
+scripts/
+test/
+.editorconfig
+.eslintignore
+.eslintrc.yml
+.gitattributes
+.gitignore
+.istanbul.yml
+.npmignore
+.stylelintrc
+.travis.yml
+appveyor.yml
+Gruntfile.js


### PR DESCRIPTION
- `client/views/` contains templates whose built version is provided with each releases
- `.gitignore` doesn't appear in our releases, but I'm not sure if this comes from npm itself or Travis CI publishing for us. Adding it here for completeness. None of the documentations (npm or Travis CI) mentions this explicitly, so ¯\_(ツ)_/¯. If someone knows more about this, please share.
- Surprisingly, `.npmignore` itself is not ignored...
- All other files and directories are for development purposes only

<img width="407" alt="screen shot 2016-07-14 at 00 34 06" src="https://cloud.githubusercontent.com/assets/113730/16828096/b61680ae-495a-11e6-8d94-bd97baf40aa6.png">
