### PR TITLE
Allow long URLs to break onto next line on Chrome

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -815,6 +815,7 @@ button {
 
 #chat .msg {
 	word-wrap: break-word;
+	word-break: break-word; /* Webkit-specific */
 }
 
 #chat .unread-marker {


### PR DESCRIPTION
Fixes #550.

This fixes a bug that displays a horizontal scrollbar and messes up with the layout when URLs (or text) is too long.
Fix is Chrome-specific but so is the bug.

It is possible that #523 fixes this along the way, but it looks like it may be creating some other issues. Therefore it needs cautious testing and maybe some tweaking, hence delays, while this PR fixes now this specific bug in the meantime.

### Result

Before | After
--- | ---
<img width="1014" alt="screen shot 2016-08-19 at 23 32 50" src="https://cloud.githubusercontent.com/assets/113730/17828952/863b65fa-666c-11e6-8713-67e84d141eb3.png"> | <img width="1015" alt="screen shot 2016-08-19 at 23 32 15" src="https://cloud.githubusercontent.com/assets/113730/17828951/863ad356-666c-11e6-91ff-5603a995a7e6.png">