### PR TITLE
Disable debug logs in npm releases

### DIFF
--- a/src/plugins/irc-events/connection.js
+++ b/src/plugins/irc-events/connection.js
@@ -74,9 +74,10 @@ module.exports = function(irc, network) {
 		});
 	}
 
-	irc.on("debug", function(message) {
-		log.debug("[" + client.name + " (#" + client.id + ") on " + network.name + " (#" + network.id + ")]", message);
-	});
+	// TODO Add a debug mode. See https://github.com/thelounge/lounge/issues/459
+	// irc.on("debug", function(message) {
+	// 	log.debug("[" + client.name + " (#" + client.id + ") on " + network.name + " (#" + network.id + ")]", message);
+	// });
 
 	irc.on("socket error", function(err) {
 		network.channels[0].pushMessage(client, new Msg({


### PR DESCRIPTION
This is temporary until https://github.com/thelounge/lounge/issues/459, but meanwhile we should not be spamming connection debug messages in releases or pre-releases.