### PR TITLE
Theme selector on the client

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -581,8 +581,11 @@ button {
 	outline: 0;
 	padding: 8px 10px;
 	transition: border-color .2s;
-	-webkit-appearance: none;
 	width: 100%;
+}
+
+#windows select.input {
+	height: 35px;
 }
 
 #user-specified-css-input {

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -572,6 +572,7 @@ button {
 }
 
 #windows .input {
+	background-color: white;
 	border: 1px solid #cdd3da;
 	border-radius: 2px;
 	color: #222;

--- a/client/index.html
+++ b/client/index.html
@@ -15,7 +15,7 @@
 
 	<link rel="stylesheet" href="css/bootstrap.css">
 	<link rel="stylesheet" href="css/style.css">
-	<link id="theme" rel="stylesheet" href="<%= typeof(theme) !== "undefined" ? theme : "themes/example.css" %>">
+	<link id="theme" rel="stylesheet" href="<%= theme %>">
 	<style id="user-specified-css"></style>
 
 	<link rel="shortcut icon" href="img/favicon.png" data-other="img/favicon-notification.png" data-toggled="false" id="favicon">
@@ -240,6 +240,19 @@
 									<input type="checkbox" name="coloredNicks">
 									Enable colored nicknames
 								</label>
+							</div>
+							<div class="col-sm-12">
+								<h2>Theme</h2>
+							</div>
+							<div class="col-sm-12">
+								<label for="theme-select" class="sr-only">Theme</label>
+								<select id="theme-select" name="theme" class="input">
+									<% themes.forEach(function(themeName) { %>
+										<option value="<%= themeName %>">
+											<%= themeName.charAt(0).toUpperCase() + themeName.slice(1) %>
+										</option>
+									<% }) %>
+								</select>
 							</div>
 							<% if (typeof prefetch === "undefined" || prefetch !== false) { %>
 							<div class="col-sm-12">

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -493,7 +493,7 @@ $(function() {
 
 	var highlights = [];
 
-	settings.on("change", "input, textarea", function() {
+	settings.on("change", "input, select, textarea", function() {
 		var self = $(this);
 		var name = self.attr("name");
 

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -473,6 +473,7 @@ $(function() {
 		notifyAllMessages: false,
 		part: true,
 		quit: true,
+		theme: $("#theme").attr("href").replace(/^themes\/(.*).css$/, "$1"), // Extracts default theme name, set on the server configuration
 		thumbnails: true,
 		userStyles: userStyles.text(),
 	}, JSON.parse(window.localStorage.getItem("settings")));
@@ -485,6 +486,9 @@ $(function() {
 			settings.find("#user-specified-css-input").val(options[i]);
 		} else if (i === "highlights") {
 			settings.find("input[name=" + i + "]").val(options[i]);
+		} else if (i === "theme") {
+			$("#theme").attr("href", "themes/" + options[i] + ".css");
+			settings.find("select[name=" + i + "]").val(options[i]);
 		} else if (options[i]) {
 			settings.find("input[name=" + i + "]").prop("checked", true);
 		}
@@ -516,6 +520,8 @@ $(function() {
 			chat.toggleClass("hide-" + name, !self.prop("checked"));
 		} else if (name === "coloredNicks") {
 			chat.toggleClass("colored-nicks", self.prop("checked"));
+		} else if (name === "theme") {
+			$("#theme").attr("href", "themes/" + options[name] + ".css");
 		} else if (name === "userStyles") {
 			$(document.head).find("#user-specified-css").html(options[name]);
 		} else if (name === "highlights") {

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -462,18 +462,18 @@ $(function() {
 	var userStyles = $("#user-specified-css");
 	var settings = $("#settings");
 	var options = $.extend({
-		desktopNotifications: false,
 		coloredNicks: true,
+		desktopNotifications: false,
 		join: true,
 		links: true,
 		mode: true,
 		motd: false,
 		nick: true,
 		notification: true,
-		part: true,
-		thumbnails: true,
-		quit: true,
 		notifyAllMessages: false,
+		part: true,
+		quit: true,
+		thumbnails: true,
 		userStyles: userStyles.text(),
 	}, JSON.parse(window.localStorage.getItem("settings")));
 
@@ -483,7 +483,6 @@ $(function() {
 				$(document.head).find("#user-specified-css").html(options[i]);
 			}
 			settings.find("#user-specified-css-input").val(options[i]);
-			continue;
 		} else if (i === "highlights") {
 			settings.find("input[name=" + i + "]").val(options[i]);
 		} else if (options[i]) {
@@ -515,14 +514,11 @@ $(function() {
 			"notifyAllMessages",
 		].indexOf(name) !== -1) {
 			chat.toggleClass("hide-" + name, !self.prop("checked"));
-		}
-		if (name === "coloredNicks") {
+		} else if (name === "coloredNicks") {
 			chat.toggleClass("colored-nicks", self.prop("checked"));
-		}
-		if (name === "userStyles") {
+		} else if (name === "userStyles") {
 			$(document.head).find("#user-specified-css").html(options[name]);
-		}
-		if (name === "highlights") {
+		} else if (name === "highlights") {
 			var highlightString = options[name];
 			highlights = highlightString.split(",").map(function(h) {
 				return h.trim();

--- a/client/themes/crypto.css
+++ b/client/themes/crypto.css
@@ -10,7 +10,7 @@ GitHub: https://github.com/aynik
 
 @font-face {
 	font-family: Inconsolata-g;
-	src: url("fonts/inconsolatag.woff") format("woff"), url("fonts/inconsolatag.ttf") format("ttf");
+	src: url("../css/fonts/inconsolatag.woff") format("woff"), url("../css/fonts/inconsolatag.ttf") format("ttf");
 }
 
 body {

--- a/client/themes/crypto.css
+++ b/client/themes/crypto.css
@@ -126,6 +126,10 @@ a:hover,
 	font-size: 12px;
 }
 
+#windows select.input {
+	height: 38px;
+}
+
 #footer .icon {
 	color: #666;
 }

--- a/src/server.js
+++ b/src/server.js
@@ -122,6 +122,11 @@ function index(req, res, next) {
 			Helper.config
 		);
 		data.gitCommit = gitCommit;
+		data.themes = fs.readdirSync("client/themes/").filter(function(file) {
+			return file.endsWith(".css");
+		}).map(function(css) {
+			return css.slice(0, -4);
+		});
 		var template = _.template(file);
 		res.setHeader("Content-Security-Policy", "default-src *; style-src * 'unsafe-inline'; script-src 'self'; child-src 'none'; object-src 'none'; form-action 'none'; referrer no-referrer;");
 		res.setHeader("Content-Type", "text/html");


### PR DESCRIPTION
This adds one of the 2 features mentioned in https://github.com/thelounge/lounge/issues/5#issuecomment-183358614, yup.

Beyond the obvious benefits from the user's perspective, this will help contributors/team members:

- Test PRs with different themes: we have a history of breaking our own themes because we didn't test them right. No need to restart the server now, which may be a pain when testing content based on history.

- Move the aesthetic choices (colors, sizes, margins/paddings, etc., everything non-system specific) outside of `style.css`: at the moment, users who want to set custom themes have to add the `@import 'themes/<theme>.css';` hack into their custom CSS. Currently themes spend a lot of effort canceling out design choices set in `style.css` so that's fine, but as we make themes "independent", this hack will not reliably work anymore.

More information in commit messages.

### Results

Example | Crypto | Morning | Zenburn
--- | --- | --- | ---
<img width="446" alt="screen shot 2016-09-06 at 01 17 15" src="https://cloud.githubusercontent.com/assets/113730/18262485/ee03d670-73cf-11e6-8ee1-f869f13ecacf.png"> | <img width="447" alt="screen shot 2016-09-06 at 01 17 24" src="https://cloud.githubusercontent.com/assets/113730/18262486/ee040c30-73cf-11e6-821c-3e2e94fa44a9.png"> | <img width="450" alt="screen shot 2016-09-06 at 01 17 31" src="https://cloud.githubusercontent.com/assets/113730/18262484/ee03c112-73cf-11e6-80bc-f77676e09e7b.png"> | <img width="454" alt="screen shot 2016-09-06 at 01 17 38" src="https://cloud.githubusercontent.com/assets/113730/18262487/ee046cca-73cf-11e6-9227-fc5d3685b27d.png">
