### PR TITLE
Add babel and webpack to the build process to allow ES2015

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,5 @@
 # built by tools
+client/js/bundle.js
 client/js/libs.min.js
 client/js/lounge.templates.js
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ coverage/
 # Built assets created at npm install/prepublish time
 # See https://docs.npmjs.com/misc/scripts
 client/fonts/
+client/js/bundle.js
 client/js/libs.min.js.map
 client/js/libs.min.js
 client/js/lounge.templates.js

--- a/client/index.html
+++ b/client/index.html
@@ -371,7 +371,7 @@
 	<script src="socket.io/socket.io.js"></script>
 	<script src="js/libs.min.js"></script>
 	<script src="js/lounge.templates.js"></script>
-	<script src="js/lounge.js"></script>
+	<script src="js/bundle.js"></script>
 
 	</body>
 </html>

--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
     "build:font-awesome": "node scripts/build-fontawesome.js",
     "build:libs": "uglifyjs client/js/libs/*.js client/js/libs/jquery/*.js client/js/libs/handlebars/*.js -o client/js/libs.min.js --source-map client/js/libs.min.js.map --source-map-url libs.min.js.map -p relative",
     "build:handlebars": "handlebars client/views/ -e tpl -f client/js/lounge.templates.js",
+    "build:webpack": "webpack",
+    "watch": "webpack -w",
     "test": "npm-run-all -c test:mocha lint",
     "test:mocha": "mocha -r test/fixtures/env.js test/**/*.js",
     "lint": "npm-run-all -c lint:js lint:css",
-    "lint:js": "npm-run-all -c lint:js:es5 lint:js:es6",
-    "lint:js:es5": "eslint --parser-options=\"ecmaVersion:5\" client/",
-    "lint:js:es6": "eslint --ignore-pattern client/ .",
+    "lint:js": "eslint .",
     "lint:css": "stylelint \"**/*.css\"",
     "prepublish": "npm run build"
   },
@@ -58,6 +58,8 @@
     "ldapjs": "1.0.0"
   },
   "devDependencies": {
+    "babel-loader": "6.2.5",
+    "babel-preset-es2015": "6.14.0",
     "chai": "3.5.0",
     "eslint": "3.6.0",
     "font-awesome": "4.6.3",
@@ -66,6 +68,7 @@
     "mocha": "3.0.2",
     "npm-run-all": "3.1.0",
     "stylelint": "7.3.1",
-    "uglify-js": "2.7.3"
+    "uglify-js": "2.7.3",
+    "webpack": "1.13.2"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,23 @@
+module.exports = {
+	entry: "./client/js/lounge.js",
+	resolve: {
+		extensions: ["", ".js"]
+	},
+	output: {
+		path: "./client/js",
+		filename: "bundle.js",
+		publicPath: "/"
+	},
+	module: {
+		loaders: [
+			{
+				test: /\.js$/,
+				exclude: /node_modules/,
+				loader: "babel",
+				query: {
+					presets: ["es2015"]
+				}
+			}
+		]
+	}
+};


### PR DESCRIPTION
Fixes #426.

[Some things that ES2015 enables](http://babeljs.io/docs/learn-es2015/):
- Arrow functions: `(n => n + 5)`
- Template strings: <code>\`Hello ${"world"}`</code>
- Destructuring: `var {foo, bar} = {foo: 3, bar: "hi"}`
- `import`, so the 1000-line `lounge.js` can be broken up into modules

That said, it adds complexity too:
- now you have to run `grunt watch` to rebuild on file change
- ES2015 is imperfectly handled by babel; there are some things it can't transpile, and some which it can but which also require a polyfill to be loaded

Thoughts?