### PR TITLE
Match window title border line to text color

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -645,7 +645,7 @@ button {
 }
 
 #windows .window h2 {
-	border-bottom: 1px solid #eee;
+	border-bottom: 1px solid #7f8c8d;
 	color: #7f8c8d;
 	font-size: 22px;
 	margin: 30px 0 10px;


### PR DESCRIPTION
Makes the border look nicer in Morning and Zenburn themes.

![23-081145332](https://cloud.githubusercontent.com/assets/613331/19624889/810f2f6c-9911-11e6-8c75-636f36509255.png)
![23-081153523](https://cloud.githubusercontent.com/assets/613331/19624890/81165620-9911-11e6-8411-eb2307e5d1d1.png)
