### PR TITLE
Get rid of OSX CI builds until they get much faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ node_js:
 
 matrix:
   fast_finish: true
-  include:
-  - os: osx
-    node_js: 4
 
 cache:
   directories:


### PR DESCRIPTION
OSX builds have been nothing but a pain on Travis CI: they fail with no good reason, they stay pending forever, etc.

As far as I can tell, I can't remember one valid build they failed and we legitimately discovered a bug. Dev env on OSX is very close to Linux so it's good enough to have it here.

I'm OK with having AppVeyor running slow, which it often does, but Travis CI should be fast and so far this has been the unfortunate bottleneck.