### PR TITLE
[WIP] Load previous messages from the logs

### DIFF
--- a/client/views/actions/join.tpl
+++ b/client/views/actions/join.tpl
@@ -1,3 +1,5 @@
 {{> ../user_name nick=from}}
-<i class="hostmask">({{hostmask}})</i>
+{{#if hostmask}}
+	<i class="hostmask">({{hostmask}})</i>
+{{/if}}
 has joined the channel

--- a/client/views/actions/part.tpl
+++ b/client/views/actions/part.tpl
@@ -1,5 +1,7 @@
 {{> ../user_name nick=from}}
-<i class="hostmask">({{hostmask}})</i>
+{{#if hostmask}}
+	<i class="hostmask">({{hostmask}})</i>
+{{/if}}
 has left the channel
 {{#if text}}
 	<i class="part-reason">({{{parse text}}})</i>

--- a/client/views/actions/quit.tpl
+++ b/client/views/actions/quit.tpl
@@ -1,5 +1,7 @@
 {{> ../user_name nick=from}}
-<i class="hostmask">({{hostmask}})</i>
+{{#if hostmask}}
+	<i class="hostmask">({{hostmask}})</i>
+{{/if}}
 has quit
 {{#if text}}
 	<i class="quit-reason">({{{parse text}}})</i>

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "lodash": "4.17.4",
     "moment": "2.18.1",
     "read": "1.0.7",
+    "read-last-lines": "1.2.0",
     "request": "2.81.0",
     "sanitize-filename": "1.6.1",
     "semver": "5.4.1",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "moment": "2.18.1",
     "read": "1.0.7",
     "request": "2.81.0",
+    "sanitize-filename": "1.6.1",
     "semver": "5.4.1",
     "socket.io": "1.7.4",
     "spdy": "3.4.7",

--- a/src/client.js
+++ b/src/client.js
@@ -5,7 +5,7 @@ var colors = require("colors/safe");
 var pkg = require("../package.json");
 var Chan = require("./models/chan");
 var crypto = require("crypto");
-var userLog = require("./userLog");
+const UserLog = require("./userLog");
 var Msg = require("./models/msg");
 var Network = require("./models/network");
 var ircFramework = require("irc-framework");
@@ -91,6 +91,10 @@ function Client(manager, name, config) {
 		delay += 1000;
 	});
 
+	if (this.config.log === true) {
+		this.userLog = new UserLog(client.name);
+	}
+
 	if (typeof client.config.sessions !== "object") {
 		client.config.sessions = {};
 	}
@@ -122,8 +126,7 @@ Client.prototype.emit = function(event, data) {
 				if (target.chan.type === Chan.Type.LOBBY) {
 					chan = target.network.host;
 				}
-				userLog.write(
-					this.name,
+				this.userLog.write(
 					target.network.host,
 					chan,
 					data.msg
@@ -178,8 +181,8 @@ Client.prototype.connect = function(args) {
 
 			channels.push(channel);
 
-			userLog
-				.read(client.name, args.host, channel.name)
+			this.userLog
+				.read(args.host, channel.name)
 				.forEach((message) => channel.pushMessage(client, message));
 		});
 

--- a/src/client.js
+++ b/src/client.js
@@ -171,10 +171,16 @@ Client.prototype.connect = function(args) {
 				return;
 			}
 
-			channels.push(new Chan({
+			const channel = new Chan({
 				name: chan.name,
 				key: chan.key || "",
-			}));
+			});
+
+			channels.push(channel);
+
+			userLog
+				.read(client.name, args.host, channel.name)
+				.forEach((message) => channel.pushMessage(client, message));
 		});
 
 		if (badName && client.name) {

--- a/src/client.js
+++ b/src/client.js
@@ -91,9 +91,7 @@ function Client(manager, name, config) {
 		delay += 1000;
 	});
 
-	if (this.config.log === true) {
-		this.userLog = new UserLog(client.name);
-	}
+	this.userLog = new UserLog(client.name);
 
 	if (typeof client.config.sessions !== "object") {
 		client.config.sessions = {};
@@ -179,11 +177,8 @@ Client.prototype.connect = function(args) {
 				key: chan.key || "",
 			});
 
+			channel.loadLogs(client, args.host);
 			channels.push(channel);
-
-			this.userLog
-				.read(args.host, channel.name)
-				.forEach((message) => channel.pushMessage(client, message));
 		});
 
 		if (badName && client.name) {

--- a/src/models/chan.js
+++ b/src/models/chan.js
@@ -87,6 +87,20 @@ Chan.prototype.dereferencePreviews = function(messages) {
 	});
 };
 
+Chan.prototype.loadLogs = function(client, network) {
+	client.userLog.read(network, this.name, (messages) => {
+		// TODO: Prepend messages
+		// TODO: Fix unread marker
+		Array.prototype.push.apply(this.messages, messages);
+
+		// TODO: We don't know if clients received loaded messages object or not?
+		client.emit("more", {
+			chan: this.id,
+			messages: messages
+		});
+	});
+};
+
 Chan.prototype.sortUsers = function(irc) {
 	var userModeSortPriority = {};
 	irc.network.options.PREFIX.forEach((prefix, index) => {

--- a/src/models/chan.js
+++ b/src/models/chan.js
@@ -89,14 +89,16 @@ Chan.prototype.dereferencePreviews = function(messages) {
 
 Chan.prototype.loadLogs = function(client, network) {
 	client.userLog.read(network, this.name, (messages) => {
-		// TODO: Prepend messages
-		// TODO: Fix unread marker
-		Array.prototype.push.apply(this.messages, messages);
+		// TODO: This still gets out of sync with znc buffer
+		this.messages = messages.concat(this.messages);
 
-		// TODO: We don't know if clients received loaded messages object or not?
+		if (!this.firstUnread) {
+			this.firstUnread = messages[messages.length - 1].id;
+		}
+
 		client.emit("more", {
 			chan: this.id,
-			messages: messages
+			messages: messages.slice(-100)
 		});
 	});
 };

--- a/src/plugins/inputs/query.js
+++ b/src/plugins/inputs/query.js
@@ -42,13 +42,10 @@ exports.input = function(network, chan, cmd, args) {
 		type: Chan.Type.QUERY,
 		name: target
 	});
+	newChan.loadLogs(client, network.host);
 	network.channels.push(newChan);
 	client.emit("join", {
 		network: network.id,
 		chan: newChan
 	});
-
-	client.userLog
-		.read(network.host, newChan.name)
-		.forEach((message) => newChan.pushMessage(client, message));
 };

--- a/src/plugins/inputs/query.js
+++ b/src/plugins/inputs/query.js
@@ -7,6 +7,8 @@ var Msg = require("../../models/msg");
 exports.commands = ["query"];
 
 exports.input = function(network, chan, cmd, args) {
+	const client = this;
+
 	if (args.length === 0) {
 		return;
 	}
@@ -19,7 +21,7 @@ exports.input = function(network, chan, cmd, args) {
 
 	var char = target[0];
 	if (network.irc.network.options.CHANTYPES && network.irc.network.options.CHANTYPES.indexOf(char) !== -1) {
-		chan.pushMessage(this, new Msg({
+		chan.pushMessage(client, new Msg({
 			type: Msg.Type.ERROR,
 			text: "You can not open query windows for channels, use /join instead."
 		}));
@@ -28,7 +30,7 @@ exports.input = function(network, chan, cmd, args) {
 
 	for (var i = 0; i < network.irc.network.options.PREFIX.length; i++) {
 		if (network.irc.network.options.PREFIX[i].symbol === char) {
-			chan.pushMessage(this, new Msg({
+			chan.pushMessage(client, new Msg({
 				type: Msg.Type.ERROR,
 				text: "You can not open query windows for names starting with a user prefix."
 			}));
@@ -41,8 +43,12 @@ exports.input = function(network, chan, cmd, args) {
 		name: target
 	});
 	network.channels.push(newChan);
-	this.emit("join", {
+	client.emit("join", {
 		network: network.id,
 		chan: newChan
 	});
+
+	client.userLog
+		.read(network.host, newChan.name)
+		.forEach((message) => newChan.pushMessage(client, message));
 };

--- a/src/plugins/irc-events/join.js
+++ b/src/plugins/irc-events/join.js
@@ -21,6 +21,10 @@ module.exports = function(irc, network) {
 
 			// Request channels' modes
 			network.irc.raw("MODE", chan.name);
+
+			client.userLog
+				.read(network.host, chan.name)
+				.forEach((message) => chan.pushMessage(client, message));
 		}
 		chan.users.push(new User({nick: data.nick}));
 		chan.sortUsers(irc);

--- a/src/plugins/irc-events/join.js
+++ b/src/plugins/irc-events/join.js
@@ -12,6 +12,7 @@ module.exports = function(irc, network) {
 			chan = new Chan({
 				name: data.channel
 			});
+			chan.loadLogs(client, network.host);
 			network.channels.push(chan);
 			client.save();
 			client.emit("join", {
@@ -21,10 +22,6 @@ module.exports = function(irc, network) {
 
 			// Request channels' modes
 			network.irc.raw("MODE", chan.name);
-
-			client.userLog
-				.read(network.host, chan.name)
-				.forEach((message) => chan.pushMessage(client, message));
 		}
 		chan.users.push(new User({nick: data.nick}));
 		chan.sortUsers(irc);

--- a/src/plugins/irc-events/message.js
+++ b/src/plugins/irc-events/message.js
@@ -66,6 +66,10 @@ module.exports = function(irc, network) {
 						network: network.id,
 						chan: chan
 					});
+
+					client.userLog
+						.read(network.host, chan.name)
+						.forEach((message) => chan.pushMessage(client, message));
 				}
 			}
 

--- a/src/plugins/irc-events/message.js
+++ b/src/plugins/irc-events/message.js
@@ -61,15 +61,12 @@ module.exports = function(irc, network) {
 						type: Chan.Type.QUERY,
 						name: target
 					});
+					chan.loadLogs(client, network.host);
 					network.channels.push(chan);
 					client.emit("join", {
 						network: network.id,
 						chan: chan
 					});
-
-					client.userLog
-						.read(network.host, chan.name)
-						.forEach((message) => chan.pushMessage(client, message));
 				}
 			}
 

--- a/src/plugins/irc-events/whois.js
+++ b/src/plugins/irc-events/whois.js
@@ -12,16 +12,13 @@ module.exports = function(irc, network) {
 				type: Chan.Type.QUERY,
 				name: data.nick
 			});
+			chan.loadLogs(client, network.host);
 			network.channels.push(chan);
 			client.emit("join", {
 				shouldOpen: true,
 				network: network.id,
 				chan: chan
 			});
-
-			client.userLog
-				.read(network.host, chan.name)
-				.forEach((message) => chan.pushMessage(client, message));
 		}
 
 		var msg;

--- a/src/plugins/irc-events/whois.js
+++ b/src/plugins/irc-events/whois.js
@@ -18,6 +18,10 @@ module.exports = function(irc, network) {
 				network: network.id,
 				chan: chan
 			});
+
+			client.userLog
+				.read(network.host, chan.name)
+				.forEach((message) => chan.pushMessage(client, message));
 		}
 
 		var msg;

--- a/src/userLog.js
+++ b/src/userLog.js
@@ -40,6 +40,30 @@ module.exports.read = function(user, network, chan) {
 			}));
 			return;
 		}
+
+		result = /^\[(.*)\] \* (.*) \((.*)\) join$/.exec(line);
+
+		if (result) {
+			messages.push(new Msg({
+				// time: result[1],
+				from: result[2],
+				hostmask: result[3],
+				type: "join"
+			}));
+			return;
+		}
+
+		// Support for older log format missing hostmask
+		result = /^\[(.*)\] \* (.*) join$/.exec(line);
+
+		if (result) {
+			messages.push(new Msg({
+				// time: result[1],
+				from: result[2],
+				type: "join"
+			}));
+			return;
+		}
 	});
 
 	return messages;

--- a/src/userLog.js
+++ b/src/userLog.js
@@ -64,6 +64,58 @@ module.exports.read = function(user, network, chan) {
 			}));
 			return;
 		}
+
+		result = /^\[(.*)\] \* (.*) \((.*)\) (part|quit) (.*)$/.exec(line);
+
+		if (result) {
+			messages.push(new Msg({
+				// time: result[1],
+				from: result[2],
+				hostmask: result[3],
+				text: result[5],
+				type: result[4],
+			}));
+			return;
+		}
+
+		// Support for older log format missing hostmask
+		result = /^\[(.*)\] \* (.*) (part|quit) (.*)$/.exec(line);
+
+		if (result) {
+			messages.push(new Msg({
+				// time: result[1],
+				from: result[2],
+				text: result[4],
+				type: result[3],
+			}));
+			return;
+		}
+
+		// Parts and quits without a reason
+		result = /^\[(.*)\] \* (.*) \((.*)\) (part|quit)$/.exec(line);
+
+		if (result) {
+			messages.push(new Msg({
+				// time: result[1],
+				from: result[2],
+				hostmask: result[3],
+				type: result[4],
+			}));
+			return;
+		}
+
+		// Parts and quits without a reason
+		// Support for older log format missing hostmask
+		result = /^\[(.*)\] \* (.*) (part|quit)$/.exec(line);
+
+		if (result) {
+			messages.push(new Msg({
+				// time: result[1],
+				from: result[2],
+				type: result[3],
+			}));
+			return;
+		}
 	});
 
 	return messages;

--- a/src/userLog.js
+++ b/src/userLog.js
@@ -6,129 +6,141 @@ var moment = require("moment");
 var Helper = require("./helper");
 const Msg = require("./models/msg");
 
-module.exports.parseLine = function(line) {
-	let result = /^\[(.*)\] <(.*)> (.*)$/.exec(line);
+module.exports = class UserLog {
+	constructor(name) {
+		this.name = name;
+	}
 
-	if (result) {
-		return new Msg({
-			// time: result[1],
-			from: result[2],
-			text: result[3],
+	static parseLine(line) {
+		let result = /^\[(.*)\] <(.*)> (.*)$/.exec(line);
+
+		if (result) {
+			return new Msg({
+				// time: result[1],
+				from: result[2],
+				text: result[3],
+			});
+		}
+
+		result = /^\[(.*)\] \* (\S+)(?: \((\S+)\))? ([a-z_]+)(?: (.*))?$/.exec(line);
+
+		if (!result) {
+			return;
+		}
+
+		const from = result[2];
+		const hostmask = result[3];
+		const type = result[4];
+		const remaining = result[5];
+
+		const msg = new Msg({
+			// time: time,
+			from: from,
+			type: type,
 		});
-	}
 
-	result = /^\[(.*)\] \* (\S+)(?: \((\S+)\))? ([a-z_]+)(?: (.*))?$/.exec(line);
-
-	if (!result) {
-		return;
-	}
-
-	const from = result[2];
-	const hostmask = result[3];
-	const type = result[4];
-	const remaining = result[5];
-
-	const msg = new Msg({
-		// time: time,
-		from: from,
-		type: type,
-	});
-
-	switch (type) {
-	case "action":
-		msg.text = remaining;
-		return msg;
-	case "join":
-		msg.hostmask = hostmask;
-		return msg;
-	case "mode":
-		msg.text = remaining;
-		return msg;
-	case "nick":
-		msg.new_nick = remaining;
-		return msg;
-	case "part":
-	case "quit":
-		msg.hostmask = hostmask;
-		if (remaining) {
+		switch (type) {
+		case "action":
 			msg.text = remaining;
-		}
-		return msg;
-	case "topic":
-		msg.text = remaining;
-		return msg;
-	}
-};
-
-module.exports.read = function(user, network, chan) {
-	var data = fs.readFileSync(
-		`${Helper.getUserLogsPath(user, network)}/${chan}.log`,
-		"utf-8"
-	).toString().split("\n");
-
-	// var format = Helper.config.logs.format || "YYYY-MM-DD HH:mm:ss";
-	// var tz = Helper.config.logs.timezone || "UTC+00:00";
-
-	var messages = [];
-
-	data.forEach(line => {
-		const msg = this.parseLine(line);
-		if (msg) {
-			messages.push(msg);
-		}
-	});
-
-	return messages;
-};
-
-module.exports.write = function(user, network, chan, msg) {
-	const path = Helper.getUserLogsPath(user, network);
-
-	try {
-		fsextra.ensureDirSync(path);
-	} catch (e) {
-		log.error("Unable to create logs directory", e);
-		return;
-	}
-
-	var format = Helper.config.logs.format || "YYYY-MM-DD HH:mm:ss";
-	var tz = Helper.config.logs.timezone || "UTC+00:00";
-
-	var time = moment().utcOffset(tz).format(format);
-	var line = `[${time}] `;
-
-	var type = msg.type.trim();
-	if (type === "message" || type === "highlight") {
-		// Format:
-		// [2014-01-01 00:00:00] <Arnold> Put that cookie down.. Now!!
-		line += `<${msg.from}> ${msg.text}`;
-	} else {
-		// Format:
-		// [2014-01-01 00:00:00] * Arnold quit
-		line += `* ${msg.from} `;
-
-		if (msg.hostmask) {
-			line += `(${msg.hostmask}) `;
-		}
-
-		line += msg.type;
-
-		if (msg.new_nick) { // `/nick <new_nick>`
-			line += ` ${msg.new_nick}`;
-		} else if (msg.text) {
-			line += ` ${msg.text}`;
+			return msg;
+		case "join":
+			msg.hostmask = hostmask;
+			return msg;
+		case "mode":
+			msg.text = remaining;
+			return msg;
+		case "nick":
+			msg.new_nick = remaining;
+			return msg;
+		case "part":
+		case "quit":
+			msg.hostmask = hostmask;
+			if (remaining) {
+				msg.text = remaining;
+			}
+			return msg;
+		case "topic":
+			msg.text = remaining;
+			return msg;
 		}
 	}
 
-	fs.appendFile(
-		// Quick fix to escape pre-escape channel names that contain % using %%,
-		// and / using %. **This does not escape all reserved words**
-		path + "/" + chan.replace(/%/g, "%%").replace(/\//g, "%") + ".log",
-		line + "\n",
-		function(e) {
-			if (e) {
-				log.error("Failed to write user log", e);
+	read(network, chan) {
+		let data;
+
+		try {
+			data = fs.readFileSync(
+				`${Helper.getUserLogsPath(this.name, network)}/${chan}.log`,
+				"utf-8"
+			).toString().split("\n");
+		} catch (e) {
+			return [];
+		}
+
+		// var format = Helper.config.logs.format || "YYYY-MM-DD HH:mm:ss";
+		// var tz = Helper.config.logs.timezone || "UTC+00:00";
+
+		var messages = [];
+
+		data.forEach((line) => {
+			const msg = UserLog.parseLine(line);
+			if (msg) {
+				messages.push(msg);
+			}
+		});
+
+		return messages;
+	}
+
+	write(network, chan, msg) {
+		const path = Helper.getUserLogsPath(this.name, network);
+
+		try {
+			fsextra.ensureDirSync(path);
+		} catch (e) {
+			log.error("Unabled to create logs directory", e);
+			return;
+		}
+
+		var format = Helper.config.logs.format || "YYYY-MM-DD HH:mm:ss";
+		var tz = Helper.config.logs.timezone || "UTC+00:00";
+
+		var time = moment().utcOffset(tz).format(format);
+		var line = `[${time}] `;
+
+		var type = msg.type.trim();
+		if (type === "message" || type === "highlight") {
+			// Format:
+			// [2014-01-01 00:00:00] <Arnold> Put that cookie down.. Now!!
+			line += `<${msg.from}> ${msg.text}`;
+		} else {
+			// Format:
+			// [2014-01-01 00:00:00] * Arnold quit
+			line += `* ${msg.from} `;
+
+			if (msg.hostmask) {
+				line += `(${msg.hostmask}) `;
+			}
+
+			line += msg.type;
+
+			if (msg.new_nick) { // `/nick <new_nick>`
+				line += ` ${msg.new_nick}`;
+			} else if (msg.text) {
+				line += ` ${msg.text}`;
 			}
 		}
-	);
+
+		fs.appendFile(
+			// Quick fix to escape pre-escape channel names that contain % using %%,
+			// and / using %. **This does not escape all reserved words**
+			path + "/" + chan.replace(/%/g, "%%").replace(/\//g, "%") + ".log",
+			line + "\n",
+			function(e) {
+				if (e) {
+					log.error("Failed to write user log", e);
+				}
+			}
+		);
+	}
 };

--- a/src/userLog.js
+++ b/src/userLog.js
@@ -116,6 +116,18 @@ module.exports.read = function(user, network, chan) {
 			}));
 			return;
 		}
+
+		result = /^\[(.*)\] \* (.*) nick (.*)$/.exec(line);
+
+		if (result) {
+			messages.push(new Msg({
+				// time: result[1],
+				from: result[2],
+				new_nick: result[3],
+				type: "nick",
+			}));
+			return;
+		}
 	});
 
 	return messages;

--- a/src/userLog.js
+++ b/src/userLog.js
@@ -28,44 +28,32 @@ module.exports.parseLine = function(line) {
 	const type = result[4];
 	const remaining = result[5];
 
+	const msg = new Msg({
+		// time: time,
+		from: from,
+		type: type,
+	});
+
 	switch (type) {
 	case "action":
-		return new Msg({
-			// time: time,
-			from: from,
-			text: remaining,
-			type: type,
-		});
+		msg.text = remaining;
+		return msg;
 	case "join":
-		return new Msg({
-			// time: time,
-			from: from,
-			hostmask: hostmask,
-			type: type,
-		});
+		msg.hostmask = hostmask;
+		return msg;
 	case "mode":
-		return new Msg({
-			// time: time,
-			from: from,
-			text: remaining,
-			type: type,
-		});
+		msg.text = remaining;
+		return msg;
 	case "nick":
-		return new Msg({
-			// time: time,
-			from: from,
-			new_nick: remaining,
-			type: type,
-		});
+		msg.new_nick = remaining;
+		return msg;
 	case "part":
 	case "quit":
-		return new Msg({
-			// time: time,
-			from: from,
-			hostmask: hostmask,
-			text: remaining,
-			type: type,
-		});
+		msg.hostmask = hostmask;
+		if (remaining) {
+			msg.text = remaining;
+		}
+		return msg;
 	}
 };
 

--- a/src/userLog.js
+++ b/src/userLog.js
@@ -26,6 +26,19 @@ module.exports.read = function(user, network, chan) {
 				from: result[2],
 				text: result[3]
 			}));
+			return;
+		}
+
+		result = /^\[(.*)\] \* (.*) action (.*)$/.exec(line);
+
+		if (result) {
+			messages.push(new Msg({
+				// time: result[1],
+				from: result[2],
+				text: result[3],
+				type: "action"
+			}));
+			return;
 		}
 	});
 

--- a/src/userLog.js
+++ b/src/userLog.js
@@ -54,6 +54,9 @@ module.exports.parseLine = function(line) {
 			msg.text = remaining;
 		}
 		return msg;
+	case "topic":
+		msg.text = remaining;
+		return msg;
 	}
 };
 

--- a/src/userLog.js
+++ b/src/userLog.js
@@ -4,6 +4,33 @@ var fs = require("fs");
 var fsextra = require("fs-extra");
 var moment = require("moment");
 var Helper = require("./helper");
+const Msg = require("./models/msg");
+
+module.exports.read = function(user, network, chan) {
+	var data = fs.readFileSync(
+		`${Helper.getUserLogsPath(user, network)}/${chan}.log`,
+		"utf-8"
+	).toString().split("\n");
+
+	// var format = Helper.config.logs.format || "YYYY-MM-DD HH:mm:ss";
+	// var tz = Helper.config.logs.timezone || "UTC+00:00";
+
+	var messages = [];
+
+	data.forEach(line => {
+		let result = /^\[(.*)\] <(.*)> (.*)$/.exec(line);
+
+		if (result) {
+			messages.push(new Msg({
+				// time: result[1],
+				from: result[2],
+				text: result[3]
+			}));
+		}
+	});
+
+	return messages;
+};
 
 module.exports.write = function(user, network, chan, msg) {
 	const path = Helper.getUserLogsPath(user, network);

--- a/src/userLog.js
+++ b/src/userLog.js
@@ -15,11 +15,11 @@ module.exports = class UserLog {
 	}
 
 	static parseLine(line) {
-		let result = /^\[(.*)\] <(.*)> (.*)$/.exec(line);
+		let result = /^\[(.*?)\] <(.*?)> (.*)$/.exec(line);
 
 		if (result) {
 			return new Msg({
-				// time: result[1],
+				time: moment(result[1]),
 				from: result[2],
 				text: result[3],
 			});
@@ -31,13 +31,14 @@ module.exports = class UserLog {
 			return;
 		}
 
+		const time = moment(result[1]);
 		const from = result[2];
 		const hostmask = result[3];
 		const type = result[4];
 		const remaining = result[5];
 
 		const msg = new Msg({
-			// time: time,
+			time: time,
 			from: from,
 			type: type,
 		});
@@ -70,7 +71,7 @@ module.exports = class UserLog {
 
 	read(network, chan, callback) {
 		readLastLines
-			.read(this.getLogFilePath(network, chan), 100)
+			.read(this.getLogFilePath(network, chan), Helper.config.maxHistory) // TODO: Fails to read UTF-8
 			.then((lines) => {
 				const messages = [];
 
@@ -101,7 +102,7 @@ module.exports = class UserLog {
 		var format = Helper.config.logs.format || "YYYY-MM-DD HH:mm:ss";
 		var tz = Helper.config.logs.timezone || "UTC+00:00";
 
-		var time = moment().utcOffset(tz).format(format);
+		var time = moment(msg.time).utcOffset(tz).format(format);
 		var line = `[${time}] `;
 
 		var type = msg.type.trim();

--- a/src/userLog.js
+++ b/src/userLog.js
@@ -43,6 +43,13 @@ module.exports.parseLine = function(line) {
 			hostmask: hostmask,
 			type: type,
 		});
+	case "mode":
+		return new Msg({
+			// time: time,
+			from: from,
+			text: remaining,
+			type: type,
+		});
 	case "nick":
 		return new Msg({
 			// time: time,

--- a/test/tests/userLogTest.js
+++ b/test/tests/userLogTest.js
@@ -2,13 +2,13 @@
 
 const expect = require("chai").expect;
 
-const userLog = require("../../src/userLog");
+const UserLog = require("../../src/userLog");
 
-describe("userLog", () => {
+describe("UserLog", () => {
 	describe("#parseLine", () => {
 		it("should correctly parse a normal message", () => {
 			const line = "[2014-05-22 12:00:00] <astorije> This is a message.";
-			const msg = userLog.parseLine(line);
+			const msg = UserLog.parseLine(line);
 
 			expect(msg).to.include({
 				from: "astorije",
@@ -19,7 +19,7 @@ describe("userLog", () => {
 
 		it("should correctly parse an action message", () => {
 			const line = "[2014-05-22 12:00:00] * astorije action loves The Lounge.";
-			const msg = userLog.parseLine(line);
+			const msg = UserLog.parseLine(line);
 
 			expect(msg).to.include({
 				from: "astorije",
@@ -30,7 +30,7 @@ describe("userLog", () => {
 
 		it("should correctly parse a join message", () => {
 			const line = "[2014-05-22 12:00:00] * astorije (~astorije@example.com) join";
-			const msg = userLog.parseLine(line);
+			const msg = UserLog.parseLine(line);
 
 			expect(msg).to.include({
 				from: "astorije",
@@ -41,7 +41,7 @@ describe("userLog", () => {
 
 		it("should correctly parse a join message when hostmask is missing", () => {
 			const line = "[2014-05-22 12:00:00] * astorije join";
-			const msg = userLog.parseLine(line);
+			const msg = UserLog.parseLine(line);
 
 			expect(msg).to.include({
 				from: "astorije",
@@ -52,7 +52,7 @@ describe("userLog", () => {
 
 		it("should correctly parse a mode message", () => {
 			const line = "[2014-05-22 12:00:00] * ChanServ mode +v astorije";
-			const msg = userLog.parseLine(line);
+			const msg = UserLog.parseLine(line);
 
 			expect(msg).to.include({
 				from: "ChanServ",
@@ -63,7 +63,7 @@ describe("userLog", () => {
 
 		it("should correctly parse a nick change message", () => {
 			const line = "[2014-05-22 12:00:00] * astorije nick astorije-lvl-9000";
-			const msg = userLog.parseLine(line);
+			const msg = UserLog.parseLine(line);
 
 			expect(msg).to.include({
 				from: "astorije",
@@ -74,7 +74,7 @@ describe("userLog", () => {
 
 		it("should correctly parse a part message", () => {
 			const line = "[2014-05-22 12:00:00] * astorije (~astorije@example.com) part";
-			const msg = userLog.parseLine(line);
+			const msg = UserLog.parseLine(line);
 
 			expect(msg).to.include({
 				from: "astorije",
@@ -86,7 +86,7 @@ describe("userLog", () => {
 
 		it("should correctly parse a part message when reason is given", () => {
 			const line = "[2014-05-22 12:00:00] * astorije (~astorije@example.com) part \"Goodbye\"";
-			const msg = userLog.parseLine(line);
+			const msg = UserLog.parseLine(line);
 
 			expect(msg).to.include({
 				from: "astorije",
@@ -98,7 +98,7 @@ describe("userLog", () => {
 
 		it("should correctly parse a part message when hostmask is missing", () => {
 			const line = "[2014-05-22 12:00:00] * astorije part";
-			const msg = userLog.parseLine(line);
+			const msg = UserLog.parseLine(line);
 
 			expect(msg).to.include({
 				from: "astorije",
@@ -110,7 +110,7 @@ describe("userLog", () => {
 
 		it("should correctly parse a quit message", () => {
 			const line = "[2014-05-22 12:00:00] * astorije (~astorije@example.com) quit";
-			const msg = userLog.parseLine(line);
+			const msg = UserLog.parseLine(line);
 
 			expect(msg).to.include({
 				from: "astorije",
@@ -122,7 +122,7 @@ describe("userLog", () => {
 
 		it("should correctly parse a quit message when reason is given", () => {
 			const line = "[2014-05-22 12:00:00] * astorije (~astorije@example.com) quit Farewell";
-			const msg = userLog.parseLine(line);
+			const msg = UserLog.parseLine(line);
 
 			expect(msg).to.include({
 				from: "astorije",
@@ -134,7 +134,7 @@ describe("userLog", () => {
 
 		it("should correctly parse a quit message when hostmask is missing", () => {
 			const line = "[2014-05-22 12:00:00] * astorije quit";
-			const msg = userLog.parseLine(line);
+			const msg = UserLog.parseLine(line);
 
 			expect(msg).to.include({
 				from: "astorije",
@@ -146,7 +146,7 @@ describe("userLog", () => {
 
 		it("should correctly parse a topic message", () => {
 			const line = "[2014-05-22 12:00:00] * ChanServ topic Welcome to The Lounge, web IRC client - Latest release: 42.0.0 - https://thelounge.github.io/";
-			const msg = userLog.parseLine(line);
+			const msg = UserLog.parseLine(line);
 
 			expect(msg).to.include({
 				from: "ChanServ",

--- a/test/tests/userLogTest.js
+++ b/test/tests/userLogTest.js
@@ -50,6 +50,17 @@ describe("userLog", () => {
 			});
 		});
 
+		it("should correctly parse a mode message", () => {
+			const line = "[2014-05-22 12:00:00] * ChanServ mode +v astorije";
+			const msg = userLog.parseLine(line);
+
+			expect(msg).to.include({
+				from: "ChanServ",
+				text: "+v astorije",
+				type: "mode",
+			});
+		});
+
 		it("should correctly parse a nick change message", () => {
 			const line = "[2014-05-22 12:00:00] * astorije nick astorije-lvl-9000";
 			const msg = userLog.parseLine(line);
@@ -132,6 +143,5 @@ describe("userLog", () => {
 				type: "quit",
 			});
 		});
-
 	});
 });

--- a/test/tests/userLogTest.js
+++ b/test/tests/userLogTest.js
@@ -143,5 +143,16 @@ describe("userLog", () => {
 				type: "quit",
 			});
 		});
+
+		it("should correctly parse a topic message", () => {
+			const line = "[2014-05-22 12:00:00] * ChanServ topic Welcome to The Lounge, web IRC client - Latest release: 42.0.0 - https://thelounge.github.io/";
+			const msg = userLog.parseLine(line);
+
+			expect(msg).to.include({
+				from: "ChanServ",
+				text: "Welcome to The Lounge, web IRC client - Latest release: 42.0.0 - https://thelounge.github.io/",
+				type: "topic",
+			});
+		});
 	});
 });

--- a/test/tests/userLogTest.js
+++ b/test/tests/userLogTest.js
@@ -1,0 +1,137 @@
+"use strict";
+
+const expect = require("chai").expect;
+
+const userLog = require("../../src/userLog");
+
+describe("userLog", () => {
+	describe("#parseLine", () => {
+		it("should correctly parse a normal message", () => {
+			const line = "[2014-05-22 12:00:00] <astorije> This is a message.";
+			const msg = userLog.parseLine(line);
+
+			expect(msg).to.include({
+				from: "astorije",
+				type: "message",
+				text: "This is a message.",
+			});
+		});
+
+		it("should correctly parse an action message", () => {
+			const line = "[2014-05-22 12:00:00] * astorije action loves The Lounge.";
+			const msg = userLog.parseLine(line);
+
+			expect(msg).to.include({
+				from: "astorije",
+				type: "action",
+				text: "loves The Lounge.",
+			});
+		});
+
+		it("should correctly parse a join message", () => {
+			const line = "[2014-05-22 12:00:00] * astorije (~astorije@example.com) join";
+			const msg = userLog.parseLine(line);
+
+			expect(msg).to.include({
+				from: "astorije",
+				hostmask: "~astorije@example.com",
+				type: "join",
+			});
+		});
+
+		it("should correctly parse a join message when hostmask is missing", () => {
+			const line = "[2014-05-22 12:00:00] * astorije join";
+			const msg = userLog.parseLine(line);
+
+			expect(msg).to.include({
+				from: "astorije",
+				hostmask: undefined,
+				type: "join",
+			});
+		});
+
+		it("should correctly parse a nick change message", () => {
+			const line = "[2014-05-22 12:00:00] * astorije nick astorije-lvl-9000";
+			const msg = userLog.parseLine(line);
+
+			expect(msg).to.include({
+				from: "astorije",
+				type: "nick",
+				new_nick: "astorije-lvl-9000",
+			});
+		});
+
+		it("should correctly parse a part message", () => {
+			const line = "[2014-05-22 12:00:00] * astorije (~astorije@example.com) part";
+			const msg = userLog.parseLine(line);
+
+			expect(msg).to.include({
+				from: "astorije",
+				hostmask: "~astorije@example.com",
+				text: "",
+				type: "part",
+			});
+		});
+
+		it("should correctly parse a part message when reason is given", () => {
+			const line = "[2014-05-22 12:00:00] * astorije (~astorije@example.com) part \"Goodbye\"";
+			const msg = userLog.parseLine(line);
+
+			expect(msg).to.include({
+				from: "astorije",
+				hostmask: "~astorije@example.com",
+				text: "\"Goodbye\"",
+				type: "part",
+			});
+		});
+
+		it("should correctly parse a part message when hostmask is missing", () => {
+			const line = "[2014-05-22 12:00:00] * astorije part";
+			const msg = userLog.parseLine(line);
+
+			expect(msg).to.include({
+				from: "astorije",
+				hostmask: undefined,
+				text: "",
+				type: "part",
+			});
+		});
+
+		it("should correctly parse a quit message", () => {
+			const line = "[2014-05-22 12:00:00] * astorije (~astorije@example.com) quit";
+			const msg = userLog.parseLine(line);
+
+			expect(msg).to.include({
+				from: "astorije",
+				hostmask: "~astorije@example.com",
+				text: "",
+				type: "quit",
+			});
+		});
+
+		it("should correctly parse a quit message when reason is given", () => {
+			const line = "[2014-05-22 12:00:00] * astorije (~astorije@example.com) quit Farewell";
+			const msg = userLog.parseLine(line);
+
+			expect(msg).to.include({
+				from: "astorije",
+				hostmask: "~astorije@example.com",
+				text: "Farewell",
+				type: "quit",
+			});
+		});
+
+		it("should correctly parse a quit message when hostmask is missing", () => {
+			const line = "[2014-05-22 12:00:00] * astorije quit";
+			const msg = userLog.parseLine(line);
+
+			expect(msg).to.include({
+				from: "astorije",
+				hostmask: undefined,
+				text: "",
+				type: "quit",
+			});
+		});
+
+	});
+});


### PR DESCRIPTION
This is highly WIP. I'm not sure how successful it will be, but it's sad we have (almost) everything in the logs and we can't read from them when we restart the app (I know, I know, <insert here your favorite discussion about database>, but this is really just an attempt to read from what we have at minimal cost.
### TODO

I'm sure there are many TODOs before I could call this remotely reviewable, so I'll be listing them here to keep track of stuff.
- [x] Replay previous messages:
  - [x] At startup
  - [x] When joining a channel
  - [x] When clicking on a nick (`/whois`)
  - [x] When querying someone (`/query`)
  - [x] When receiving a message from someone that opens a new window
- [ ] Display all types of messages:
  - [x] Messages
  - [x] Actions
  - [x] Joins
  - [x] Modes
  - [x] Nick changes
  - [x] Parts
  - [x] Quits
  - [x] Topics
  - [ ] Others
- [x] Use the history limit to not load everything from files
- [x] Display actual timestamp instead of time when logs were read
- [ ] Clean up that uuuugly repeated code for parsing messages...
- [x] Go async
- [ ] Go stream
- [ ] Figure out why this branch is banning me from Freenode...
- [ ] Fix #1392
