### PR TITLE
Send user to closest window when closing active one instead of network window

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -398,9 +398,16 @@ $(function() {
 	socket.on("part", function(data) {
 		var chanMenuItem = sidebar.find(".chan[data-id='" + data.chan + "']");
 
-		// When parting from the active channel/query, jump to the network's lobby
+		// When parting from the active channel/query, jump to the next window if
+		// there is one, or the last one otherwise
 		if (chanMenuItem.hasClass("active")) {
-			chanMenuItem.parent(".network").find(".lobby").click();
+			var newActive = chanMenuItem.next(".chan");
+
+			if (newActive.length === 0) {
+				newActive = chanMenuItem.prev(".chan");
+			}
+
+			newActive.click();
 		}
 
 		chanMenuItem.remove();


### PR DESCRIPTION

This is an alternative to #503.
It corresponds to option 2 described in [this comment](https://github.com/thelounge/lounge/pull/503#issuecomment-239996423).

When closing the active channel/query, user is currently (on master) sent back to the network window. This was done in #489 in order to quickly fix a bug, with intent to improve later.

While #503 restores previous behavior (on latest stable), this PR simply sends the user to closest channel/query to reduce jump to its minimum.
#503 is technically the most accurate thing to do as it will send you back where you were N channels ago if you close N channels (assuming you stay focused on channels under the same network, otherwise it will not work as expected), but it is actually not efficient in terms of usability and can still make the user jump places in long lists.

This is for example how Chrome roughly handles closing the current tab.

### Results

Before | After
--- | ---
![closing-before](https://cloud.githubusercontent.com/assets/113730/17801870/a79311c4-65ba-11e6-966c-5f97fe0b244c.gif) | ![closing-after](https://cloud.githubusercontent.com/assets/113730/17801869/a791bc02-65ba-11e6-9d38-e2fe803ebf55.gif)
