### PR TITLE
Store channel keys

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -42,6 +42,7 @@ var inputs = [
 	"connect",
 	"disconnect",
 	"invite",
+	"join",
 	"kick",
 	"mode",
 	"nick",
@@ -156,7 +157,8 @@ Client.prototype.connect = function(args) {
 			}
 
 			channels.push(new Chan({
-				name: chan.name
+				name: chan.name,
+				key: chan.key
 			}));
 		});
 
@@ -167,11 +169,15 @@ Client.prototype.connect = function(args) {
 	// also used by the "connect" window
 	} else if (args.join) {
 		channels = args.join
-			.replace(/,/g, " ")
-			.split(/\s+/g)
+			.split(/\s*,\s*/g)
 			.map(function(chan) {
+				var splitchan = chan.split(/\s+/g, 2);
+				if (splitchan.length === 1) {
+					splitchan.push("");
+				}
 				return new Chan({
-					name: chan
+					name: splitchan[0],
+					key: splitchan[1]
 				});
 			});
 	}

--- a/src/models/chan.js
+++ b/src/models/chan.js
@@ -19,6 +19,7 @@ function Chan(attr) {
 		id: id++,
 		messages: [],
 		name: "",
+		key: "",
 		topic: "",
 		type: Chan.Type.CHANNEL,
 		firstUnread: 0,

--- a/src/models/network.js
+++ b/src/models/network.js
@@ -84,7 +84,8 @@ Network.prototype.export = function() {
 		})
 		.map(function(chan) {
 			return _.pick(chan, [
-				"name"
+				"name",
+				"key"
 			]);
 		});
 

--- a/src/plugins/inputs/join.js
+++ b/src/plugins/inputs/join.js
@@ -1,24 +1,33 @@
 "use strict";
 
 var Chan = require("../../models/chan");
+var _ = require("lodash");
 
 exports.commands = ["join"];
 
 exports.input = function(network, chan, cmd, args) {
+	var client = this;
 	if (args.length !== 0) {
 		var irc = network.irc;
-		irc.join(args[0], args[1]);
+		if (args.length === 2) {
+			irc.join(args[0], args[1]);
+		} else {
+			irc.join(args[0]);
+		}
+		_.zip(args[0].split(/,/g), args[1].split(/,/g))
+			.map(function(chanPairs) {
+				var channel = new Chan({
+					type: Chan.Type.CHANNEL,
+					name: chanPairs[0],
+					key: chanPairs[1],
+				});
+				network.channels.push(channel);
+				client.emit("join", {
+					network: network.id,
+					chan: channel
+				});
+			});
 	}
-	var newChan = new Chan({
-		type: Chan.Type.CHANNEL,
-		name: args[0],
-		key: args[1],
-	});
-	network.channels.push(newChan);
-	this.emit("join", {
-		network: network.id,
-		chan: newChan
-	});
 	this.save();
 	return true;
 };

--- a/src/plugins/inputs/join.js
+++ b/src/plugins/inputs/join.js
@@ -1,0 +1,24 @@
+"use strict";
+
+var Chan = require("../../models/chan");
+
+exports.commands = ["join"];
+
+exports.input = function(network, chan, cmd, args) {
+	if (args.length !== 0) {
+		var irc = network.irc;
+		irc.join(args[0], args[1]);
+	}
+	var newChan = new Chan({
+		type: Chan.Type.CHANNEL,
+		name: args[0],
+		key: args[1],
+	});
+	network.channels.push(newChan);
+	this.emit("join", {
+		network: network.id,
+		chan: newChan
+	});
+	this.save();
+	return true;
+};

--- a/src/plugins/irc-events/connection.js
+++ b/src/plugins/irc-events/connection.js
@@ -40,7 +40,7 @@ module.exports = function(irc, network) {
 			}
 
 			setTimeout(function() {
-				network.irc.join(chan.name);
+				network.irc.join(chan.name, chan.key);
 			}, delay);
 			delay += 1000;
 		});

--- a/test/models/network.js
+++ b/test/models/network.js
@@ -13,8 +13,8 @@ describe("Network", function() {
 			var network = new Network({
 				name: "networkName",
 				channels: [
-					new Chan({name: "#thelounge"}),
-					new Chan({name: "&foobar"}),
+					new Chan({name: "#thelounge", key: ""}),
+					new Chan({name: "&foobar", key: ""}),
 					new Chan({name: "Channel List", type: Chan.Type.SPECIAL}),
 					new Chan({name: "PrivateChat", type: Chan.Type.QUERY}),
 				]
@@ -34,8 +34,8 @@ describe("Network", function() {
 				ip: null,
 				hostname: null,
 				channels: [
-					{name: "#thelounge"},
-					{name: "&foobar"},
+					{name: "#thelounge", key: ""},
+					{name: "&foobar", key: ""},
 				]
 			});
 		});

--- a/test/models/network.js
+++ b/test/models/network.js
@@ -15,6 +15,8 @@ describe("Network", function() {
 				channels: [
 					new Chan({name: "#thelounge", key: ""}),
 					new Chan({name: "&foobar", key: ""}),
+					new Chan({name: "#secret", key: "foo"}),
+					new Chan({name: "&secure", key: "bar"}),
 					new Chan({name: "Channel List", type: Chan.Type.SPECIAL}),
 					new Chan({name: "PrivateChat", type: Chan.Type.QUERY}),
 				]
@@ -36,6 +38,8 @@ describe("Network", function() {
 				channels: [
 					{name: "#thelounge", key: ""},
 					{name: "&foobar", key: ""},
+					{name: "#secret", key: "foo"},
+					{name: "&secure", key: "bar"}
 				]
 			});
 		});


### PR DESCRIPTION
Fixes issue #412 

This stores channel keys in the user's config file. It can grab them from /join commands or if they are entered in the connect window (in the format #channel $key). It also sends the keys to server when reconnecting.
