### PR TITLE
Match custom highlights as case-insensitive regexes

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -204,7 +204,7 @@ $(function() {
 		var template = "msg";
 
 		if (!data.msg.highlight && !data.msg.self && (type === "message" || type === "notice") && highlights.some(function(h) {
-			return data.msg.text.indexOf(h) > -1;
+			return data.msg.text.match(new RegExp(h, "i"));
 		})) {
 			data.msg.highlight = true;
 		}


### PR DESCRIPTION
 Match custom highlights as case-insensitive regular expressions.