### PR TITLE
Make sure users with wrong tokens are locked out instead of crashing the app

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -286,10 +286,10 @@ function auth(data) {
 		}
 	} else {
 		client = manager.findClient(data.user, data.token);
-		var signedIn = data.token && data.token === client.config.token;
+		var signedIn = data.token && client && data.token === client.config.token;
 		var token;
 
-		if (data.remember || data.token) {
+		if (client && (data.remember || data.token)) {
 			token = client.config.token;
 		}
 


### PR DESCRIPTION
Fixes #569, see issue for more details.
That issue only appears when a wrong token stored in `localStorage`, so users could login fine in private browsing for example.

@PugaBear let me know if this fixes your issue.