### PR TITLE
Use min-height of textarea when computing auto-resize after deleting a char

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1263,6 +1263,7 @@ button {
 	background: transparent;
 	border: none;
 	font: inherit;
+	min-height: 18px; /* Required when computing input height at char deletion */
 	height: 18px;
 	max-height: 90px;
 	line-height: 1.5;

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -632,8 +632,11 @@ $(function() {
 		.history()
 		.on("input keyup", function() {
 			var style = window.getComputedStyle(this);
-			this.style.height = "0px";
-			this.offsetHeight; // force reflow
+
+			// Start by resetting height before computing as scrollHeight does not
+			// decrease when deleting characters
+			this.style.height = this.style.minHeight;
+
 			this.style.height = Math.min(
 				Math.round(window.innerHeight - 100), // prevent overflow
 				this.scrollHeight


### PR DESCRIPTION
Fixes #482.

This fixes a bug that was breaking the textarea on Android.
@williamboman, can you give it a try?