### PR TITLE
Fix loading fonts in Microsoft Edge

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -138,7 +138,7 @@ function index(req, res, next) {
 			return css.slice(0, -4);
 		});
 		var template = _.template(file);
-		res.setHeader("Content-Security-Policy", "default-src *; connect-src 'self' ws: wss:; style-src * 'unsafe-inline'; script-src 'self'; child-src 'none'; object-src 'none'; form-action 'none'; referrer no-referrer;");
+		res.setHeader("Content-Security-Policy", "default-src *; connect-src 'self' ws: wss:; style-src * 'unsafe-inline'; script-src 'self'; child-src 'self'; object-src 'none'; form-action 'none'; referrer no-referrer;");
 		res.setHeader("Content-Type", "text/html");
 		res.writeHead(200);
 		res.end(template(data));


### PR DESCRIPTION
Fixes the following error:
> CSP14312: Resource violated directive ‘child-src 'none'’ in Content-Security-Policy: /css/fonts/Lato-regular/Lato-regular.woff2. Resource will be blocked.
> CSS3117: `@font-face` failed cross-origin request. Resource access is restricted.