### PR TITLE
consolidate version numbers throughout all interfaces

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -257,7 +257,7 @@ Client.prototype.connect = function(args) {
 	});
 
 	network.irc.connect({
-		version: pkg.name + " " + pkg.version + " -- " + pkg.homepage,
+		version: pkg.name + " " + Helper.getVersion() + " -- " + pkg.homepage,
 		host: network.host,
 		port: network.port,
 		nick: nick,

--- a/src/command-line/index.js
+++ b/src/command-line/index.js
@@ -3,13 +3,12 @@
 global.log = require("../log.js");
 
 var program = require("commander");
-var pkg = require("../../package.json");
 var fs = require("fs");
 var fsextra = require("fs-extra");
 var path = require("path");
 var Helper = require("../helper");
 
-program.version(pkg.version, "-v, --version");
+program.version(Helper.getVersion(), "-v, --version");
 program.option("");
 program.option("    --home <path>" , "home path");
 

--- a/src/helper.js
+++ b/src/helper.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const pkg = require("../package.json");
 var _ = require("lodash");
 var path = require("path");
 var os = require("os");
@@ -11,6 +12,8 @@ var Helper = {
 	getUserConfigPath: getUserConfigPath,
 	getUserLogsPath: getUserLogsPath,
 	setHome: setHome,
+	getVersion: getVersion,
+	getGitCommit: getGitCommit,
 };
 
 module.exports = Helper;
@@ -21,6 +24,29 @@ Helper.config = require(path.resolve(path.join(
 	"defaults",
 	"config.js"
 )));
+
+function getVersion() {
+	const gitCommit = getGitCommit();
+	return gitCommit ? `source (${gitCommit})` : `v${pkg.version}`;
+}
+
+let _gitCommit;
+function getGitCommit() {
+	if (_gitCommit !== undefined) {
+		return _gitCommit;
+	}
+	try {
+		_gitCommit = require("child_process")
+			.execSync("git rev-parse --short HEAD 2> /dev/null") // Returns hash of current commit
+			.toString()
+			.trim();
+		return _gitCommit;
+	} catch (e) {
+		// Not a git repository or git is not installed
+		_gitCommit = null;
+		return null;
+	}
+}
 
 function setHome(homePath) {
 	this.HOME = expandHome(homePath || "~/.lounge");

--- a/src/server.js
+++ b/src/server.js
@@ -81,8 +81,10 @@ module.exports = function() {
 
 	manager.sockets = sockets;
 
-	var protocol = config.https.enable ? "https" : "http";
-	log.info("The Lounge v" + pkg.version + " is now running on", protocol + "://" + (config.host || "*") + ":" + config.port + "/", (config.public ? "in public mode" : "in private mode"));
+	let protocol = config.https.enable ? "https" : "http";
+	let host = config.host || "*";
+	log.info("The Lounge", Helper.getVersion(), "is now running");
+	log.info(`Available on: ${protocol}://${host}:${config.port}/ in ${config.public ? "public" : "private"} mode`);
 	log.info("Press ctrl-c to stop\n");
 
 	if (!config.public) {
@@ -110,17 +112,6 @@ function allRequests(req, res, next) {
 	return next();
 }
 
-// Information to populate the About section in UI, either from npm or from git
-var gitCommit = null;
-try {
-	gitCommit = require("child_process")
-		.execSync("git rev-parse --short HEAD 2> /dev/null") // Returns hash of current commit
-		.toString()
-		.trim();
-} catch (e) {
-	// Not a git repository or git is not installed: treat it as npm release
-}
-
 function index(req, res, next) {
 	if (req.url.split("?")[0] !== "/") {
 		return next();
@@ -135,7 +126,7 @@ function index(req, res, next) {
 			pkg,
 			Helper.config
 		);
-		data.gitCommit = gitCommit;
+		data.gitCommit = Helper.getGitCommit();
 		data.themes = fs.readdirSync("client/themes/").filter(function(themeFile) {
 			return themeFile.endsWith(".css");
 		}).map(function(css) {


### PR DESCRIPTION
I find the current reporting of versions, both in the client and CLI, is a bit lackluster. For example, starting the server on latest `master` logs a message that (as of now) says `The Lounge v2.0.0-pre.6 is now running ...` when in fact `master` is 30 commits ahead of pre-6.

This PR consolidates version numbers reported in the client and the CLI. Effectively, this means there'll only be visible changes when starting lounge through the CLI;

![screenshot 2016-09-07 at 16 04 32](https://cloud.githubusercontent.com/assets/6705160/18314840/0bba77be-7515-11e6-829c-493024aaa573.png)
![screenshot 2016-09-07 at 16 04 38](https://cloud.githubusercontent.com/assets/6705160/18314841/0bd18274-7515-11e6-9adb-d4f529e3be49.png)

