### PR TITLE
Fix accidentally removed border-radius

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -591,6 +591,7 @@ button {
 	border-radius: 2px;
 	bottom: 4px;
 	left: 220px;
+	overflow: hidden; /* Without this, border-radius has no effect */
 	position: absolute;
 	right: 5px;
 	top: 4px;


### PR DESCRIPTION
This was removed by [this](https://github.com/thelounge/lounge/pull/379/files#diff-97db1f70168fb5f12457b238ff6052b5L504). I don't think this as further consequences but I would prefer @maxpoulin64 to confirm that.

#### Screenshots

This is very minor, but there is idiom about the devil and details :-)

Before fix | After fix
--- | ---
<img width="489" alt="screen shot 2016-07-31 at 17 50 14" src="https://cloud.githubusercontent.com/assets/113730/17279657/f4bd8258-5747-11e6-8106-e5631049494b.png"> | <img width="489" alt="screen shot 2016-07-31 at 17 49 40" src="https://cloud.githubusercontent.com/assets/113730/17279660/f4cc42a2-5747-11e6-9b0d-7c922ed89abb.png">
<img width="224" alt="screen shot 2016-07-31 at 17 50 43" src="https://cloud.githubusercontent.com/assets/113730/17279659/f4cb3f7e-5747-11e6-939d-dae6e92e654b.png"> | <img width="209" alt="screen shot 2016-07-31 at 17 49 56" src="https://cloud.githubusercontent.com/assets/113730/17279658/f4c7fe90-5747-11e6-9159-fa76efc579f2.png">
