### PR TITLE
Make sure git commit check would not send stderr to the console

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var _ = require("lodash");
 var pkg = require("../package.json");
 var bcrypt = require("bcrypt-nodejs");
@@ -81,9 +83,10 @@ function allRequests(req, res, next) {
 }
 
 // Information to populate the About section in UI, either from npm or from git
+var gitCommit = null;
 try {
-	var gitCommit = require("child_process")
-		.execSync("git rev-parse --short HEAD") // Returns hash of current commit
+	gitCommit = require("child_process")
+		.execSync("git rev-parse --short HEAD 2> /dev/null") // Returns hash of current commit
 		.toString()
 		.trim();
 } catch (e) {


### PR DESCRIPTION
Before that change, running a release would display this in the console:
```
fatal: Not a git repository (or any of the parent directories): .git
```

Also, this adds strict mode for that file, and make sure `gitCommit` never throws a `ReferenceError`.