### PR TITLE
Prevent Ctrl-Tab from triggering tab completion

### DIFF
--- a/client/js/libs/jquery/tabcomplete.js
+++ b/client/js/libs/jquery/tabcomplete.js
@@ -112,7 +112,7 @@
 		
 		this.on("keydown.tabcomplete", function(e) {
 			var key = e.which;
-			if (key == keys.tab
+			if (key == keys.tab && !e.ctrlKey
 				|| (options.arrowKeys && (key == keys.up || key == keys.down))) {
 				
 				// Don't lose focus on tab click.


### PR DESCRIPTION
Fixes #529

This is probably the simplest workaround for Firefox sending a keydown event when switching browser tabs via Ctrl-Tab