### PR TITLE
Fix duplicate nicks (maybe)

### DIFF
--- a/src/plugins/irc-events/join.js
+++ b/src/plugins/irc-events/join.js
@@ -1,3 +1,4 @@
+var _ = require("lodash");
 var Chan = require("../../models/chan");
 var Msg = require("../../models/msg");
 var User = require("../../models/user");
@@ -17,11 +18,15 @@ module.exports = function(irc, network) {
 				chan: chan
 			});
 		}
-		chan.users.push(new User({nick: data.nick, modes: ""}));
-		chan.sortUsers(irc);
-		client.emit("users", {
-			chan: chan.id
-		});
+
+		if (!_.find(chan.users, {nick: data.nick})) {
+			chan.users.push(new User({nick: data.nick, modes: ""}));
+			chan.sortUsers(irc);
+			client.emit("users", {
+				chan: chan.id
+			});
+		}
+
 		var msg = new Msg({
 			time: data.time,
 			from: data.nick,


### PR DESCRIPTION
Due to the rarity of this bug, I suspect there is some kind of race condition going on where we send a `NAMES` request, and in the meantime users have joined on the server so we get them back as a result. But then we also receive their respective `JOIN`s after the names list, so we add them to our existing list.

Well even if it's not it, it should fix the problem anyway so whatever.