### PR TITLE
Use CI caches for downloaded files instead of installed ones

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
 
 cache:
   directories:
-    - node_modules
+    - ~/.npm
 
 notifications:
   email:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ test_script:
 
 # cache npm modules
 cache:
-  - node_modules
+  - '%AppData%/npm-cache'
 
 # Don't actually build
 build: off


### PR DESCRIPTION
This allows for a more meaningful build: if a newer version of a sub-package breaks, builds would still pass as it uses the cached version. This uses a cache for downloaded packages instead.

I am expecting this to slow down a little bit the builds (but we are OK overall) but be more accurate in practice.

See https://docs.npmjs.com/cli/cache#configuration and https://docs.npmjs.com/files/folders#node-modules.