### PR TITLE
Remove table layout for chat messages (and fix layout issues yet again)

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -929,12 +929,9 @@ kbd {
 	padding-right: 10px;
 	text-align: right;
 	width: 134px;
-	align-self: stretch;
 }
 
 #chat .text {
-	margin: auto;
-	overflow: hidden;
 	flex: 1 1 auto;
 }
 
@@ -999,14 +996,6 @@ kbd {
 
 #chat .self .text {
 	color: #999;
-}
-
-#chat .msg.motd .text,
-#chat .msg.message .text,
-#chat .msg.action .action-text,
-#chat .msg.notice .text {
-	white-space: pre-wrap;
-	overflow: hidden;
 }
 
 #chat .msg.channel_list_loading .text {

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -832,15 +832,15 @@ kbd {
 }
 
 #chat .messages {
-	display: table;
-	table-layout: fixed;
-	width: 100%;
 	padding: 10px 0;
 }
 
 #chat .msg {
 	word-wrap: break-word;
 	word-break: break-word; /* Webkit-specific */
+	display: flex;
+	overflow: hidden;
+	position: relative;
 }
 
 #chat .unread-marker {
@@ -912,16 +912,15 @@ kbd {
 #chat .time,
 #chat .from,
 #chat .text {
-	display: table-cell;
+	display: block;
 	padding: 2px 0;
-	vertical-align: top;
+	flex: 0 0 auto;
 }
 
 #chat .time {
 	color: #ddd;
 	text-align: right;
-	max-width: 46px;
-	min-width: 46px;
+	width: 46px;
 }
 
 #chat .from {
@@ -929,8 +928,14 @@ kbd {
 	color: #b1c3ce;
 	padding-right: 10px;
 	text-align: right;
-	max-width: 134px;
-	min-width: 134px;
+	width: 134px;
+	align-self: stretch;
+}
+
+#chat .text {
+	margin: auto;
+	overflow: hidden;
+	flex: 1 1 auto;
 }
 
 #loading a,


### PR DESCRIPTION
Fixes this:
![capture d ecran_2016-07-22_22-04-49](https://cloud.githubusercontent.com/assets/5481612/17075136/6ddd482c-5058-11e6-8675-b8075053c001.png)

back into this:
![capture d ecran_2016-07-22_22-05-12](https://cloud.githubusercontent.com/assets/5481612/17075138/725d2ef8-5058-11e6-96fe-c9b6fbeb6514.png)

EDIT: So, this still had bugs, so I removed the table layout entirely. This one seems to just play nice now.
