### PR TITLE
Disable pull-to-refresh on mobile that conflicts with scrolling the message list

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -46,6 +46,12 @@ body {
 	color: #222;
 	font: 16px Lato, sans-serif;
 	margin: 0;
+
+	/**
+	  * Disable pull-to-refresh on mobile that conflicts with scrolling the message list.
+	  * See http://stackoverflow.com/a/29313685/1935861
+	  */
+	overflow-y: hidden;
 }
 
 a {


### PR DESCRIPTION
At the moment, if to scroll down the messages but by accident start on the topic instead of the chat window, bye bye, this refreshes the entire app, losing the current scroll position. One of the most annoying small UX issues at the moment, IMO.

See option 3 of http://stackoverflow.com/a/29313685/1935861. IMO this is the least error-prone and aggressive of the 3 options (option 4 does not apply).

(Marking as `Do not merge` as this is not critical and should wait for 2.0.0 release to be merged)