### PR TITLE
views/chat: set title attribute on topic

### DIFF
--- a/client/views/chat.tpl
+++ b/client/views/chat.tpl
@@ -7,7 +7,7 @@
 		{{/equal}}
 		<button class="menu" aria-label="Open the context menu"></button>
 		<span class="title">{{name}}</span>
-		<span class="topic">{{{parse topic}}}</span>
+		<span title="{{topic}}" class="topic">{{{parse topic}}}</span>
 	</div>
 	<div class="chat">
 		<div class="show-more {{#equal messages.length 100}}show{{/equal}}">


### PR DESCRIPTION
The `title` attribute is only set [when receiving a topic change event](https://git.io/vKVC1) right now, not on page load.