### PR TITLE
Keep track of the previous channels

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -395,13 +395,13 @@ $(function() {
 	socket.on("part", function(data) {
 		var chanMenuItem = sidebar.find(".chan[data-id='" + data.chan + "']");
 
-		// When parting from the active channel/query, jump to the network's lobby
-		if (chanMenuItem.hasClass("active")) {
-			chanMenuItem.parent(".network").find(".lobby").click();
-		}
-
 		chanMenuItem.remove();
 		$("#chan-" + data.chan).remove();
+
+		if (chanMenuItem.hasClass("active")) {
+			var nextChanId = chat.children().last().data("id");
+			sidebar.find(".chan[data-id='" + nextChanId + "']").click();
+		}
 	});
 
 	socket.on("quit", function(data) {
@@ -781,6 +781,7 @@ $(function() {
 		document.title = title;
 
 		if (self.hasClass("chan")) {
+			chan.appendTo(chat);
 			$("#chat-container").addClass("active");
 			setNick(self.closest(".network").data("nick"));
 		}


### PR DESCRIPTION
Following #489, this re-adds the old behavior of returning to the previous channel on close. While not exactly super intuitive, it still more useful than going to a server window even if it's random and has the advantage of bringing you back to where you were after a `/whois` or ZNC's `*status` or after chatting with a bot such as NickServ or ChanServ.

I don't see how reordering the DOM like that could have a negative impact since the others are `display:none` anyway, and completely removes the need for the z-index trickery.
