### PR TITLE
Fix unread counters resetting when they shouldn't

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -186,7 +186,7 @@ $(function() {
 
 	socket.on("open", function(id) {
 		// Another client opened the channel, clear the unread counter
-		sidebar.find("[data-id='" + id + "'] .badge")
+		sidebar.find(".chan[data-id='" + id + "'] .badge")
 			.removeClass("highlight")
 			.empty();
 	});


### PR DESCRIPTION
Addresses issue #718. It's a simple fix. 

The issue happened because both channels and networks have a `data-id` attribute, so when it was suppose to clear the unread badge for channel 0, it instead cleared all the badges for network 0. Channels' id's also don't reset back to 0 for each network, so it shouldn't have a problem with that.