### PR TITLE
src/server: log.debug config path on start-up

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -76,9 +76,10 @@ module.exports = function() {
 
 	manager.sockets = sockets;
 
-	let protocol = config.https.enable ? "https" : "http";
-	let host = config.host || "*";
+	const protocol = config.https.enable ? "https" : "http";
+	const host = config.host || "*";
 	log.info("The Lounge", Helper.getVersion(), "is now running");
+	log.info(`Configuration file: ${Helper.CONFIG_PATH}`);
 	log.info(`Available on: ${protocol}://${host}:${config.port}/ in ${config.public ? "public" : "private"} mode`);
 	log.info("Press ctrl-c to stop\n");
 


### PR DESCRIPTION
Feels like "where/which config file does my lounge instance use?" questions are quite common, this hopefully makes things clearer.

<img width="603" alt="lounge__node_" src="https://cloud.githubusercontent.com/assets/6705160/20316051/a445e474-ab60-11e6-8c15-4693e85c5433.png">

