### PR TITLE
Fix memory and reference shuffling when creating models

### DIFF
--- a/src/models/chan.js
+++ b/src/models/chan.js
@@ -13,7 +13,7 @@ Chan.Type = {
 var id = 0;
 
 function Chan(attr) {
-	_.merge(this, _.extend({
+	_.defaults(this, attr, {
 		id: id++,
 		messages: [],
 		name: "",
@@ -23,7 +23,7 @@ function Chan(attr) {
 		unread: 0,
 		highlight: false,
 		users: []
-	}, attr));
+	});
 }
 
 Chan.prototype.pushMessage = function(client, msg) {

--- a/src/models/msg.js
+++ b/src/models/msg.js
@@ -26,13 +26,13 @@ module.exports = Msg;
 var id = 0;
 
 function Msg(attr) {
-	_.merge(this, _.extend({
+	_.defaults(this, attr, {
 		from: "",
 		id: id++,
 		text: "",
 		type: Msg.Type.MESSAGE,
 		self: false
-	}, attr));
+	});
 
 	if (this.time > 0) {
 		this.time = new Date(this.time);

--- a/src/models/network.js
+++ b/src/models/network.js
@@ -6,7 +6,7 @@ module.exports = Network;
 var id = 0;
 
 function Network(attr) {
-	_.merge(this, _.extend({
+	_.defaults(this, attr, {
 		name: "",
 		host: "",
 		port: 6667,
@@ -24,7 +24,8 @@ function Network(attr) {
 			PREFIX: [],
 		},
 		chanCache: [],
-	}, attr));
+	});
+
 	this.name = attr.name || prettify(attr.host);
 	this.channels.unshift(
 		new Chan({
@@ -53,9 +54,10 @@ Network.prototype.setNick = function(nick) {
 
 Network.prototype.toJSON = function() {
 	return _.omit(this, [
+		"chanCache",
+		"highlightRegex",
 		"irc",
 		"password",
-		"highlightRegex"
 	]);
 };
 

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -3,10 +3,10 @@ var _ = require("lodash");
 module.exports = User;
 
 function User(attr, prefixLookup) {
-	_.merge(this, _.extend({
+	_.defaults(this, attr, {
 		modes: [],
 		nick: ""
-	}, attr));
+	});
 
 	// irc-framework sets character mode, but lounge works with symbols
 	this.modes = this.modes.map(mode => prefixLookup[mode]);

--- a/test/models/network.js
+++ b/test/models/network.js
@@ -3,18 +3,23 @@
 var expect = require("chai").expect;
 
 var Chan = require("../../src/models/chan");
+var Msg = require("../../src/models/msg");
 var Network = require("../../src/models/network");
 
 describe("Network", function() {
 	describe("#export()", function() {
 
 		it("should produce an valid object", function() {
-			var network = new Network({name: "networkName"});
+			var network = new Network({
+				name: "networkName",
+				channels: [
+					new Chan({name: "#thelounge"}),
+					new Chan({name: "&foobar"}),
+					new Chan({name: "Channel List", type: Chan.Type.SPECIAL}),
+					new Chan({name: "PrivateChat", type: Chan.Type.QUERY}),
+				]
+			});
 			network.setNick("chillin`");
-			network.channels.push(new Chan({name: "#thelounge"}));
-			network.channels.push(new Chan({name: "&foobar"}));
-			network.channels.push(new Chan({name: "Lobby", type: Chan.Type.LOBBY}));
-			network.channels.push(new Chan({name: "PrivateChat", type: Chan.Type.QUERY}));
 
 			expect(network.export()).to.deep.equal({
 				name: "networkName",
@@ -33,6 +38,52 @@ describe("Network", function() {
 					{"name": "&foobar"},
 				]
 			});
+		});
+
+		it("lobby should be at the top", function() {
+			var network = new Network({
+				name: "Super Nice Network",
+				channels: [
+					new Chan({name: "AAAA!", type: Chan.Type.QUERY}),
+					new Chan({name: "#thelounge"}),
+					new Chan({name: "&foobar"}),
+				]
+			});
+			network.channels.push(new Chan({name: "#swag"}));
+
+			expect(network.channels[0].name).to.equal("Super Nice Network");
+			expect(network.channels[0].type).to.equal(Chan.Type.LOBBY);
+		});
+
+		it("should maintain channel reference", function() {
+			var chan = new Chan({
+				name: "#506-bug-fix",
+				messages: [
+					new Msg({
+						text: "message in constructor"
+					})
+				]
+			});
+
+			var network = new Network({
+				name: "networkName",
+				channels: [
+					chan
+				]
+			});
+
+			chan.messages.push(new Msg({
+				text: "message in original instance"
+			}));
+
+			network.channels[1].messages.push(new Msg({
+				text: "message after network creation"
+			}));
+
+			expect(network.channels[1].messages).to.have.lengthOf(3);
+			expect(network.channels[1].messages[0].text).to.equal("message in constructor");
+			expect(network.channels[1].messages[1].text).to.equal("message in original instance");
+			expect(network.channels[1].messages[2].text).to.equal("message after network creation");
 		});
 	});
 });


### PR DESCRIPTION
A bug we discovered yesterday during mysql logging debugging.

> 09:54	+Max-P	But yeah it's really weird, objects as values in _.extend gets duplicated and their constructor/prototype reattached after
> 09:54	+Max-P	So in Chan's constructor, `this` was one instance, but the actual one we use is a copy
> 10:22	+xPaw	create chan -> create network with chan -> push message to original chan obj -> print network -> no message