### PR TITLE
Fix webirc and 4-in-6 addresses

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -70,11 +70,15 @@ module.exports = function() {
 };
 
 function getClientIp(req) {
+	var ip;
+
 	if (!Helper.config.reverseProxy) {
-		return req.connection.remoteAddress;
+		ip = req.connection.remoteAddress;
 	} else {
-		return req.headers["x-forwarded-for"] || req.connection.remoteAddress;
+		ip = req.headers["x-forwarded-for"] || req.connection.remoteAddress;
 	}
+
+	return ip.replace(/^::ffff:/, "");
 }
 
 function allRequests(req, res, next) {


### PR DESCRIPTION
Since we fixed IPv6, now node returns us IPv4 addresses in the 6-in-4 format such as `::ffff:8.8.8.8`. Not only does this conflict with servers because it starts with `:`, it is also [not a valid argument](https://kiwiirc.com/docs/webirc) for the webirc command.