### PR TITLE
Reset the unread marker on channel change

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -764,9 +764,13 @@ $(function() {
 			.find(".chat")
 			.unsticky();
 
-		lastActive
+		var lastActiveChan = lastActive
 			.find(".chan.active")
 			.removeClass("active");
+
+		lastActiveChan
+			.find(".unread-marker")
+			.appendTo(lastActiveChan.find(".messages"));
 
 		var chan = $(target)
 			.addClass("active")


### PR DESCRIPTION
This restores the old behavior of resetting the unread marker on channel change, as that's usually at this point one wants to check for new messages and is also what matches on the server. I feel this is overall more consistent and useful, and also more in line with what other clients do.