### PR TITLE
Display localized timestamp in title of message times

### DIFF
--- a/client/js/libs/handlebars/localetime.js
+++ b/client/js/libs/handlebars/localetime.js
@@ -1,0 +1,5 @@
+"use strict";
+
+Handlebars.registerHelper("localetime", function(time) {
+	return new Date(time).toLocaleString();
+});

--- a/client/views/msg.tpl
+++ b/client/views/msg.tpl
@@ -1,5 +1,5 @@
 <div class="msg {{type}}{{#if self}} self{{/if}}{{#if highlight}} highlight{{/if}}" id="msg-{{id}}">
-	<span class="time">
+	<span class="time" title="{{localetime time}}">
 		{{tz time}}
 	</span>
 	<span class="from">

--- a/client/views/msg_action.tpl
+++ b/client/views/msg_action.tpl
@@ -1,5 +1,5 @@
 <div class="msg {{type}}{{#if self}} self{{/if}}{{#if highlight}} highlight{{/if}}" id="msg-{{id}}">
-	<span class="time">
+	<span class="time" title="{{localetime time}}">
 		{{tz time}}
 	</span>
 	<span class="from"></span>

--- a/client/views/msg_unhandled.tpl
+++ b/client/views/msg_unhandled.tpl
@@ -1,5 +1,5 @@
 <div class="msg {{type}}{{#if self}} self{{/if}}{{#if highlight}} highlight{{/if}}">
-	<span class="time">
+	<span class="time" title="{{localetime time}}">
 		{{tz time}}
 	</span>
 	<span class="from">[{{command}}]</span>


### PR DESCRIPTION
This addresses https://github.com/thelounge/lounge/issues/98#issuecomment-250777924.

It adds a `title` when hovering on timestamp:

<img width="185" alt="screen shot 2016-10-01 at 02 42 21" src="https://cloud.githubusercontent.com/assets/113730/19012369/4bc0c7e0-8781-11e6-8d6d-8bc24b3e54c1.png">

I didn't do a tooltip on purpose, I think it works better that way.

Note that I did try to use an ES6-style fat arrow, but `npm run build` would fail on that with `SyntaxError: Unexpected token: operator (>)`. Any help welcome.

(/Cc @DanielOaks)