### PR TITLE
	lint: default to ecmaVersion: 6, keep ecmaVersion: 5 for client/

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -7,6 +7,9 @@ env:
   mocha: true
   node: true
 
+parserOptions:
+  ecmaVersion: 6
+
 rules:
   block-spacing: [2, always]
   brace-style: [2, 1tbs]

--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "test": "npm-run-all -c test:mocha lint",
     "test:mocha": "mocha -r test/fixtures/env.js test/**/*.js",
     "lint": "npm-run-all -c lint:js lint:css",
-    "lint:js": "eslint .",
+    "lint:js": "npm-run-all -c lint:js:es5 lint:js:es6",
+    "lint:js:es5": "eslint --parser-options=\"ecmaVersion:5\" client/",
+    "lint:js:es6": "eslint --ignore-pattern client/ .",
     "lint:css": "stylelint \"**/*.css\"",
     "prepublish": "npm run build"
   },


### PR DESCRIPTION
Cleanest solution I could come up with right now.

Adds ~3s to the linting process though, ymmv. (not sure how big part the added es6 environment plays in that, doubt it's much)

Unblocks #592.