### PR TITLE
Consolidate locale time helpers

### DIFF
--- a/client/js/libs/handlebars/date.js
+++ b/client/js/libs/handlebars/date.js
@@ -1,7 +1,0 @@
-Handlebars.registerHelper(
-	"localeDate", function(date) {
-		date = new Date(date);
-
-		return date.toLocaleString();
-	}
-);

--- a/client/views/actions/topic_set_by.tpl
+++ b/client/views/actions/topic_set_by.tpl
@@ -1,3 +1,3 @@
 Topic set by
 <span role="button" class="user {{colorClass nick}}" data-name="{{nick}}">{{mode}}{{nick}}</span>
-on {{localeDate when}}
+on {{localetime when}}


### PR DESCRIPTION
When working on #660, I missed that a similar helper already existed, added in #167.