### PR TITLE
Add human-readable idle time in whois info

### DIFF
--- a/client/views/actions/whois.tpl
+++ b/client/views/actions/whois.tpl
@@ -33,3 +33,9 @@
 	is away <i>({{whois.away}})</i>
 </div>
 {{/if}}
+{{#if whois.idle}}
+<div>
+	<span role="button" class="user {{colorClass whois.nick}}" data-name="{{whois.nick}}">{{whois.nick}}</span>
+	has been idle since {{localetime whois.idleTime}}.
+</div>
+{{/if}}

--- a/src/client.js
+++ b/src/client.js
@@ -52,6 +52,7 @@ var inputs = [
 	"raw",
 	"topic",
 	"list",
+	"whois"
 ].reduce(function(plugins, name) {
 	var path = "./plugins/inputs/" + name;
 	var plugin = require(path);

--- a/src/plugins/inputs/whois.js
+++ b/src/plugins/inputs/whois.js
@@ -1,0 +1,15 @@
+"use strict";
+
+exports.commands = ["whois"];
+
+exports.input = function(network, chan, cmd, args) {
+	if (args.length === 1) {
+		// This queries server of the other user and not of the current user, which
+		// does not know idle time.
+		// See http://superuser.com/a/272069/208074.
+		network.irc.raw("WHOIS", args[0], args[0]);
+	} else {
+		// Re-assembling the command parsed in client.js
+		network.irc.raw(`${cmd} ${args.join(" ")}`);
+	}
+};

--- a/src/plugins/irc-events/whois.js
+++ b/src/plugins/irc-events/whois.js
@@ -27,6 +27,9 @@ module.exports = function(irc, network) {
 				text: "No such nick: " + data.nick
 			});
 		} else {
+			// Absolute datetime in milliseconds since nick is idle
+			data.idleTime = Date.now() - data.idle * 1000;
+
 			msg = new Msg({
 				type: Msg.Type.WHOIS,
 				whois: data


### PR DESCRIPTION
One step towards #560.

See http://superuser.com/a/272069/208074 for explanation on `/whois nick nick` instead of `/whois nick`.

### Results

<img width="389" alt="screen shot 2016-12-18 at 22 17 47" src="https://cloud.githubusercontent.com/assets/113730/21300280/952d525e-c570-11e6-82ae-837376ab91fc.png">

This PR used to say "since X days, X hours, X minutes and X seconds" but was moved to the format above for simplicity and consistency with other date/times in the current UI.
Helper and tests to do that have been moved to the archive PR #819.