### PR TITLE
Implement /away and /back commands

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -6,6 +6,8 @@ $(function() {
 	var path = window.location.pathname + "socket.io/";
 	var socket = io({path: path});
 	var commands = [
+		"/away",
+		"/back",
 		"/close",
 		"/connect",
 		"/deop",
@@ -15,6 +17,7 @@ $(function() {
 		"/join",
 		"/kick",
 		"/leave",
+		"/me",
 		"/mode",
 		"/msg",
 		"/nick",

--- a/src/client.js
+++ b/src/client.js
@@ -39,6 +39,7 @@ var inputs = [
 	"msg",
 	"part",
 	"action",
+	"away",
 	"connect",
 	"disconnect",
 	"invite",

--- a/src/plugins/inputs/away.js
+++ b/src/plugins/inputs/away.js
@@ -1,0 +1,19 @@
+"use strict";
+
+exports.commands = ["away", "back"];
+
+exports.input = function(network, chan, cmd, args) {
+	if (cmd === "away") {
+		let reason = " ";
+
+		if (args.length > 0) {
+			reason = args.join(" ");
+		}
+
+		network.irc.raw("AWAY", reason);
+
+		return;
+	}
+
+	network.irc.raw("AWAY");
+};


### PR DESCRIPTION
Fixes #705 as the away message has to be a single argument instead of multiple.

Breaking change: `/away` will now mark you as away with empty message instead of marking you as back. New command `/back` is used for that instead. (same as HexChat).