### PR TITLE
Fix a left margin appearing on all non-default themes

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -555,10 +555,6 @@ button {
 	flex-direction: column;
 }
 
-.signed-out #main {
-	left: 5px;
-}
-
 #header {
 	display: none;
 	height: 40px;

--- a/client/themes/example.css
+++ b/client/themes/example.css
@@ -5,3 +5,7 @@
 body {
 	margin: 0;
 }
+
+.signed-out #main {
+	left: 5px;
+}


### PR DESCRIPTION
@xPaw found that https://github.com/thelounge/lounge/commit/1f4e2b42fd55e07014a75cd3d8ddf59fd64e9afd added a 5px left margin on all themes. Oops!