### PR TITLE
Add hostmasks in logs when possible

### DIFF
--- a/src/userLog.js
+++ b/src/userLog.js
@@ -16,19 +16,26 @@ module.exports.write = function(user, network, chan, msg) {
 	var tz = Helper.config.logs.timezone || "UTC+00:00";
 
 	var time = moment().utcOffset(tz).format(format);
-	var line = "[" + time + "] ";
+	var line = `[${time}] `;
 
 	var type = msg.type.trim();
 	if (type === "message" || type === "highlight") {
 		// Format:
 		// [2014-01-01 00:00:00] <Arnold> Put that cookie down.. Now!!
-		line += "<" + msg.from + "> " + msg.text;
+		line += `<${msg.from}> ${msg.text}`;
 	} else {
 		// Format:
 		// [2014-01-01 00:00:00] * Arnold quit
-		line += "* " + msg.from + " " + msg.type;
+		line += `* ${msg.from} `;
+
+		if (msg.hostmask) {
+			line += `(${msg.hostmask}) `;
+		}
+
+		line += msg.type;
+
 		if (msg.text) {
-			line += " " + msg.text;
+			line += ` ${msg.text}`;
 		}
 	}
 


### PR DESCRIPTION
This will augment logs for `join`/`part`/`quit` with something similar to:

```
[2016-10-03 23:19:29] * astorije2 (~lounge-us@123.45.67.89) join
[2016-10-03 23:22:04] * foobar (~foo@irc.example.com) join

[2016-10-03 23:22:00] * foo (foo@gateway/web/freenode/ip.12.34.56.789) quit Quit: Page closed
[2016-10-03 23:22:12] * bar (~foo@unaffiliated/bar) quit Ping timeout: 252 seconds

[2016-10-03 23:31:23] * astorije (~astorije@128.30.0.0) part
```

Also switched line concatenating to ES6 templates because it's the future, baby.