### PR TITLE
Changing nick in the UI

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1340,8 +1340,11 @@ button {
 }
 
 #nick.editable button#set-nick,
+#nick.editable #set-nick-tooltip,
 #nick button#submit-nick,
-#nick button#cancel-nick {
+#nick:not(.editable) #save-nick-tooltip,
+#nick button#cancel-nick,
+#nick:not(.editable) #cancel-nick-tooltip {
 	display: none;
 }
 

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -160,7 +160,8 @@ button {
 #chat .whois .from:before,
 #chat .nick .from:before,
 #chat .action .from:before,
-.context-menu-item:before {
+.context-menu-item:before,
+#nick button:before {
 	font: normal normal normal 14px/1 FontAwesome;
 	font-size: inherit; /* Can't have font-size inherit on line above, so need to override */
 	-webkit-font-smoothing: antialiased;
@@ -258,6 +259,18 @@ button {
 #settings #play:before {
 	content: "\f028"; /* http://fontawesome.io/icon/volume-up/ */
 	margin-right: 9px;
+}
+
+#set-nick:before {
+	content: "\f040"; /* http://fontawesome.io/icon/pencil/ */
+}
+
+#submit-nick:before {
+	content: "\f00c"; /* http://fontawesome.io/icon/check/ */
+}
+
+#cancel-nick:before {
+	content: "\f00d"; /* http://fontawesome.io/icon/times/ */
 }
 
 /* End icons */
@@ -1284,31 +1297,60 @@ button {
 	align-items: flex-end;
 }
 
+[contenteditable]:focus {
+	outline: none;
+}
+
+/* Nick editor */
+
 #form #nick {
 	background: #f6f6f6;
 	color: #666;
 	font: inherit;
 	font-size: 11px;
 	margin: 4px;
-	line-height: 26px;
+	line-height: 22px;
 	height: 24px;
-	padding: 0 9px;
-	border-radius: 1px;
+	padding-left: 9px;
+	padding-right: 5px;
+	border-radius: 2px;
 	-webkit-user-select: none;
 	-moz-user-select: none;
 	-ms-user-select: none;
 	user-select: none;
 	-webkit-flex: 0 0 auto;
 	flex: 0 0 auto;
+	border: 1px solid transparent;
+	transition: border-color .2s;
 }
 
-#form #nick:empty {
-	visibility: hidden;
+#form #nick-value {
+	padding-right: 5px;
 }
 
-#form #nick:after {
-	content: ":";
+#form #nick.editable {
+	border-color: black;
 }
+
+#nick button#set-nick,
+#nick button#submit-nick,
+#nick button#cancel-nick {
+	color: #aaa;
+	width: 18px;
+}
+
+#nick.editable button#set-nick,
+#nick button#submit-nick,
+#nick button#cancel-nick {
+	display: none;
+}
+
+#nick.editable button#submit-nick,
+#nick.editable button#cancel-nick {
+	display: inline-block;
+}
+
+/* End nick editor */
 
 #form #input {
 	background: transparent;

--- a/client/index.html
+++ b/client/index.html
@@ -61,10 +61,9 @@
 						<div class="input">
 							<span id="nick">
 								<span id="nick-value" spellcheck="false"></span><!-- Comments here remove spaces between elements
-								--><button id="set-nick" type="button" title="Set Nick" aria-label="Set nick"></button><!--
-								--><button id="cancel-nick" type="button" title="Cancel Nick" aria-label="Cancel nick"></button><!--
-								--><button id="submit-nick" type="button" title="Submit Nick" aria-label="Submit nick"></button>
-								</span>
+								--><span id="set-nick-tooltip" class="tooltipped tooltipped-e" aria-label="Change nick"><button id="set-nick" type="button" aria-label="Change nick"></button></span><!--
+								--><span id="cancel-nick-tooltip" class="tooltipped tooltipped-e" aria-label="Cancel"><button id="cancel-nick" type="button" aria-label="Cancel"></button></span><!--
+								--><span id="save-nick-tooltip" class="tooltipped tooltipped-e" aria-label="Save"><button id="submit-nick" type="button" aria-label="Save"></button></span>
 							</span>
 							<textarea id="input" class="mousetrap"></textarea>
 							<span class="tooltipped tooltipped-w" aria-label="Send message">

--- a/client/index.html
+++ b/client/index.html
@@ -59,7 +59,13 @@
 					<div id="chat"></div>
 					<form id="form" method="post" action="">
 						<div class="input">
-							<label for="input" id="nick"></label>
+							<span id="nick">
+								<span id="nick-value" spellcheck="false"></span><!-- Comments here remove spaces between elements
+								--><button id="set-nick" type="button" title="Set Nick" aria-label="Set nick"></button><!--
+								--><button id="cancel-nick" type="button" title="Cancel Nick" aria-label="Cancel nick"></button><!--
+								--><button id="submit-nick" type="button" title="Submit Nick" aria-label="Submit nick"></button>
+								</span>
+							</span>
 							<textarea id="input" class="mousetrap"></textarea>
 							<span class="tooltipped tooltipped-w" aria-label="Send message">
 								<button id="submit" type="submit" aria-label="Send message"></button>

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -734,16 +734,20 @@ $(function() {
 		$("#nick-value").attr("contenteditable", toggle);
 	}
 
-	// FIXME Reset content when new nick is invalid (already in use, forbidden chars, ...)
 	function submitNick() {
-		var newNick = $("#nick-value").text();
+		var newNick = $("#nick-value").text().trim();
+
+		if (newNick.length === 0) {
+			cancelNick();
+			return;
+		}
+
+		toggleNickEditor(false);
 
 		socket.emit("input", {
 			target: chat.data("id"),
 			text: "/nick " + newNick
 		});
-
-		toggleNickEditor(false);
 	}
 
 	function cancelNick() {
@@ -1253,10 +1257,11 @@ $(function() {
 	}
 
 	function setNick(nick) {
-		$("#nick-value").text(nick);
 		// Closes the nick editor when canceling, changing channel, or when a nick
 		// is set in a different tab / browser / device.
 		toggleNickEditor(false);
+
+		$("#nick-value").text(nick);
 	}
 
 	function move(array, old_index, new_index) {

--- a/src/client.js
+++ b/src/client.js
@@ -42,6 +42,7 @@ var inputs = [
 	"invite",
 	"kick",
 	"mode",
+	"nick",
 	"notice",
 	"query",
 	"quit",

--- a/src/plugins/inputs/nick.js
+++ b/src/plugins/inputs/nick.js
@@ -1,0 +1,37 @@
+var Msg = require("../../models/msg");
+
+exports.commands = ["nick"];
+exports.allowDisconnected = true;
+
+exports.input = function(network, chan, cmd, args) {
+	if (args.length === 0) {
+		chan.pushMessage(this, new Msg({
+			type: Msg.Type.ERROR,
+			text: "Usage: /nick <your new nick>"
+		}));
+		return;
+	}
+
+	if (args.length !== 1) {
+		chan.pushMessage(this, new Msg({
+			type: Msg.Type.ERROR,
+			text: "Nicknames may not contain spaces."
+		}));
+		return;
+	}
+
+	var newNick = args[0];
+
+	// If connected to IRC, send to server and wait for ACK
+	// otherwise update the nick and UI straight away
+	if (network.irc && network.irc.connection) {
+		network.irc.raw("NICK", newNick);
+	} else {
+		network.setNick(newNick);
+
+		this.emit("nick", {
+			network: network.id,
+			nick: newNick
+		});
+	}
+};

--- a/src/plugins/irc-events/error.js
+++ b/src/plugins/irc-events/error.js
@@ -28,6 +28,11 @@ module.exports = function(irc, network) {
 			var random = (data.nick || irc.user.nick) + Math.floor(10 + (Math.random() * 89));
 			irc.changeNick(random);
 		}
+
+		client.emit("nick", {
+			network: network.id,
+			nick: irc.user.nick
+		});
 	});
 
 	irc.on("nick invalid", function(data) {
@@ -42,5 +47,10 @@ module.exports = function(irc, network) {
 			var random = "i" + Math.random().toString(36).substr(2, 10); // 'i' so it never begins with a number
 			irc.changeNick(random);
 		}
+
+		client.emit("nick", {
+			network: network.id,
+			nick: irc.user.nick
+		});
 	});
 };


### PR DESCRIPTION
This PR gives a nice UI integration for letting users change their nicks.

### TODO (help needed)

- [x] [R710](https://github.com/thelounge/lounge/pull/551/files#diff-e5178f7b74fe45f2cfe1baf9aa1ef6faR710) Since I'm actually modifying the content of the `contenteditable` box, I am currently leaving the saved value there, assuming that saving will just work. If the nick already exists, or if an invalid character is used, or if any other reason prevents IRC to change the nick, the label will keep the saved value until browsing among channels. 2 solutions:

  1. ~~When saving, value of the label stays the saved value. If an error pops up, we rollback to the previous nick. This has the benefits of looking clean, but in practice it means we need to listen to the correct IRC errors, which might not be easy. For example, I recently noticed that a nick could not be saved, with a super generic, like "Failed action" or something like that. Not sure how `irc-framework` handles this, but it might just be not possible.~~

  2. ~~When saving, content of the label is reverted to previous nick. From there, we let the rest of the app changing the nick label as part of nick handling as it already does when sending `/nick newnick`. I actually prefer that solution! It looks less polished, but it's the smallest source of bugs. One caveat is that upon saving a new nick, users will see the old nick in a flash, then the new nick, but that can be easily handled by delaying the revert by a few seconds. I think I will go with this option unless I see a compelling argument not to.~~~

  3. Scratch all this, actual solution requires a mix of both and is rather complicated. I suggest going forward with this PR and improving upon this at a later time.

- [x] [R1320](https://github.com/thelounge/lounge/pull/551/files#diff-97db1f70168fb5f12457b238ff6052b5R1320) The whole nick box was being hidden in CSS when nick was empty with `#form #nick:empty { visibility: hidden; }`. Now that there are other elements in the box, `#nick:empty` will never be true. I am not sure how to fix this really. I could add some `if`s to check when the connection is not established, or if there is an error or whatever, but the advantage of setting this with CSS was that we didn't need to bother about the *why* and just hide the item as a whole. Any smart idea?

- [x] Tooltips will look much nicer once #540 is merged.

- [x] Extra commits need to be squashed once everyone is happy with the implementation.

### Result

![set-nick](https://cloud.githubusercontent.com/assets/113730/17505610/48357088-5dd0-11e6-9646-c6b81346d2c7.gif)
