### PR TITLE
Explicitly authorize websockets in CSP header

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -128,7 +128,7 @@ function index(req, res, next) {
 			return css.slice(0, -4);
 		});
 		var template = _.template(file);
-		res.setHeader("Content-Security-Policy", "default-src *; style-src * 'unsafe-inline'; script-src 'self'; child-src 'none'; object-src 'none'; form-action 'none'; referrer no-referrer;");
+		res.setHeader("Content-Security-Policy", "default-src *; connect-src 'self' ws: wss:; style-src * 'unsafe-inline'; script-src 'self'; child-src 'none'; object-src 'none'; form-action 'none'; referrer no-referrer;");
 		res.setHeader("Content-Type", "text/html");
 		res.writeHead(200);
 		res.end(template(data));


### PR DESCRIPTION
Fixes #580.

This follows a recent change in WebKit (see https://webkit.org/blog/6830/a-refined-content-security-policy/, section "More restrictive wildcard *") to remove websocket schemes from the connect-src directive.
Users of Safari v10 (to be publicly released in a few days) would be affected by this and could not load the app.

Ping @Gilles123 to test this.