### PR TITLE
Improve inline previews for links and images

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -933,6 +933,7 @@ kbd {
 
 #chat .text {
 	flex: 1 1 auto;
+	overflow: hidden;
 }
 
 #loading a,
@@ -1103,7 +1104,7 @@ kbd {
 	color: #222;
 	font-size: 12px;
 	max-width: 100%;
-	padding: 6px 8px;
+	padding: 6px;
 	margin-top: 2px;
 	overflow: hidden;
 }
@@ -1116,31 +1117,28 @@ kbd {
 	max-width: 100%;
 	max-height: 128px;
 	display: block;
-	margin: 2px 0;
 }
 
 #chat .toggle-content .thumb {
 	float: left;
-	margin-right: 10px;
+	margin-right: 6px;
 	max-width: 48px;
-	max-height: 36px;
+	max-height: 32px;
 }
 
-#chat .toggle-content .head {
-	font-weight: bold;
+#chat .toggle-content .head,
+#chat .toggle-content .body {
 	white-space: nowrap;
 	text-overflow: ellipsis;
 	overflow: hidden;
 }
 
+#chat .toggle-content .head {
+	font-weight: bold;
+}
+
 #chat .toggle-content .body {
 	color: #999;
-	max-width: 460px;
-	word-break: normal;
-	word-wrap: break-word;
-	overflow: hidden;
-	max-height: 30px;
-	text-overflow: ellipsis;
 }
 
 #chat .toggle-content.show {

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1105,6 +1105,7 @@ kbd {
 	max-width: 100%;
 	padding: 6px 8px;
 	margin-top: 2px;
+	overflow: hidden;
 }
 
 #chat .toggle-content a {
@@ -1113,18 +1114,23 @@ kbd {
 
 #chat .toggle-content img {
 	max-width: 100%;
-	max-height: 250px;
+	max-height: 128px;
 	display: block;
 	margin: 2px 0;
 }
 
 #chat .toggle-content .thumb {
-	max-height: 110px;
-	max-width: 210px;
+	float: left;
+	margin-right: 10px;
+	max-width: 48px;
+	max-height: 36px;
 }
 
 #chat .toggle-content .head {
 	font-weight: bold;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	overflow: hidden;
 }
 
 #chat .toggle-content .body {
@@ -1132,10 +1138,17 @@ kbd {
 	max-width: 460px;
 	word-break: normal;
 	word-wrap: break-word;
+	overflow: hidden;
+	max-height: 30px;
+	text-overflow: ellipsis;
 }
 
 #chat .toggle-content.show {
-	display: inline-block !important;
+	display: block;
+}
+
+#chat .toggle-content.toggle-type-image.show {
+	display: inline;
 }
 
 #chat .count {

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1144,11 +1144,7 @@ kbd {
 }
 
 #chat .toggle-content.show {
-	display: block;
-}
-
-#chat .toggle-content.toggle-type-image.show {
-	display: inline;
+	display: inline-block !important;
 }
 
 #chat .count {

--- a/client/views/toggle.tpl
+++ b/client/views/toggle.tpl
@@ -1,5 +1,5 @@
 {{#toggle}}
-<div class="toggle-content">
+<div class="toggle-content toggle-type-{{type}}">
 	{{#equal type "image"}}
 		<a href="{{link}}" target="_blank">
 			<img src="{{link}}">


### PR DESCRIPTION
This is a CSS mod I have had for a little while that improves the readability and space efficiency of the link and image previews, so I thought it would be time to finally share it.

![capture d ecran_2016-07-22_23-03-24](https://cloud.githubusercontent.com/assets/5481612/17075418/96180ec8-5060-11e6-9aee-32f8e975ec81.png)
![capture d ecran_2016-07-22_23-01-43](https://cloud.githubusercontent.com/assets/5481612/17075419/98fdea72-5060-11e6-8bca-040a29a17535.png)

For me, this makes it viable to have them all expand by default and you don't get extra huge images in your face all the time. You can see on the first screenshot I have hidden the toggle button entirely, as I don't feel like I need it anymore.
