### PR TITLE
Override defaults via URL

### DIFF
--- a/defaults/config.js
+++ b/defaults/config.js
@@ -108,6 +108,17 @@ module.exports = {
 	lockNetwork: false,
 
 	//
+	// Enable overrides
+	//
+	// If set to true, URL query parameters for overriding defaults will
+	// be ignored.
+	//
+	// @type     boolean
+	// @default  false
+	//
+	enableOverrides: false,
+
+	//
 	// WEBIRC support
 	//
 	// If enabled, The Lounge will pass the connecting user's host and IP to the

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint": "npm-run-all -c lint:js lint:css",
     "lint:js": "npm-run-all -c lint:js:es5 lint:js:es6",
     "lint:js:es5": "eslint --parser-options=\"ecmaVersion:5\" client/",
-    "lint:js:es6": "eslint --env es6 --ignore-pattern client/ .",
+    "lint:js:es6": "eslint --ignore-pattern client/ .",
     "lint:css": "stylelint \"**/*.css\"",
     "prepublish": "npm run build"
   },

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "event-stream": "3.3.2",
     "express": "4.13.4",
     "fs-extra": "0.30.0",
-    "he": "^1.1.0",
+    "he": "1.1.0",
     "irc-framework": "2.5.0",
     "ldapjs": "1.0.0",
     "lodash": "4.11.2",
@@ -63,7 +63,6 @@
   },
   "devDependencies": {
     "chai": "3.5.0",
-    "cheerio": "^0.20.0",
     "eslint": "2.11.1",
     "font-awesome": "4.6.3",
     "grunt": "1.0.1",
@@ -73,7 +72,6 @@
     "istanbul": "0.4.3",
     "mocha": "2.4.5",
     "npm-run-all": "2.1.1",
-    "request": "^2.74.0",
     "stylelint": "6.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint": "npm-run-all -c lint:js lint:css",
     "lint:js": "npm-run-all -c lint:js:es5 lint:js:es6",
     "lint:js:es5": "eslint --parser-options=\"ecmaVersion:5\" client/",
-    "lint:js:es6": "eslint --ignore-pattern client/ .",
+    "lint:js:es6": "eslint --env es6 --ignore-pattern client/ .",
     "lint:css": "stylelint \"**/*.css\"",
     "prepublish": "npm run build"
   },
@@ -50,18 +50,20 @@
     "event-stream": "3.3.2",
     "express": "4.13.4",
     "fs-extra": "0.30.0",
+    "he": "^1.1.0",
     "irc-framework": "2.5.0",
+    "ldapjs": "1.0.0",
     "lodash": "4.11.2",
     "moment": "2.13.0",
     "read": "1.0.7",
     "request": "2.74.0",
     "semver": "5.1.0",
     "socket.io": "1.4.5",
-    "spdy": "3.3.2",
-    "ldapjs": "1.0.0"
+    "spdy": "3.3.2"
   },
   "devDependencies": {
     "chai": "3.5.0",
+    "cheerio": "^0.20.0",
     "eslint": "2.11.1",
     "font-awesome": "4.6.3",
     "grunt": "1.0.1",
@@ -71,6 +73,7 @@
     "istanbul": "0.4.3",
     "mocha": "2.4.5",
     "npm-run-all": "2.1.1",
+    "request": "^2.74.0",
     "stylelint": "6.6.0"
   }
 }

--- a/src/server.js
+++ b/src/server.js
@@ -11,6 +11,7 @@ var io = require("socket.io");
 var dns = require("dns");
 var Helper = require("./helper");
 var ldap = require("ldapjs");
+var he = require("he");
 
 var manager = null;
 var ldapclient = null;
@@ -81,6 +82,7 @@ module.exports = function() {
 			manager.autoload();
 		}
 	}
+	return server;
 };
 
 function getClientIp(req) {
@@ -121,6 +123,17 @@ function index(req, res, next) {
 			pkg,
 			Helper.config
 		);
+		if (Helper.config.enableOverrides) {
+			var url_config_items = ["password", "nick", "username", "realname", "join"];
+			if (!Helper.config.lockNetwork) {
+				url_config_items.push("host", "port", "tls");
+			}
+			for (var key of url_config_items) {
+				if (key in req.query) {
+					data.defaults[key] = he.encode(req.query[key]);
+				}
+			}
+		}
 		data.gitCommit = gitCommit;
 		data.themes = fs.readdirSync("client/themes/").filter(function(file) {
 			return file.endsWith(".css");

--- a/test/server/url_config.js
+++ b/test/server/url_config.js
@@ -5,11 +5,11 @@ var server = require("../../src/server");
 var Helper = require("../../src/helper");
 
 function OverrideDefaults() {
-	this.old_config = new Map();
+	this.old_config = {};
 }
 
-OverrideDefaults.prototype.set =	function(property, value) {
-	this.old_config.set(property, Helper.config.defaults[property]);
+OverrideDefaults.prototype.set = function(property, value) {
+	this.old_config[property] = Helper.config.defaults[property];
 	Helper.config.defaults[property] = value;
 };
 
@@ -19,16 +19,16 @@ OverrideDefaults.prototype.restore = function() {
 			Helper.config.defaults[property] = this.old_config[property];
 		}
 	}
-	this.old_config.clear();
+	this.old_config = {};
 };
 
 describe("URL-configurable parameters", function() {
 	before(function() {
 		Helper.config.port = 0;
 		Helper.config.enableOverrides = true;
-		global.log = {info: () => {}};
+		global.log = {info: function() {}};
 		this.server = server();
-		this.base_url = `http://localhost:${this.server.address().port}/`;
+		this.base_url = "http://localhost:" + this.server.address().port + "/";
 		this.override = new OverrideDefaults();
 	});
 
@@ -41,12 +41,13 @@ describe("URL-configurable parameters", function() {
 	});
 
 	it("should allow simple overriding", function(done) {
+		var that = this;
 		Helper.config.defaults.username = "DefaultUserName";
-		request.get(`${this.base_url}`, (err, res, body) => {
+		request.get(this.base_url, function (err, res, body) {
 			assert.equal(err, null);
 			assert.equal(res.statusCode, 200);
 			assert.equal(cheerio("input[name=username]", body).attr("value"), "DefaultUserName");
-			request.get(`${this.base_url}?username=URLUserName`, (err, res, body) => {
+			request.get(that.base_url + "?username=URLUserName", function (err, res, body) {
 				assert.equal(err, null);
 				assert.equal(res.statusCode, 200);
 				assert.equal(cheerio("input[name=username]", body).attr("value"), "URLUserName");
@@ -55,16 +56,17 @@ describe("URL-configurable parameters", function() {
 		});
 	});
 	it("should honor enableOverrides", function(done) {
+		var that = this;
 		this.override.set("host", "DefaultHost");
 		this.override.set("port", 443);
-		const config_url = `${this.base_url}?host=URLHost&port=12345`;
-		request.get(config_url, (err, res, body) => {
+		const config_url = this.base_url + "?host=URLHost&port=12345";
+		request.get(config_url, function (err, res, body) {
 			assert.equal(err, null);
 			assert.equal(res.statusCode, 200);
 			assert.equal(cheerio("input[name=host]", body).attr("value"), "URLHost");
 			assert.equal(cheerio("input[name=port]", body).attr("value"), 12345);
 			Helper.config.enableOverrides = false;
-			request.get(`${this.base_url}?host=URLHost`, (err, res, body) => {
+			request.get(that.base_url + "?host=URLHost", function (err, res, body) {
 				assert.equal(err, null);
 				assert.equal(res.statusCode, 200);
 				assert.equal(cheerio("input[name=host]", body).attr("value"), "DefaultHost");
@@ -75,16 +77,17 @@ describe("URL-configurable parameters", function() {
 		});
 	});
 	it("should honor lockNetwork", function(done) {
+		var that = this;
 		this.override.set("host", "DefaultHost");
 		this.override.set("port", 443);
-		const config_url = `${this.base_url}?host=URLHost&port=12345`;
-		request.get(config_url, (err, res, body) => {
+		const config_url = this.base_url + "?host=URLHost&port=12345";
+		request.get(config_url, function (err, res, body) {
 			assert.equal(err, null);
 			assert.equal(res.statusCode, 200);
 			assert.equal(cheerio("input[name=host]", body).attr("value"), "URLHost");
 			assert.equal(cheerio("input[name=port]", body).attr("value"), 12345);
 			Helper.config.lockNetwork = true;
-			request.get(`${this.base_url}?host=URLHost`, (err, res, body) => {
+			request.get(that.base_url + "?host=URLHost", function (err, res, body) {
 				assert.equal(err, null);
 				assert.equal(res.statusCode, 200);
 				assert.equal(cheerio("input[name=host]", body).attr("value"), "DefaultHost");
@@ -96,8 +99,8 @@ describe("URL-configurable parameters", function() {
 	});
 	it("should not allow stuffing inputs", function(done) {
 		this.override.set("nick", "DefaultNick");
-		const config_url = `${this.base_url}?nick="><script></script>`;
-		request.get(config_url, (err, res, body) => {
+		const config_url = this.base_url + '?nick="><script></script>';
+		request.get(config_url, function (err, res, body) {
 			assert.equal(err, null);
 			assert.equal(res.statusCode, 200);
 			assert.equal(cheerio("input[name=nick]", body).attr("value"), '"><script></script>');

--- a/test/server/url_config.js
+++ b/test/server/url_config.js
@@ -1,0 +1,107 @@
+var assert = require("assert");
+var request = require("request");
+var cheerio = require("cheerio");
+var server = require("../../src/server");
+var Helper = require("../../src/helper");
+
+function OverrideDefaults() {
+	this.old_config = new Map();
+}
+
+OverrideDefaults.prototype.set =	function(property, value) {
+	this.old_config.set(property, Helper.config.defaults[property]);
+	Helper.config.defaults[property] = value;
+};
+
+OverrideDefaults.prototype.restore = function() {
+	for (var property in this.old_config) {
+		if (this.old_config.hasOwnProperty(property)) {
+			Helper.config.defaults[property] = this.old_config[property];
+		}
+	}
+	this.old_config.clear();
+};
+
+describe("URL-configurable parameters", function() {
+	before(function() {
+		Helper.config.port = 0;
+		Helper.config.enableOverrides = true;
+		global.log = {info: () => {}};
+		this.server = server();
+		this.base_url = `http://localhost:${this.server.address().port}/`;
+		this.override = new OverrideDefaults();
+	});
+
+	after(function() {
+		this.server.close();
+	});
+
+	afterEach(function() {
+		this.override.restore();
+	});
+
+	it("should allow simple overriding", function(done) {
+		Helper.config.defaults.username = "DefaultUserName";
+		request.get(`${this.base_url}`, (err, res, body) => {
+			assert.equal(err, null);
+			assert.equal(res.statusCode, 200);
+			assert.equal(cheerio("input[name=username]", body).attr("value"), "DefaultUserName");
+			request.get(`${this.base_url}?username=URLUserName`, (err, res, body) => {
+				assert.equal(err, null);
+				assert.equal(res.statusCode, 200);
+				assert.equal(cheerio("input[name=username]", body).attr("value"), "URLUserName");
+				done();
+			});
+		});
+	});
+	it("should honor enableOverrides", function(done) {
+		this.override.set("host", "DefaultHost");
+		this.override.set("port", 443);
+		const config_url = `${this.base_url}?host=URLHost&port=12345`;
+		request.get(config_url, (err, res, body) => {
+			assert.equal(err, null);
+			assert.equal(res.statusCode, 200);
+			assert.equal(cheerio("input[name=host]", body).attr("value"), "URLHost");
+			assert.equal(cheerio("input[name=port]", body).attr("value"), 12345);
+			Helper.config.enableOverrides = false;
+			request.get(`${this.base_url}?host=URLHost`, (err, res, body) => {
+				assert.equal(err, null);
+				assert.equal(res.statusCode, 200);
+				assert.equal(cheerio("input[name=host]", body).attr("value"), "DefaultHost");
+				assert.equal(cheerio("input[name=port]", body).attr("value"), 443);
+				Helper.config.enableOverrides = true;
+				done();
+			});
+		});
+	});
+	it("should honor lockNetwork", function(done) {
+		this.override.set("host", "DefaultHost");
+		this.override.set("port", 443);
+		const config_url = `${this.base_url}?host=URLHost&port=12345`;
+		request.get(config_url, (err, res, body) => {
+			assert.equal(err, null);
+			assert.equal(res.statusCode, 200);
+			assert.equal(cheerio("input[name=host]", body).attr("value"), "URLHost");
+			assert.equal(cheerio("input[name=port]", body).attr("value"), 12345);
+			Helper.config.lockNetwork = true;
+			request.get(`${this.base_url}?host=URLHost`, (err, res, body) => {
+				assert.equal(err, null);
+				assert.equal(res.statusCode, 200);
+				assert.equal(cheerio("input[name=host]", body).attr("value"), "DefaultHost");
+				assert.equal(cheerio("input[name=port]", body).attr("value"), 443);
+				Helper.config.lockNetwork = false;
+				done();
+			});
+		});
+	});
+	it("should not allow stuffing inputs", function(done) {
+		this.override.set("nick", "DefaultNick");
+		const config_url = `${this.base_url}?nick="><script></script>`;
+		request.get(config_url, (err, res, body) => {
+			assert.equal(err, null);
+			assert.equal(res.statusCode, 200);
+			assert.equal(cheerio("input[name=nick]", body).attr("value"), '"><script></script>');
+			done();
+		});
+	});
+});


### PR DESCRIPTION
This allows for specifying defaults via URL:

    http://example.com/?join=%23thelounge&nick=jimbob&host=irc.freenode.net

The `enableOverrides` config setting must be set to true before this feature will work.

The `es6` environment is selected so eslint doesn't complain about `Map` not existing. The init function now returns the Express instance so the added test can have it bind to an available port and use that for testing.