### PR TITLE
Fix small input text on Morning and Zenburn

### DIFF
--- a/client/themes/morning.css
+++ b/client/themes/morning.css
@@ -30,6 +30,7 @@ body {
 }
 
 #windows .header .topic,
+#windows #form .input,
 .messages .msg,
 .sidebar {
 	font-family: inherit;
@@ -148,7 +149,6 @@ body {
 }
 
 #windows #form .input {
-	font-family: inherit;
 	background-color: #2e3642 !important;
 	border-color: #242a33 !important;
 	color: #ccc;

--- a/client/themes/zenburn.css
+++ b/client/themes/zenburn.css
@@ -31,6 +31,7 @@ body {
 }
 
 #windows .header .topic,
+#windows #form .input,
 .messages .msg,
 .sidebar {
 	font-family: inherit;
@@ -175,7 +176,6 @@ body {
 }
 
 #windows #form .input {
-	font-family: inherit;
 	background-color: #434443 !important;
 	border-color: #101010 !important;
 	color: #dcdccc !important;


### PR DESCRIPTION
Fixes https://github.com/thelounge/lounge/issues/600.

This bug was (re-)introduced in https://github.com/thelounge/lounge/pull/562, [here specifically](https://github.com/thelounge/lounge/pull/562/files#diff-53a2103ea4ad1eb199a9906db330e16bL34). `inherit` was setting text back to 12px instead of 13px.

Before | After
--- | ---
<img width="1012" alt="screen shot 2016-09-11 at 18 08 53" src="https://cloud.githubusercontent.com/assets/113730/18425519/28f8ea6a-7888-11e6-87f5-78468a27fc13.png"> | <img width="1007" alt="screen shot 2016-09-12 at 01 22 53" src="https://cloud.githubusercontent.com/assets/113730/18425515/244cf6be-7888-11e6-90e0-bd9ed976bb86.png">
