### PR TITLE
Add a script to easily run PRs from external contributors

### DIFF
--- a/scripts/run-pr.sh
+++ b/scripts/run-pr.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e
+
+if [ -z "$1" ]; then
+  echo "No pull request ID was specified."
+  exit 1
+fi
+
+git fetch https://github.com/thelounge/lounge.git refs/pull/${1}/head
+git checkout FETCH_HEAD
+npm install
+npm test || true
+npm start


### PR DESCRIPTION
Because I'm fed up of looking for the [right section in the maintainers' corner](https://github.com/thelounge/lounge/wiki/Maintainers'-corner#test-a-pr-locally) (because yes, I forget how to do it every single time), copy/paste, replace PR ID, ...
I'm thinking this saves some precious 3 seconds and can also help others to play with PRs without Googling too much.

Running it is as simple as:

```sh
./scripts/run-pr.sh 500
```