### PR TITLE
Fill in prefixLookup on network initialization

### DIFF
--- a/src/plugins/irc-events/connection.js
+++ b/src/plugins/irc-events/connection.js
@@ -48,6 +48,11 @@ module.exports = function(irc, network) {
 	});
 
 	irc.on("socket connected", function() {
+		network.prefixLookup = {};
+		irc.network.options.PREFIX.forEach(function(mode) {
+			network.prefixLookup[mode.mode] = mode.symbol;
+		});
+
 		network.channels[0].pushMessage(client, new Msg({
 			text: "Connected to the network."
 		}));


### PR DESCRIPTION
Fixes #644.

I'm not sure if directly reaching into `irc-framework/src/networkinfo` is a good idea here, but it seems like [irc-fw only creates this object when you call `connect()`](https://github.com/kiwiirc/irc-framework/blob/master/src/client.js#L73), and I don't know of a good way to test that.