### PR TITLE
Restore padding and height of message input pre-textarea era

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -548,10 +548,10 @@ button {
 	background: rgba(0, 0, 0, .06);
 	border-radius: 2px;
 	bottom: 4px;
-	height: 48px;
+	height: 45px;
 	left: 5px;
 	font-size: 14px;
-	line-height: 48px;
+	line-height: 45px;
 	position: absolute;
 	text-align: center;
 	width: 210px;
@@ -1249,7 +1249,6 @@ button {
 	background: white;
 	display: flex;
 	align-items: flex-end;
-	min-height: 37px;
 }
 
 #form #nick {
@@ -1257,7 +1256,7 @@ button {
 	color: #666;
 	font: inherit;
 	font-size: 11px;
-	margin: 5px;
+	margin: 4px;
 	line-height: 26px;
 	height: 24px;
 	padding: 0 9px;
@@ -1296,9 +1295,9 @@ button {
 #form #submit {
 	color: #9ca5b4;
 	font-size: 14px;
-	height: 34px;
+	height: 32px;
 	transition: opacity .2s;
-	width: 34px;
+	width: 32px;
 	flex: 0 0 auto;
 }
 


### PR DESCRIPTION
Margins around the nick, and overall height of the input, perfectly set prior to the textarea introduction. Turns out, there was also a 1px-offset in there, and I could see something was off without being able to pinpoint what exactly.

Not sure how long the current style of textarea will stay around, but this PR at least puts things back in order until then.

I have played a looot with this, adding and removing stuff, when in the end the changes are **just** because now the border is set on a different element, and we all know how CSS is a bit bitchy about how overall heights and margins are set depending on the border.

#### Results

On pre.4 (without textarea) | Before PR | After PR
--- | --- | ---
<img width="1280" alt="screen shot 2016-08-02 at 00 29 43" src="https://cloud.githubusercontent.com/assets/113730/17317239/6fb1b680-5849-11e6-82da-33632a787095.png"> | <img width="1280" alt="screen shot 2016-08-02 at 00 30 09" src="https://cloud.githubusercontent.com/assets/113730/17317240/6fb1d066-5849-11e6-8f24-dbe79b7936fc.png"> | <img width="1280" alt="screen shot 2016-08-02 at 00 30 25" src="https://cloud.githubusercontent.com/assets/113730/17317241/6fb1f23a-5849-11e6-86b8-f9f1e00b344c.png">
