### PR TITLE
Do not set app orientation in manifest to use user setting at OS level

### DIFF
--- a/client/manifest.json
+++ b/client/manifest.json
@@ -3,7 +3,6 @@
 	"short_name": "The Lounge",
 	"description": "Self-hosted web IRC client",
 	"display": "standalone",
-	"orientation": "any",
 	"theme_color": "#455164",
 	"background_color": "#455164",
 	"icons":


### PR DESCRIPTION
Fixes #586.

Turns out, when this setting is not set, the auto-rotate being on or off is respected as expected. Who knew!

I know @YaManicKill and @vectr0n have been testing on different devices, would be great if you guys could confirm :-)
Maybe an iOS user should confirm that things are fine on this side as well.

(I have also tried with `natural`, but that doesn't work for us: it means portrait for phones and landscape for tablets).