### PR TITLE
Strict mode for all JS files

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -34,6 +34,7 @@ rules:
   space-before-blocks: 2
   space-infix-ops: 2
   spaced-comment: [2, always]
+  strict: 2
 
 globals:
   log: false

--- a/client/js/libs/handlebars/diff.js
+++ b/client/js/libs/handlebars/diff.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var diff;
 
 Handlebars.registerHelper(

--- a/client/js/libs/handlebars/equal.js
+++ b/client/js/libs/handlebars/equal.js
@@ -1,3 +1,5 @@
+"use strict";
+
 Handlebars.registerHelper(
 	"equal", function(a, b, opt) {
 		a = a.toString();

--- a/client/js/libs/handlebars/modes.js
+++ b/client/js/libs/handlebars/modes.js
@@ -1,3 +1,5 @@
+"use strict";
+
 Handlebars.registerHelper(
 	"modes", function(mode) {
 		var modes = {

--- a/client/js/libs/handlebars/parse.js
+++ b/client/js/libs/handlebars/parse.js
@@ -1,3 +1,5 @@
+"use strict";
+
 Handlebars.registerHelper(
 	"parse", function(text) {
 		text = Handlebars.Utils.escapeExpression(text);

--- a/client/js/libs/handlebars/roundBadgeNumber.js
+++ b/client/js/libs/handlebars/roundBadgeNumber.js
@@ -1,3 +1,5 @@
+"use strict";
+
 Handlebars.registerHelper(
 	"roundBadgeNumber", function(count) {
 		if (count < 1000) {

--- a/client/js/libs/handlebars/tz.js
+++ b/client/js/libs/handlebars/tz.js
@@ -1,3 +1,5 @@
+"use strict";
+
 Handlebars.registerHelper(
 	"tz", function(time) {
 		time = new Date(time);

--- a/client/js/libs/handlebars/users.js
+++ b/client/js/libs/handlebars/users.js
@@ -1,3 +1,5 @@
+"use strict";
+
 Handlebars.registerHelper(
 	"users", function(count) {
 		return count + " " + (count === 1 ? "user" : "users");

--- a/client/js/loading-slow-alert.js
+++ b/client/js/loading-slow-alert.js
@@ -1,3 +1,5 @@
+"use strict";
+
 /*
  * This is a separate file for two reasons:
  * 1. CSP policy does not allow inline javascript

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -1,3 +1,5 @@
+"use strict";
+
 $(function() {
 	$("#loading-page-message").text("Connecting…");
 

--- a/defaults/config.js
+++ b/defaults/config.js
@@ -1,3 +1,5 @@
+"use strict";
+
 module.exports = {
 	//
 	// Set the server mode.

--- a/index.js
+++ b/index.js
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+
+"use strict";
+
 process.chdir(__dirname);
 
 // Perform node version check before loading any other files or modules

--- a/src/client.js
+++ b/src/client.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var _ = require("lodash");
 var package = require("../package.json");
 var Chan = require("./models/chan");

--- a/src/client.js
+++ b/src/client.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var _ = require("lodash");
-var package = require("../package.json");
+var pkg = require("../package.json");
 var Chan = require("./models/chan");
 var crypto = require("crypto");
 var userLog = require("./userLog");
@@ -230,7 +230,7 @@ Client.prototype.connect = function(args) {
 			} else {
 				webirc = {
 					password: config.webirc[network.host],
-					username: package.name,
+					username: pkg.name,
 					address: args.ip,
 					hostname: args.hostname
 				};
@@ -257,7 +257,7 @@ Client.prototype.connect = function(args) {
 	});
 
 	network.irc.connect({
-		version: package.name + " " + package.version + " -- " + package.homepage,
+		version: pkg.name + " " + pkg.version + " -- " + pkg.homepage,
 		host: network.host,
 		port: network.port,
 		nick: nick,

--- a/src/clientManager.js
+++ b/src/clientManager.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var _ = require("lodash");
 var fs = require("fs");
 var Client = require("./client");

--- a/src/command-line/add.js
+++ b/src/command-line/add.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var ClientManager = new require("../clientManager");
 var bcrypt = require("bcrypt-nodejs");
 var program = require("commander");

--- a/src/command-line/config.js
+++ b/src/command-line/config.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var program = require("commander");
 var child = require("child_process");
 var Helper = require("../helper");

--- a/src/command-line/edit.js
+++ b/src/command-line/edit.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var ClientManager = new require("../clientManager");
 var program = require("commander");
 var child = require("child_process");

--- a/src/command-line/index.js
+++ b/src/command-line/index.js
@@ -1,3 +1,5 @@
+"use strict";
+
 global.log = require("../log.js");
 
 var program = require("commander");

--- a/src/command-line/list.js
+++ b/src/command-line/list.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var ClientManager = new require("../clientManager");
 var program = require("commander");
 

--- a/src/command-line/remove.js
+++ b/src/command-line/remove.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var ClientManager = new require("../clientManager");
 var program = require("commander");
 

--- a/src/command-line/reset.js
+++ b/src/command-line/reset.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var bcrypt = require("bcrypt-nodejs");
 var ClientManager = new require("../clientManager");
 var fs = require("fs");

--- a/src/command-line/start.js
+++ b/src/command-line/start.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var ClientManager = new require("../clientManager");
 var program = require("commander");
 var server = require("../server");

--- a/src/helper.js
+++ b/src/helper.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var _ = require("lodash");
 var path = require("path");
 var os = require("os");

--- a/src/identd.js
+++ b/src/identd.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var _ = require("lodash");
 var net = require("net");
 

--- a/src/log.js
+++ b/src/log.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var colors = require("colors/safe");
 var moment = require("moment");
 var Helper = require("./helper");

--- a/src/models/chan.js
+++ b/src/models/chan.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var _ = require("lodash");
 var Helper = require("../helper");
 

--- a/src/models/msg.js
+++ b/src/models/msg.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var _ = require("lodash");
 
 Msg.Type = {

--- a/src/models/network.js
+++ b/src/models/network.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var _ = require("lodash");
 var Chan = require("./chan");
 

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var _ = require("lodash");
 
 module.exports = User;

--- a/src/oidentd.js
+++ b/src/oidentd.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var fs = require("fs");
 var Helper = require("./helper");
 

--- a/src/plugins/inputs/action.js
+++ b/src/plugins/inputs/action.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.commands = ["slap", "me"];
 
 exports.input = function(network, chan, cmd, args) {

--- a/src/plugins/inputs/connect.js
+++ b/src/plugins/inputs/connect.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var Msg = require("../../models/msg");
 
 exports.commands = ["connect", "server"];

--- a/src/plugins/inputs/ctcp.js
+++ b/src/plugins/inputs/ctcp.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.commands = ["ctcp"];
 
 exports.input = function(network, chan, cmd, args) {

--- a/src/plugins/inputs/disconnect.js
+++ b/src/plugins/inputs/disconnect.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.commands = ["disconnect"];
 
 exports.input = function(network, chan, cmd, args) {

--- a/src/plugins/inputs/invite.js
+++ b/src/plugins/inputs/invite.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var Chan = require("../../models/chan");
 
 exports.commands = ["invite"];

--- a/src/plugins/inputs/kick.js
+++ b/src/plugins/inputs/kick.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.commands = ["kick"];
 
 exports.input = function(network, chan, cmd, args) {

--- a/src/plugins/inputs/list.js
+++ b/src/plugins/inputs/list.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.commands = ["list"];
 
 exports.input = function(network, chan, cmd, args) {

--- a/src/plugins/inputs/mode.js
+++ b/src/plugins/inputs/mode.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.commands = ["mode", "op", "voice", "deop", "devoice"];
 
 exports.input = function(network, chan, cmd, args) {

--- a/src/plugins/inputs/msg.js
+++ b/src/plugins/inputs/msg.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.commands = ["msg", "say"];
 
 exports.input = function(network, chan, cmd, args) {

--- a/src/plugins/inputs/nick.js
+++ b/src/plugins/inputs/nick.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var Msg = require("../../models/msg");
 
 exports.commands = ["nick"];

--- a/src/plugins/inputs/notice.js
+++ b/src/plugins/inputs/notice.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.commands = ["notice"];
 
 exports.input = function(network, chan, cmd, args) {

--- a/src/plugins/inputs/part.js
+++ b/src/plugins/inputs/part.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var _ = require("lodash");
 var Msg = require("../../models/msg");
 var Chan = require("../../models/chan");

--- a/src/plugins/inputs/query.js
+++ b/src/plugins/inputs/query.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var _ = require("lodash");
 var Chan = require("../../models/chan");
 var Msg = require("../../models/msg");

--- a/src/plugins/inputs/quit.js
+++ b/src/plugins/inputs/quit.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var _ = require("lodash");
 
 exports.commands = ["quit"];

--- a/src/plugins/inputs/raw.js
+++ b/src/plugins/inputs/raw.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.commands = ["raw", "send", "quote"];
 
 exports.input = function(network, chan, cmd, args) {

--- a/src/plugins/inputs/topic.js
+++ b/src/plugins/inputs/topic.js
@@ -1,3 +1,5 @@
+"use strict";
+
 exports.commands = ["topic"];
 
 exports.input = function(network, chan, cmd, args) {

--- a/src/plugins/irc-events/connection.js
+++ b/src/plugins/irc-events/connection.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var _ = require("lodash");
 var identd = require("../../identd");
 var Msg = require("../../models/msg");

--- a/src/plugins/irc-events/ctcp.js
+++ b/src/plugins/irc-events/ctcp.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var Msg = require("../../models/msg");
 
 module.exports = function(irc, network) {

--- a/src/plugins/irc-events/error.js
+++ b/src/plugins/irc-events/error.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var Msg = require("../../models/msg");
 
 module.exports = function(irc, network) {

--- a/src/plugins/irc-events/invite.js
+++ b/src/plugins/irc-events/invite.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var Msg = require("../../models/msg");
 
 module.exports = function(irc, network) {

--- a/src/plugins/irc-events/join.js
+++ b/src/plugins/irc-events/join.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var Chan = require("../../models/chan");
 var Msg = require("../../models/msg");
 var User = require("../../models/user");

--- a/src/plugins/irc-events/kick.js
+++ b/src/plugins/irc-events/kick.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var _ = require("lodash");
 var Msg = require("../../models/msg");
 

--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var _ = require("lodash");
 var cheerio = require("cheerio");
 var Msg = require("../../models/msg");

--- a/src/plugins/irc-events/list.js
+++ b/src/plugins/irc-events/list.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var Chan = require("../../models/chan");
 var Msg = require("../../models/msg");
 

--- a/src/plugins/irc-events/message.js
+++ b/src/plugins/irc-events/message.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var Chan = require("../../models/chan");
 var Msg = require("../../models/msg");
 

--- a/src/plugins/irc-events/mode.js
+++ b/src/plugins/irc-events/mode.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var _ = require("lodash");
 var Chan = require("../../models/chan");
 var Msg = require("../../models/msg");

--- a/src/plugins/irc-events/motd.js
+++ b/src/plugins/irc-events/motd.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var Msg = require("../../models/msg");
 
 module.exports = function(irc, network) {

--- a/src/plugins/irc-events/names.js
+++ b/src/plugins/irc-events/names.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var _ = require("lodash");
 var User = require("../../models/user");
 

--- a/src/plugins/irc-events/nick.js
+++ b/src/plugins/irc-events/nick.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var _ = require("lodash");
 var Msg = require("../../models/msg");
 

--- a/src/plugins/irc-events/part.js
+++ b/src/plugins/irc-events/part.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var _ = require("lodash");
 var Msg = require("../../models/msg");
 

--- a/src/plugins/irc-events/quit.js
+++ b/src/plugins/irc-events/quit.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var _ = require("lodash");
 var Msg = require("../../models/msg");
 

--- a/src/plugins/irc-events/topic.js
+++ b/src/plugins/irc-events/topic.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var Msg = require("../../models/msg");
 
 module.exports = function(irc, network) {

--- a/src/plugins/irc-events/unhandled.js
+++ b/src/plugins/irc-events/unhandled.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var Msg = require("../../models/msg");
 
 module.exports = function(irc, network) {

--- a/src/plugins/irc-events/welcome.js
+++ b/src/plugins/irc-events/welcome.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var Msg = require("../../models/msg");
 
 module.exports = function(irc, network) {

--- a/src/plugins/irc-events/whois.js
+++ b/src/plugins/irc-events/whois.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var Chan = require("../../models/chan");
 var Msg = require("../../models/msg");
 

--- a/src/userLog.js
+++ b/src/userLog.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var fs = require("fs");
 var fsextra = require("fs-extra");
 var moment = require("moment");

--- a/test/fixtures/.lounge/config.js
+++ b/test/fixtures/.lounge/config.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var config = require("../../../defaults/config.js");
 
 config.prefetch = true;

--- a/test/fixtures/env.js
+++ b/test/fixtures/env.js
@@ -1,2 +1,4 @@
+"use strict";
+
 var home = require("path").join(__dirname, ".lounge");
 require("../../src/helper").setHome(home);

--- a/test/plugins/link.js
+++ b/test/plugins/link.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var assert = require("assert");
 
 var util = require("../util");

--- a/test/util.js
+++ b/test/util.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var EventEmitter = require("events").EventEmitter;
 var util = require("util");
 var _ = require("lodash");


### PR DESCRIPTION
Several ES6 additions are only available in strict mode. Example:

> SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode

Strict mode was also enabled in a few of our files already, and it is a good thing to have anyway.

This inherently fixes CI builds of #681 and any PR that would start using `const`/`let` for example.