### PR TITLE
Date separator fixes

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -420,9 +420,12 @@ $(function() {
 
 		// Remove the date-change marker we put at the top, because it may
 		// not actually be a date change now
-		var firstChild = $(chan).children().eq(0);
-		if (firstChild.attr("class") === "date-marker") {
-			firstChild.remove();
+		var children = $(chan).children();
+		if (children.eq(0).attr("class") === "date-marker") { // Check top most child
+			children.eq(0).remove();
+		} else if (children.eq(0).attr("class") === "unread-marker" && children.eq(1).attr("class") === "date-marker") {
+			// Otherwise the date-marker would get 'stuck' because of the new-massages marker
+			children.eq(1).remove();
 		}
 
 		// get the scrollable wrapper around messages

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -424,7 +424,7 @@ $(function() {
 		if (children.eq(0).attr("class") === "date-marker") { // Check top most child
 			children.eq(0).remove();
 		} else if (children.eq(0).attr("class") === "unread-marker" && children.eq(1).attr("class") === "date-marker") {
-			// Otherwise the date-marker would get 'stuck' because of the new-massages marker
+			// Otherwise the date-marker would get 'stuck' because of the new-message marker
 			children.eq(1).remove();
 		}
 

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -421,9 +421,9 @@ $(function() {
 		// Remove the date-change marker we put at the top, because it may
 		// not actually be a date change now
 		var children = $(chan).children();
-		if (children.eq(0).attr("class") === "date-marker") { // Check top most child
+		if (children.eq(0).hasClass("date-marker")) { // Check top most child
 			children.eq(0).remove();
-		} else if (children.eq(0).attr("class") === "unread-marker" && children.eq(1).attr("class") === "date-marker") {
+		} else if (children.eq(0).hasClass("unread-marker") && children.eq(1).hasClass("date-marker")) {
 			// Otherwise the date-marker would get 'stuck' because of the new-message marker
 			children.eq(1).remove();
 		}

--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -32,6 +32,7 @@ module.exports = function(irc, network) {
 		var msg = new Msg({
 			self: data.nick === irc.user.nick,
 			type: Msg.Type.TOGGLE,
+			time: data.time, // msg handles it if it isn't defined
 		});
 		chan.pushMessage(client, msg);
 
@@ -49,7 +50,8 @@ function parse(msg, url, res, client) {
 		head: "",
 		body: "",
 		thumb: "",
-		link: url
+		link: url,
+		time: msg.time,
 	};
 
 	switch (res.type) {


### PR DESCRIPTION
Fixes #763 and #760; I decided to do this in one pr since both are so small fixes. 

For #763 an extra check was added for the new-messages marker and skips it

For #760 I added the reported time, if that was not available, the current time