### PR TITLE
Disable tooltips on mobile to prevent them to stay after clicking

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1557,6 +1557,24 @@ button {
 }
 
 @media (max-width: 768px) {
+	/**
+	  * TODO Replace this with `@media (hover: hover)` when Firefox supports it
+	  * See:
+	  * - http://stackoverflow.com/a/28058919/1935861
+	  * - http://caniuse.com/#feat=css-media-interaction
+	  * - https://www.w3.org/TR/mediaqueries-4/
+	  * - https://developer.mozilla.org/en-US/docs/Web/CSS/@media/hover
+	  */
+	.tooltipped:hover:before,
+	.tooltipped:hover:after,
+	.tooltipped:active:before,
+	.tooltipped:active:after,
+	.tooltipped:focus:before,
+	.tooltipped:focus:after {
+		visibility: hidden;
+		opacity: 0;
+	}
+
 	.container {
 		margin-top: 60px !important;
 	}


### PR DESCRIPTION
This fixes #585. Yeah, I know, this is less than ideal. But this is somewhat blocking 2.0.0 release. And none of the other options are ideal either (some discussed options will simply not work).

On v1.5.0, these buttons didn't have any tooltips, so they won't be missed on mobile. Plus any hovering effect on mobile is kind of a lost battle anyway.

We have an open issue on Primer's tooltips: https://github.com/primer/tooltips/issues/4

I suggest we hide them on mobile to freely deploy 2.0.0, and see to work them back in when we have a better solution.