### PR TITLE
Fix title icons for channels and channel lists

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -185,7 +185,7 @@ button {
 #chat .channel .title:before { content: "\f0f6"; /* http://fontawesome.io/icon/file-text-o/ */ }
 
 #sidebar .chan.special:before,
-#chat .channel .title:before { content: "\f03a"; /* http://fontawesome.io/icon/list/ */ }
+#chat .special .title:before { content: "\f03a"; /* http://fontawesome.io/icon/list/ */ }
 
 #footer .sign-in:before { content: "\f023"; /* http://fontawesome.io/icon/lock/ */ }
 #footer .connect:before { content: "\f067"; /* http://fontawesome.io/icon/plus/ */ }


### PR DESCRIPTION
This bug slipped when adding `/list` support in #258.

### Results

Before | After
--- | ---
<img width="281" alt="screen shot 2016-09-30 at 01 53 15" src="https://cloud.githubusercontent.com/assets/113730/18981984/b71fff46-86b0-11e6-89cb-0a570921d149.png"> | <img width="278" alt="screen shot 2016-09-30 at 01 51 51" src="https://cloud.githubusercontent.com/assets/113730/18981965/8faa9bf6-86b0-11e6-8ba9-319bb46a0c01.png">
<img width="121" alt="screen shot 2016-09-30 at 01 53 24" src="https://cloud.githubusercontent.com/assets/113730/18981985/b722c33e-86b0-11e6-888b-bce2bd66df6f.png"> | <img width="159" alt="screen shot 2016-09-30 at 01 52 06" src="https://cloud.githubusercontent.com/assets/113730/18981966/8faac8f6-86b0-11e6-937f-9e5e703c2125.png">



