### PR TITLE
Make sure input height is reset when submitting with icon

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -631,6 +631,10 @@ $(function() {
 		return false;
 	});
 
+	function resetInputHeight(input) {
+		input.style.height = input.style.minHeight;
+	}
+
 	var input = $("#input")
 		.history()
 		.on("input keyup", function() {
@@ -638,7 +642,7 @@ $(function() {
 
 			// Start by resetting height before computing as scrollHeight does not
 			// decrease when deleting characters
-			this.style.height = this.style.minHeight;
+			resetInputHeight(this);
 
 			this.style.height = Math.min(
 				Math.round(window.innerHeight - 100), // prevent overflow
@@ -662,6 +666,7 @@ $(function() {
 		}
 
 		input.val("");
+		resetInputHeight(input.get(0));
 
 		if (text.indexOf("/clear") === 0) {
 			clear();


### PR DESCRIPTION
This is especially noticeable on mobile, where clicking Send icon is more natural.

Before | After
--- | ---
![input-no-reset-height](https://cloud.githubusercontent.com/assets/113730/17579241/ed5b290e-5f60-11e6-81f0-94b98833a027.gif) | ![input-reset-height](https://cloud.githubusercontent.com/assets/113730/17579240/ed5a9a84-5f60-11e6-8b46-2f6f01901291.gif)

(The screenshots show an extra empty line in the `textarea`, this is an unrelated bug that I haven't had the chance to debug yet. Help welcome 😄)