### PR TITLE
Display unread marker on current channel when initially loading the page

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -333,7 +333,8 @@ $(function() {
 	socket.on("msg", function(data) {
 		var msg = buildChatMessage(data);
 		var target = "#chan-" + data.chan;
-		var container = chat.find(target + " .messages");
+		var channel = chat.find(target);
+		var container = channel.find(".messages");
 
 		container
 			.append(msg)
@@ -342,7 +343,9 @@ $(function() {
 				data.msg
 			]);
 
-		if (data.msg.self) {
+		// Unread marker is "hidden" (moved to bottom) if message comes from own
+		// user or if the channel is both active and focused
+		if (data.msg.self || (channel.hasClass("active") && document.hasFocus())) {
 			container
 				.find(".unread-marker")
 				.appendTo(container);

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -349,6 +349,12 @@ $(function() {
 			container
 				.find(".unread-marker")
 				.appendTo(container);
+
+			// Channel is marked as read on the server
+			socket.emit(
+				"open",
+				data.chan
+			);
 		}
 	});
 

--- a/src/models/chan.js
+++ b/src/models/chan.js
@@ -43,7 +43,7 @@ Chan.prototype.pushMessage = function(client, msg) {
 		this.messages.splice(0, this.messages.length - Helper.config.maxHistory);
 	}
 
-	if (!msg.self && this.id !== client.activeChannel) {
+	if (!msg.self) {
 		if (!this.firstUnread) {
 			this.firstUnread = msg.id;
 		}


### PR DESCRIPTION
Fixes #561.

I did a lot of testing, when focusing/not focusing the app, when receiving a message in active/non-active channel, when loading the page / when the page is already loaded, etc., but this is rather intricate, so I wouldn't be against any additional testing/feedback!

(Can't wait to completely get rid of `activeChannel` on the server, seriously, why does the server have to know what the client is currently viewing...)