### PR TITLE
client: don't dismiss notifications programmatically after 5s

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -905,14 +905,11 @@ $(function() {
 						icon: "img/logo-64.png",
 						tag: target
 					});
-					notify.onclick = function() {
+					notify.addEventListener("click", function() {
 						window.focus();
 						button.click();
 						this.close();
-					};
-					window.setTimeout(function() {
-						notify.close();
-					}, 5 * 1000);
+					});
 				}
 			}
 		}


### PR DESCRIPTION
I suspect this was originally implemented because Chrome would
not automatically close notifications before Chrome 47 (October 2015).

This'll allow Lounge notifications to linger after being automatically closed, for example
in the notification tray in macOS. 
<img width="361" alt="screenshot 2016-09-07 at 01 40 46" src="https://cloud.githubusercontent.com/assets/6705160/18294790/2532fe06-749c-11e6-855d-f92603694dcd.png">


This will cause a noticeable difference, especially in browsers/environments that doesn't use the OS notification API (Chrome). Notification cards will be visible much longer before being dismissed automatically.