### PR TITLE
Warn against running from source as root in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,7 @@ lounge --help
 
 ### Running from source
 
-The following commands install the development version of The Lounge. A word of
-caution: while it is the most recent codebase, this is not production-ready!
+The following commands install the development version of The Lounge:
 
 ```sh
 git clone https://github.com/thelounge/lounge.git
@@ -70,6 +69,12 @@ cd lounge
 npm install
 npm start
 ```
+
+A word of caution:
+
+- While it is the most recent codebase, this is not production-ready!
+- It is not recommended to run this as root. However, if you decide to do so,
+  you will have to run `npm run build`.
 
 ## Development setup
 


### PR DESCRIPTION
This was discussed in IRC yesterday.

Basically, npm pre/post scripts are not executed when running as root. There are ways to do so, but this goes beyond what the README should say.
Also, we should not be held responsible for someone messing up their system while running code that is deemed not prod-ready.
