### PR TITLE
Fix token persistency across server refresh

### DIFF
--- a/src/clientManager.js
+++ b/src/clientManager.js
@@ -17,7 +17,7 @@ function ClientManager() {
 ClientManager.prototype.findClient = function(name, token) {
 	for (var i in this.clients) {
 		var client = this.clients[i];
-		if (client.name === name || (token && token === client.token)) {
+		if (client.name === name || (token && token === client.config.token)) {
 			return client;
 		}
 	}

--- a/src/server.js
+++ b/src/server.js
@@ -282,11 +282,11 @@ function auth(data) {
 		}
 	} else {
 		client = manager.findClient(data.user, data.token);
-		var signedIn = data.token && client && client.token === data.token;
+		var signedIn = data.token && data.token === client.config.token;
 		var token;
 
 		if (data.remember || data.token) {
-			token = client.token;
+			token = client.config.token;
 		}
 
 		var authCallback = function(success) {


### PR DESCRIPTION
This fixes a regression introduced by LDAP support addition (https://github.com/thelounge/lounge/pull/477), which forces users to re-login when the server restarts. This was originally implemented in https://github.com/thelounge/lounge/pull/370.

@thisisdarshan and @lindskogen, could you proof read this PR, please? It seems to me that this was just a typo on #477 but maybe I'm wrong and this is breaking your LDAP implementation, so I value your opinion :-)