### PR TITLE
Auto away when no clients are connected

### DIFF
--- a/src/models/network.js
+++ b/src/models/network.js
@@ -14,6 +14,7 @@ function Network(attr) {
 		port: 6667,
 		tls: false,
 		password: "",
+		awayMessage: "",
 		commands: [],
 		username: "",
 		realname: "",
@@ -56,6 +57,7 @@ Network.prototype.setNick = function(nick) {
 
 Network.prototype.toJSON = function() {
 	return _.omit(this, [
+		"awayMessage",
 		"chanCache",
 		"highlightRegex",
 		"irc",
@@ -65,6 +67,7 @@ Network.prototype.toJSON = function() {
 
 Network.prototype.export = function() {
 	var network = _.pick(this, [
+		"awayMessage",
 		"nick",
 		"name",
 		"host",

--- a/src/plugins/inputs/away.js
+++ b/src/plugins/inputs/away.js
@@ -3,17 +3,15 @@
 exports.commands = ["away", "back"];
 
 exports.input = function(network, chan, cmd, args) {
-	if (cmd === "away") {
-		let reason = " ";
+	let reason = "";
 
-		if (args.length > 0) {
-			reason = args.join(" ");
-		}
+	if (cmd === "away") {
+		reason = args.length > 0 ? args.join(" ") : " ";
 
 		network.irc.raw("AWAY", reason);
-
-		return;
+	} else { // back command
+		network.irc.raw("AWAY");
 	}
 
-	network.irc.raw("AWAY");
+	network.awayMessage = reason;
 };

--- a/src/plugins/irc-events/connection.js
+++ b/src/plugins/irc-events/connection.js
@@ -1,5 +1,6 @@
 "use strict";
 
+var _ = require("lodash");
 var Msg = require("../../models/msg");
 var Chan = require("../../models/chan");
 var Helper = require("../../helper");
@@ -16,6 +17,14 @@ module.exports = function(irc, network) {
 			network.channels[0].pushMessage(client, new Msg({
 				text: "Enabled capabilities: " + network.irc.network.cap.enabled.join(", ")
 			}), true);
+		}
+
+		// Always restore away message for this network
+		if (network.awayMessage) {
+			irc.raw("AWAY", network.awayMessage);
+		// Only set generic away message if there are no clients attached
+		} else if (client.awayMessage && _.size(client.attachedClients) === 0) {
+			irc.raw("AWAY", client.awayMessage);
 		}
 
 		var delay = 1000;

--- a/test/models/network.js
+++ b/test/models/network.js
@@ -10,6 +10,7 @@ describe("Network", function() {
 	describe("#export()", function() {
 		it("should produce an valid object", function() {
 			var network = new Network({
+				awayMessage: "I am away",
 				name: "networkName",
 				channels: [
 					new Chan({name: "#thelounge"}),
@@ -21,6 +22,7 @@ describe("Network", function() {
 			network.setNick("chillin`");
 
 			expect(network.export()).to.deep.equal({
+				awayMessage: "I am away",
 				name: "networkName",
 				host: "",
 				port: 6667,


### PR DESCRIPTION
2 issues:
- [x] Setting away message to empty should disable auto-away (and disable by default?)
- [x] Should keep in mind away message set by using /away command. However this is not blocking issue for this PR.

Auto away is useful for people that use lounge along with Znc as it has checks for away clients.