### PR TITLE
Initial part/join condensing

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -197,6 +197,7 @@ kbd {
 #settings #play:before,
 #form #submit:before,
 #chat .invite .from:before,
+#chat .condensed .expander:before,
 #chat .join .from:before,
 #chat .kick .from:before,
 #chat .part .from:before,
@@ -282,6 +283,22 @@ kbd {
 #chat .nick .from:before {
 	content: "\f007"; /* http://fontawesome.io/icon/user/ */
 	color: #2ecc40;
+}
+
+#chat .condensed {
+	cursor: pointer;
+}
+
+#chat .condensed div {
+	cursor: default;
+}
+
+#chat .condensed .expander:before {
+	content: "\f0d7"; /* http://fontawesome.io/icon/caret-down/ */
+}
+
+#chat .condensed.closed .expander:before {
+	content: "\f0da"; /* http://fontawesome.io/icon/caret-right/ */
 }
 
 #chat .join .from:before {
@@ -801,6 +818,18 @@ kbd {
 	display: block;
 }
 
+#chat .condensed {
+	flex-wrap: wrap;
+}
+
+#chat .condensed .msg {
+	flex-basis: 100%;
+}
+
+#chat .condensed.closed .msg {
+	display: none;
+}
+
 #windows .header .topic,
 .messages .msg,
 .sidebar {
@@ -1092,15 +1121,17 @@ kbd {
 	color: #555;
 }
 
-#chat.hide-join .join,
-#chat.hide-mode .mode,
-#chat.hide-motd .motd,
-#chat.hide-nick .nick,
-#chat.hide-part .part,
-#chat.hide-quit .quit {
+#chat.hide-optional .join,
+#chat.hide-optional .mode,
+#chat.hide-optional .nick,
+#chat.hide-optional .part,
+#chat.hide-optional .quit,
+#chat.hide-optional .condensed,
+#chat.hide-motd .motd {
 	display: none !important;
 }
 
+#chat .condensed .content,
 #chat .join .content,
 #chat .kick .content,
 #chat .mode .content,
@@ -2129,4 +2160,8 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 #chat .action .text,
 #chat table.channel-list .topic {
 	white-space: pre-wrap;
+}
+
+.hide-text {
+	color: transparent !important;
 }

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -198,7 +198,6 @@ kbd {
 #settings #play:before,
 #form #submit:before,
 #chat .invite .from:before,
-#chat .condensed .expander:before,
 #chat .join .from:before,
 #chat .kick .from:before,
 #chat .part .from:before,
@@ -284,22 +283,6 @@ kbd {
 #chat .nick .from:before {
 	content: "\f007"; /* http://fontawesome.io/icon/user/ */
 	color: #2ecc40;
-}
-
-#chat .condensed {
-	cursor: pointer;
-}
-
-#chat .condensed div {
-	cursor: default;
-}
-
-#chat .condensed .expander:before {
-	content: "\f0d7"; /* http://fontawesome.io/icon/caret-down/ */
-}
-
-#chat .condensed.closed .expander:before {
-	content: "\f0da"; /* http://fontawesome.io/icon/caret-right/ */
 }
 
 #chat .join .from:before {
@@ -827,8 +810,21 @@ kbd {
 	flex-wrap: wrap;
 }
 
-#chat .condensed .msg {
-	flex-basis: 100%;
+#chat .condensed .content {
+	flex: 1;
+}
+
+#chat .condensed-text {
+	cursor: pointer;
+	transition: opacity .2s;
+}
+
+#chat .condensed-text:hover {
+	opacity: .6;
+}
+
+#chat .condensed-text .toggle-button:hover {
+	opacity: 1;
 }
 
 #chat .condensed.closed .msg {
@@ -1174,17 +1170,12 @@ kbd {
 
 #chat .toggle-button {
 	display: inline-block;
-	color: #666;
-	transition: color .2s, transform .2s;
+	transition: opacity .2s, transform .2s;
 }
 
-#chat .toggle-button.opened {
+#chat .toggle-button.opened, /* Thumbnail toggle */
+#chat .msg.condensed:not(.closed) .toggle-button { /* Expanded status message toggle */
 	transform: rotate(90deg);
-}
-
-#chat .toggle-button:hover {
-	/* transform and opacity together glitch, so need to use RGBA transition */
-	color: rgba(102, 102, 102, .8); /* #666 x .8 opacity */
 }
 
 #chat .toggle-content {

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -194,6 +194,7 @@ kbd {
 #chat .title:before,
 #footer .icon,
 #chat .count:before,
+#settings .extra-help,
 #settings #play:before,
 #form #submit:before,
 #chat .invite .from:before,
@@ -332,6 +333,10 @@ kbd {
 	right: 18px;
 	font-size: 14px;
 	line-height: 50px;
+}
+
+#settings .extra-help:before {
+	content: "\f059"; /* http://fontawesome.io/icon/question-circle/ */
 }
 
 #settings #play:before {
@@ -1400,8 +1405,13 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 	margin: 4px 10px 0 0;
 }
 
+#settings .extra-help,
 #settings #play {
 	color: #7f8c8d;
+}
+
+#settings .extra-help {
+	cursor: help;
 }
 
 #settings #play {
@@ -1723,6 +1733,16 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 	animation-timing-function: ease-in;
 	-webkit-animation-delay: .4s;
 	animation-delay: .4s;
+}
+
+.tooltipped-no-delay:hover:before,
+.tooltipped-no-delay:hover:after,
+.tooltipped-no-delay:active:before,
+.tooltipped-no-delay:active:after,
+.tooltipped-no-delay:focus:before,
+.tooltipped-no-delay:focus:after {
+	-webkit-animation-delay: 0s;
+	animation-delay: 0s;
 }
 
 .tooltipped-s:after,

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1126,12 +1126,12 @@ kbd {
 	color: #555;
 }
 
-#chat.hide-optional .join,
-#chat.hide-optional .mode,
-#chat.hide-optional .nick,
-#chat.hide-optional .part,
-#chat.hide-optional .quit,
-#chat.hide-optional .condensed,
+#chat.hide-status-messages .join,
+#chat.hide-status-messages .mode,
+#chat.hide-status-messages .nick,
+#chat.hide-status-messages .part,
+#chat.hide-status-messages .quit,
+#chat.hide-status-messages .condensed,
 #chat.hide-motd .motd {
 	display: none !important;
 }
@@ -1397,12 +1397,11 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 
 #settings .opt {
 	display: block;
-	padding: 5px 0 10px 1px;
+	padding: 5px 0 5px 1px;
 }
 
 #settings .opt input {
-	float: left;
-	margin: 4px 10px 0 0;
+	margin-right: 6px;
 }
 
 #settings .extra-help,
@@ -1412,6 +1411,10 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 
 #settings .extra-help {
 	cursor: help;
+}
+
+#settings h2 .extra-help {
+	font-size: .8em;
 }
 
 #settings #play {

--- a/client/index.html
+++ b/client/index.html
@@ -218,38 +218,20 @@
 							</div>
 							<div class="col-sm-6">
 								<label class="opt">
-									<input type="checkbox" name="join">
-									Show joins
+									<input type="checkbox" name="optional">
+									Show <abbr title="Joins, parts, kicks, nick changes, and mode changes">status messages</abbr>
+								</label>
+							</div>
+							<div class="col-sm-6">
+								<label class="opt">
+									<input type="checkbox" name="condense">
+									Condense <abbr title="Joins, parts, kicks, nick changes, and mode changes">status messages</abbr>
 								</label>
 							</div>
 							<div class="col-sm-6">
 								<label class="opt">
 									<input type="checkbox" name="motd">
 									Show <abbr title="Message Of The Day">MOTD</abbr>
-								</label>
-							</div>
-							<div class="col-sm-6">
-								<label class="opt">
-									<input type="checkbox" name="part">
-									Show parts
-								</label>
-							</div>
-							<div class="col-sm-6">
-								<label class="opt">
-									<input type="checkbox" name="nick">
-									Show nick changes
-								</label>
-							</div>
-							<div class="col-sm-6">
-								<label class="opt">
-									<input type="checkbox" name="mode">
-									Show mode
-								</label>
-							</div>
-							<div class="col-sm-6">
-								<label class="opt">
-									<input type="checkbox" name="quit">
-									Show quits
 								</label>
 							</div>
 							<div class="col-sm-6">

--- a/client/index.html
+++ b/client/index.html
@@ -218,21 +218,6 @@
 							</div>
 							<div class="col-sm-6">
 								<label class="opt">
-									<input type="checkbox" name="optional">
-									Show status messages
-									<span class="tooltipped tooltipped-n tooltipped-no-delay" aria-label="Joins, parts, kicks, nick changes, and mode changes">
-										<button class="extra-help" aria-label="Joins, parts, kicks, nick changes, and mode changes"></button>
-									</span>
-								</label>
-							</div>
-							<div class="col-sm-6">
-								<label class="opt">
-									<input type="checkbox" name="condense">
-									Condense status messages
-								</label>
-							</div>
-							<div class="col-sm-6">
-								<label class="opt">
 									<input type="checkbox" name="motd">
 									Show <abbr title="Message Of The Day">MOTD</abbr>
 								</label>
@@ -241,6 +226,28 @@
 								<label class="opt">
 									<input type="checkbox" name="showSeconds">
 									Show seconds in timestamp
+								</label>
+							</div>
+							<div class="col-sm-12">
+								<h2>
+									Status messages
+									<span class="tooltipped tooltipped-n tooltipped-no-delay" aria-label="Joins, parts, kicks, nick changes, and mode changes">
+										<button class="extra-help" aria-label="Joins, parts, kicks, nick changes, and mode changes"></button>
+									</span>
+								</h2>
+							</div>
+							<div class="col-sm-12">
+								<label class="opt">
+									<input type="radio" name="statusMessages" value="shown">
+									Show all status messages individually
+								</label>
+								<label class="opt">
+									<input type="radio" name="statusMessages" value="condensed">
+									Condense status messages together
+								</label>
+								<label class="opt">
+									<input type="radio" name="statusMessages" value="hidden">
+									Hide all status messages
 								</label>
 							</div>
 							<div class="col-sm-12">

--- a/client/index.html
+++ b/client/index.html
@@ -219,13 +219,16 @@
 							<div class="col-sm-6">
 								<label class="opt">
 									<input type="checkbox" name="optional">
-									Show <abbr title="Joins, parts, kicks, nick changes, and mode changes">status messages</abbr>
+									Show status messages
+									<span class="tooltipped tooltipped-n tooltipped-no-delay" aria-label="Joins, parts, kicks, nick changes, and mode changes">
+										<button class="extra-help" aria-label="Joins, parts, kicks, nick changes, and mode changes"></button>
+									</span>
 								</label>
 							</div>
 							<div class="col-sm-6">
 								<label class="opt">
 									<input type="checkbox" name="condense">
-									Condense <abbr title="Joins, parts, kicks, nick changes, and mode changes">status messages</abbr>
+									Condense status messages
 								</label>
 							</div>
 							<div class="col-sm-6">

--- a/client/js/condensed.js
+++ b/client/js/condensed.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const constants = require("./constants");
+const templates = require("../views");
 
 module.exports = {
 	updateText
@@ -33,5 +34,6 @@ function updateText(condensed, addedTypes) {
 			text += obj[messageType] > 1 ? "s" : "";
 		}
 	}
-	condensed.find(".condensed-msg").text(text);
+	condensed.find(".condensed-text")
+		.html(text + templates.msg_condensed_toggle());
 }

--- a/client/js/condensed.js
+++ b/client/js/condensed.js
@@ -1,0 +1,37 @@
+"use strict";
+
+const constants = require("./constants");
+
+module.exports = {
+	updateText
+};
+
+function updateText(condensed, addedTypes) {
+	var obj = {};
+
+	for (var i in constants.condensedTypes) {
+		var msgType = constants.condensedTypes[i];
+		obj[msgType] = condensed.data(msgType) || 0;
+	}
+
+	for (var k in addedTypes) {
+		var added = addedTypes[k];
+		obj[added]++;
+		condensed.data(added, obj[added]);
+	}
+
+	var text = "";
+
+	for (var j in constants.condensedTypes) {
+		var messageType = constants.condensedTypes[j];
+		if (obj[messageType]) {
+			text += text === "" ? "" : ", ";
+			text += obj[messageType] + " " + messageType;
+			if (messageType === "nick" || messageType === "mode") {
+				text += " change";
+			}
+			text += obj[messageType] > 1 ? "s" : "";
+		}
+	}
+	condensed.find(".condensed-msg").text(text);
+}

--- a/client/js/condensed.js
+++ b/client/js/condensed.js
@@ -8,32 +8,48 @@ module.exports = {
 };
 
 function updateText(condensed, addedTypes) {
-	var obj = {};
+	const obj = {};
 
-	for (var i in constants.condensedTypes) {
-		var msgType = constants.condensedTypes[i];
-		obj[msgType] = condensed.data(msgType) || 0;
-	}
+	constants.condensedTypes.forEach((type) => {
+		obj[type] = condensed.data(type) || 0;
+	});
 
-	for (var k in addedTypes) {
-		var added = addedTypes[k];
-		obj[added]++;
-		condensed.data(added, obj[added]);
-	}
+	addedTypes.forEach((type) => {
+		obj[type]++;
+		condensed.data(type, obj[type]);
+	});
 
-	var text = "";
-
-	for (var j in constants.condensedTypes) {
-		var messageType = constants.condensedTypes[j];
-		if (obj[messageType]) {
-			text += text === "" ? "" : ", ";
-			text += obj[messageType] + " " + messageType;
-			if (messageType === "nick" || messageType === "mode") {
-				text += " change";
+	const strings = [];
+	constants.condensedTypes.forEach((type) => {
+		if (obj[type]) {
+			switch (type) {
+			case "join":
+				strings.push(obj[type] + (obj[type] > 1 ? " users have joined the channel" : " user has joined the channel"));
+				break;
+			case "part":
+				strings.push(obj[type] + (obj[type] > 1 ? " users have left the channel" : " user has left the channel"));
+				break;
+			case "quit":
+				strings.push(obj[type] + (obj[type] > 1 ? " users have quit" : " user has quit"));
+				break;
+			case "nick":
+				strings.push(obj[type] + (obj[type] > 1 ? " users have changed nick" : " user has changed nick"));
+				break;
+			case "kick":
+				strings.push(obj[type] + (obj[type] > 1 ? " users were kicked" : " user was kicked"));
+				break;
+			case "mode":
+				strings.push(obj[type] + (obj[type] > 1 ? " modes were set" : " mode was set"));
+				break;
 			}
-			text += obj[messageType] > 1 ? "s" : "";
 		}
+	});
+
+	let text = strings.pop();
+	if (strings.length) {
+		text = strings.join(", ") + ", and " + text;
 	}
+
 	condensed.find(".condensed-text")
 		.html(text + templates.msg_condensed_toggle());
 }

--- a/client/js/constants.js
+++ b/client/js/constants.js
@@ -56,6 +56,32 @@ const commands = [
 	"/whois"
 ];
 
+const actionTypes = [
+	"ban_list",
+	"invite",
+	"join",
+	"mode",
+	"kick",
+	"nick",
+	"part",
+	"quit",
+	"topic",
+	"topic_set_by",
+	"action",
+	"whois",
+	"ctcp",
+	"channel_list",
+];
+
+const condensedTypes = [
+	"join",
+	"kick",
+	"mode",
+	"nick",
+	"part",
+	"quit",
+];
+
 const timeFormats = {
 	msgDefault: "HH:mm",
 	msgWithSeconds: "HH:mm:ss"
@@ -63,6 +89,8 @@ const timeFormats = {
 
 module.exports = {
 	colorCodeMap: colorCodeMap,
-	timeFormats: timeFormats,
-	commands: commands
+	commands: commands,
+	condensedTypes: condensedTypes,
+	actionTypes: actionTypes,
+	timeFormats: timeFormats
 };

--- a/client/js/constants.js
+++ b/client/js/constants.js
@@ -75,11 +75,11 @@ const actionTypes = [
 
 const condensedTypes = [
 	"join",
-	"kick",
-	"mode",
-	"nick",
 	"part",
 	"quit",
+	"nick",
+	"kick",
+	"mode",
 ];
 
 const timeFormats = {

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -439,12 +439,8 @@ $(function() {
 		}
 	});
 
-	chat.on("click", ".condensed", function() {
-		$(this).toggleClass("closed");
-	});
-
-	chat.on("click", ".condensed div", function(e) {
-		e.stopPropagation();
+	chat.on("click", ".condensed-text", function() {
+		$(this).closest(".msg.condensed").toggleClass("closed");
 	});
 
 	chat.on("click", ".user", function() {

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -439,6 +439,14 @@ $(function() {
 		}
 	});
 
+	chat.on("click", ".condensed", function() {
+		$(this).toggleClass("closed");
+	});
+
+	chat.on("click", ".condensed div", function(e) {
+		e.stopPropagation();
+	});
+
 	chat.on("click", ".user", function() {
 		var name = $(this).data("name");
 		var chan = findCurrentNetworkChan(name);
@@ -707,6 +715,9 @@ $(function() {
 	chat.on("click", ".show-more-button", function() {
 		var self = $(this);
 		var lastMessage = self.parent().next(".messages").children(".msg").first();
+		if (lastMessage.is(".condensed")) {
+			lastMessage = lastMessage.children(".msg").first();
+		}
 		var lastMessageId = parseInt(lastMessage[0].id.replace("msg-", ""), 10);
 
 		self

--- a/client/js/options.js
+++ b/client/js/options.js
@@ -11,16 +11,13 @@ const chat = $("#chat");
 
 const options = $.extend({
 	coloredNicks: true,
+	condense: true,
 	desktopNotifications: false,
-	join: true,
 	links: true,
-	mode: true,
 	motd: true,
-	nick: true,
 	notification: true,
 	notifyAllMessages: false,
-	part: true,
-	quit: true,
+	optional: true,
 	showSeconds: false,
 	theme: $("#theme").attr("href").replace(/^themes\/(.*).css$/, "$1"), // Extracts default theme name, set on the server configuration
 	thumbnails: true,
@@ -66,15 +63,7 @@ settings.on("change", "input, select, textarea", function() {
 
 	storage.set("settings", JSON.stringify(options));
 
-	if ([
-		"join",
-		"mode",
-		"motd",
-		"nick",
-		"part",
-		"quit",
-		"notifyAllMessages",
-	].indexOf(name) !== -1) {
+	if (name === "optional" || name === "motd") {
 		chat.toggleClass("hide-" + name, !self.prop("checked"));
 	} else if (name === "coloredNicks") {
 		chat.toggleClass("colored-nicks", self.prop("checked"));

--- a/client/js/options.js
+++ b/client/js/options.js
@@ -9,22 +9,29 @@ const tz = require("./libs/handlebars/tz");
 const windows = $("#windows");
 const chat = $("#chat");
 
-const options = $.extend({
+// Default options
+const options = {
+	autocomplete: true,
 	coloredNicks: true,
-	condense: true,
 	desktopNotifications: false,
+	highlights: [],
 	links: true,
 	motd: true,
 	notification: true,
 	notifyAllMessages: false,
-	optional: true,
 	showSeconds: false,
+	statusMessages: "condensed",
 	theme: $("#theme").attr("href").replace(/^themes\/(.*).css$/, "$1"), // Extracts default theme name, set on the server configuration
 	thumbnails: true,
 	userStyles: userStyles.text(),
-	highlights: [],
-	autocomplete: true
-}, JSON.parse(storage.get("settings")));
+};
+const userOptions = JSON.parse(storage.get("settings")) || {};
+
+for (const key in options) {
+	if (userOptions[key]) {
+		options[key] = userOptions[key];
+	}
+}
 
 module.exports = options;
 
@@ -40,6 +47,9 @@ for (var i in options) {
 		settings.find("#user-specified-css-input").val(options[i]);
 	} else if (i === "highlights") {
 		settings.find("input[name=" + i + "]").val(options[i]);
+	} else if (i === "statusMessages") {
+		settings.find(`input[name=${i}][value=${options[i]}]`)
+			.prop("checked", true);
 	} else if (i === "theme") {
 		$("#theme").attr("href", "themes/" + options[i] + ".css");
 		settings.find("select[name=" + i + "]").val(options[i]);
@@ -55,6 +65,10 @@ settings.on("change", "input, select, textarea", function() {
 
 	if (type === "password") {
 		return;
+	} else if (type === "radio") {
+		if (self.prop("checked")) {
+			options[name] = self.val();
+		}
 	} else if (type === "checkbox") {
 		options[name] = self.prop("checked");
 	} else {
@@ -63,8 +77,10 @@ settings.on("change", "input, select, textarea", function() {
 
 	storage.set("settings", JSON.stringify(options));
 
-	if (name === "optional" || name === "motd") {
+	if (name === "motd") {
 		chat.toggleClass("hide-" + name, !self.prop("checked"));
+	} else if (name === "statusMessages") {
+		chat.toggleClass("hide-status-messages", options[name] === "hidden");
 	} else if (name === "coloredNicks") {
 		chat.toggleClass("colored-nicks", self.prop("checked"));
 	} else if (name === "theme") {

--- a/client/js/render.js
+++ b/client/js/render.js
@@ -41,7 +41,7 @@ function appendMessage(container, chan, chanType, messageType, msg) {
 		if (lastChild && $(lastChild).hasClass("condensed") && !$(msg).hasClass("message") && lastDate === msgDate) {
 			lastChild.append(msg);
 			condense.updateText(lastChild, [messageType]);
-		} else if (lastChild && $(lastChild).is(condensedTypesClasses) && options.condense) {
+		} else if (lastChild && $(lastChild).is(condensedTypesClasses) && options.statusMessages === "condensed") {
 			var condensed = buildChatMessage({msg: {type: "condensed", time: msg.attr("data-time"), previews: []}, chan: chan});
 			condensed.append(lastChild);
 			condensed.append(msg);

--- a/client/js/renderPreview.js
+++ b/client/js/renderPreview.js
@@ -47,7 +47,7 @@ function renderPreview(preview, msg) {
 	container.trigger("keepToBottom");
 }
 
-$("#chat").on("click", ".toggle-button", function() {
+$("#chat").on("click", ".text .toggle-button", function() {
 	const self = $(this);
 	const container = self.closest(".chat");
 	const content = self.closest(".content")

--- a/client/js/socket-events/more.js
+++ b/client/js/socket-events/more.js
@@ -7,7 +7,7 @@ const chat = $("#chat");
 const templates = require("../../views");
 
 socket.on("more", function(data) {
-	const documentFragment = render.buildChannelMessages(data.chan, data.messages);
+	const documentFragment = render.buildChannelMessages(data);
 	const chan = chat
 		.find("#chan-" + data.chan)
 		.find(".messages");
@@ -24,6 +24,8 @@ socket.on("more", function(data) {
 	} else if (children.eq(1).hasClass("date-marker-container")) {
 		// The unread-marker could be at index 0, which will cause the date-marker to become "stuck"
 		children.eq(1).remove();
+	} else if (children.eq(0).hasClass("condensed") && children.eq(0).children(".date-marker-container").eq(0).hasClass("date-marker-container")) {
+		children.eq(0).children(".date-marker-container").eq(0).remove();
 	}
 
 	// Add the older messages
@@ -52,6 +54,10 @@ socket.on("more", function(data) {
 		}
 
 		if (lastDate.toDateString() !== msgDate.toDateString()) {
+			var parent = msg.parent();
+			if (parent.hasClass("condensed")) {
+				msg.insertAfter(parent);
+			}
 			msg.before(templates.date_marker({msgDate: msgDate}));
 		}
 

--- a/client/themes/morning.css
+++ b/client/themes/morning.css
@@ -101,10 +101,6 @@ body {
 	color: #428bca;
 }
 
-#chat button:hover {
-	opacity: 1;
-}
-
 /* Increase contrast of some IRC colors */
 .irc-fg2 { color: #0074d9; }
 .irc-fg5 { color: #e969a7; }
@@ -208,17 +204,9 @@ body {
 }
 
 /* Embeds */
-#chat .toggle-content,
-#chat .toggle-button {
-	color: #f3f3f3;
-}
-
-#chat .toggle-button:hover {
-	color: rgba(243, 243, 243, .8);
-}
-
 #chat .toggle-content {
 	background: #242a33;
+	color: #f3f3f3;
 }
 
 #chat .toggle-content .body {

--- a/client/themes/zenburn.css
+++ b/client/themes/zenburn.css
@@ -127,10 +127,6 @@ body {
 	color: #8c8cbc;
 }
 
-#chat button:hover {
-	opacity: 1;
-}
-
 /* Increase contrast of some IRC colors */
 .irc-fg2 { color: #1b94ff; }
 .irc-fg5 { color: #e969a7; }
@@ -235,17 +231,9 @@ body {
 
 /* Previews */
 
-#chat .toggle-content,
-#chat .toggle-button {
-	color: #dcdccc;
-}
-
-#chat .toggle-button:hover {
-	color: rgba(220, 220, 204, .8);
-}
-
 #chat .toggle-content {
 	background: #333;
+	color: #dcdccc;
 }
 
 #chat .toggle-content .body {

--- a/client/views/index.js
+++ b/client/views/index.js
@@ -25,6 +25,7 @@ module.exports = {
 	date_marker: require("./date-marker.tpl"),
 	msg: require("./msg.tpl"),
 	msg_action: require("./msg_action.tpl"),
+	msg_condensed_toggle: require("./msg_condensed_toggle.tpl"),
 	msg_condensed: require("./msg_condensed.tpl"),
 	msg_preview: require("./msg_preview.tpl"),
 	msg_preview_toggle: require("./msg_preview_toggle.tpl"),

--- a/client/views/index.js
+++ b/client/views/index.js
@@ -25,6 +25,7 @@ module.exports = {
 	date_marker: require("./date-marker.tpl"),
 	msg: require("./msg.tpl"),
 	msg_action: require("./msg_action.tpl"),
+	msg_condensed: require("./msg_condensed.tpl"),
 	msg_preview: require("./msg_preview.tpl"),
 	msg_preview_toggle: require("./msg_preview_toggle.tpl"),
 	msg_unhandled: require("./msg_unhandled.tpl"),

--- a/client/views/msg_action.tpl
+++ b/client/views/msg_action.tpl
@@ -1,4 +1,5 @@
-<div class="msg {{type}}{{#if self}} self{{/if}}{{#if highlight}} highlight{{/if}}" id="msg-{{id}}" data-time="{{time}}">
+<div class="msg {{type}}{{#if self}} self{{/if}}{{#if highlight}} highlight{{/if}}"
+	data-type="{{type}}" id="msg-{{id}}" data-time="{{time}}">
 	<span class="time tooltipped tooltipped-e" aria-label="{{localetime time}}">
 		{{tz time}}
 	</span>

--- a/client/views/msg_condensed.tpl
+++ b/client/views/msg_condensed.tpl
@@ -1,7 +1,7 @@
 <div class="msg {{type}} closed" data-time="{{time}}">
 	<span class="time hide-text">{{tz time}}</span>
-	<span class="from"><span class="expander"></span></span>
+	<span class="from"></span>
 	<span class="content">
-		<span class="text condensed-msg"></span>
+		<span class="condensed-text"></span>
 	</span>
 </div>

--- a/client/views/msg_condensed.tpl
+++ b/client/views/msg_condensed.tpl
@@ -1,0 +1,7 @@
+<div class="msg {{type}} closed" data-time="{{time}}">
+	<span class="time hide-text">{{tz time}}</span>
+	<span class="from"><span class="expander"></span></span>
+	<span class="content">
+		<span class="text condensed-msg"></span>
+	</span>
+</div>

--- a/client/views/msg_condensed_toggle.tpl
+++ b/client/views/msg_condensed_toggle.tpl
@@ -1,0 +1,1 @@
+<button class="toggle-button" aria-label="Toggle status messages"></button>


### PR DESCRIPTION
This probably isn't done, and needs a lot more testing from other people to see if I've done anything bad.

Another good thing to add would be how IRC cloud shows it (it makes a little sentence explaining some of the parts/joins in it).

But this is just an initial one.

List of stuff still to do before merging:

- [x] Initial condenser element shows as behind the date line when it's the first in the channel
- [x] Condense based on date
- [x] Don't have all messages clickable, just the condenser
- [x] Change icon
- [x] Only condense if more than 1 item
- [x] Correct counts
- [x] Clicking "more" returns some of the same messages
- [x] Issues with flex layout
- [x] Hide when parts/joins are hidden inside of it
- [x] Change show/hide settings to "show/hide" and "codense"
- [x] Split out the "more" change to another PR
- [x] Fix name on option
- [x] Fix previews properly
- [x] Properly hide condense messages
- [x] Rename `handledTypes` to `actionTypes`
- ~Try removing the second [click handler](https://github.com/thelounge/lounge/pull/759#discussion_r126403670)~ UI logic was changed a bit, making this a non-issue

![7c99048cb6f41986f0d7abe955a10193](https://cloud.githubusercontent.com/assets/2162657/20571393/27360da2-b19f-11e6-8568-20c7d7c6828c.png)

![a4192df26c41bb6d1f4e98c58915e835](https://cloud.githubusercontent.com/assets/2162657/20571396/2a4669d8-b19f-11e6-97c1-d5993468f9a0.png)
