### PR TITLE
Bump request to 2.74.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "lodash": "4.11.2",
     "moment": "2.13.0",
     "read": "1.0.7",
-    "request": "2.72.0",
+    "request": "2.74.0",
     "semver": "5.1.0",
     "socket.io": "1.4.5",
     "spdy": "3.3.2",


### PR DESCRIPTION
Fixes #554.

Diff at https://github.com/request/request/compare/v2.72.0...v2.74.0
This suppresses security vulnerability warning.

Tried playing with the link prefetcher (only place where we use `request` right now) without any issue.