### PR TITLE
Revert "Slight optimization in the textarea code"

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -632,8 +632,6 @@ $(function() {
 		.history()
 		.on("input keyup", function() {
 			var style = window.getComputedStyle(this);
-			var origHeight = this.style.height;
-
 			this.style.height = "0px";
 			this.offsetHeight; // force reflow
 			this.style.height = Math.min(
@@ -643,9 +641,7 @@ $(function() {
 				+ Math.round(parseFloat(style.borderBottomWidth) || 0)
 			) + "px";
 
-			if (this.style.height !== origHeight) {
-				$("#chat .chan.active .chat").trigger("msg.sticky"); // fix growing
-			}
+			$("#chat .chan.active .chat").trigger("msg.sticky"); // fix growing
 		})
 		.tab(complete, {hint: false});
 


### PR DESCRIPTION
Reverts thelounge/lounge#508.

Easier to show than to explain:

![bug-textarea](https://cloud.githubusercontent.com/assets/113730/16898615/6a0bcba0-4bae-11e6-956b-71a303e8aea0.gif)

Marking as `priority` as this is a regression on `master`. I don't think saving 3-4ms is worth glitching the client :-)