### PR TITLE
#371 better encoding support

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -143,6 +143,12 @@
 								<div class="col-sm-9">
 									<input class="input" id="connect:password" type="password" name="password" value="<%= defaults.password %>">
 								</div>
+								<div class="col-sm-3">
+									<label for="connect:encoding">Encoding</label>
+								</div>
+								<div class="col-sm-9">
+									<input class="input" id="connect:encoding" name="encoding" value="<%= defaults.encoding %>">
+								</div>
 								<div class="col-sm-9 col-sm-offset-3">
 									<label class="tls">
 										<input type="checkbox" name="tls" <%= defaults.tls ? "checked" : "" %> <%= typeof(lockNetwork) !== "undefined" && lockNetwork ? "disabled" : "" %>>

--- a/defaults/config.js
+++ b/defaults/config.js
@@ -196,6 +196,24 @@ module.exports = {
 		port: 6697,
 
 		//
+		// Encoding
+		//
+		// Format: <inputencoding>[:auto][/<outputencoding>]
+		// inputencoding iconv-lite supported encoding string
+		// outputcoding iconv-lite supported encoding string, default inputencoding
+		// :auto autoconverts miscoded mojibike characters
+		// Examples:
+		// iso-8859-1
+		// iso-8859-1:auto
+		// iso-8859-1/utf8
+		// iso-8859-1:auto/utf8
+		//
+		// @type     string
+		// @default  utf8
+		//
+		encoding: "utf8",
+
+		//
 		// Password
 		//
 		// @type     string

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "event-stream": "3.3.2",
     "express": "4.13.4",
     "fs-extra": "0.30.0",
-    "irc-framework": "2.5.0",
+    "irc-framework": "git://github.com/metsjeesus/irc-framework.git#encoding",
     "lodash": "4.11.2",
     "moment": "2.13.0",
     "read": "1.0.7",

--- a/src/client.js
+++ b/src/client.js
@@ -183,6 +183,7 @@ Client.prototype.connect = function(args) {
 		commands: args.commands,
 		ip: args.ip,
 		hostname: args.hostname,
+		encoding: args.encoding,
 		channels: channels,
 	});
 	network.setNick(nick);
@@ -255,6 +256,7 @@ Client.prototype.connect = function(args) {
 		version: package.name + " " + package.version + " -- " + package.homepage,
 		host: network.host,
 		port: network.port,
+		encoding: network.encoding,
 		nick: nick,
 		username: network.username,
 		gecos: network.realname,

--- a/src/models/network.js
+++ b/src/models/network.js
@@ -20,6 +20,7 @@ function Network(attr) {
 		hostname: null,
 		id: id++,
 		irc: null,
+		encoding: "utf8",
 		serverOptions: {
 			PREFIX: [],
 		},
@@ -70,7 +71,8 @@ Network.prototype.export = function() {
 		"realname",
 		"commands",
 		"ip",
-		"hostname"
+		"hostname",
+		"encoding"
 	]);
 
 	network.channels = this.channels

--- a/test/models/network.js
+++ b/test/models/network.js
@@ -25,6 +25,7 @@ describe("Network", function() {
 				username: "",
 				realname: "",
 				commands: [],
+				encoding: "utf8",
 				nick: "chillin`",
 				ip: null,
 				hostname: null,


### PR DESCRIPTION
I just explain problem first.
I got situation where irc server sends both utf8 and iso-8859-1 messages. And i want both to be human readable. Problem is, if i use utf8, i cant see or recover iso-8859-1 messages. But if i use iso-8859-1 as encoding, i cant see utf8 messages but i can recover them.  Using iso-8859-1 makes other problem, if outgoing messages are coded on iso-8859-1, you cant send utf8 text correctly like `Iñtërnâtiônàlizætiøn☃💩'`

So, to fix it, you need different encodings to irc incoming messages and outgoing messages. And top of that, you need to get rid Mojibake, miscoded characters.  My solution is backward compatible encoding string in irc-framework configuration. So you can configure it in lounge for every network you connect.

`utf8`- normal way
`iso-8859-1/utf8`- incoming messages are coded in iso-8859-1, outgoing in utf8
`iso-8859-1:auto`- incoming and outgoing is iso-8859-1 and gets rid of mojibikes on incoming messages
`iso-8859-1:auto/utf8`- incoming messags are coded iso-8859-1 and gets rid of mojibikes, outgoing messages are coded utf8

autocorrect reqursively makes text human readable. That means certain text combinations, like `Ã¤` automatcly will be converted to `ä` and text will lose that information. For humans its good, but not for computers. 

;tldr made thing that fixes utf8 - iso-8859-1 Mojibake characters in node.