### PR TITLE
Make user autoload more transparent in the app

### DIFF
--- a/defaults/config.js
+++ b/defaults/config.js
@@ -56,17 +56,6 @@ module.exports = {
 	theme: "themes/example.css",
 
 	//
-	// Autoload users
-	//
-	// When this setting is enabled, your 'users/' folder will be monitored. This is useful
-	// if you want to add/remove users while the server is running.
-	//
-	// @type     boolean
-	// @default  true
-	//
-	autoload: true,
-
-	//
 	// Prefetch URLs
 	//
 	// If enabled, The Lounge will try to load thumbnails and site descriptions from

--- a/src/client.js
+++ b/src/client.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var _ = require("lodash");
+var colors = require("colors/safe");
 var pkg = require("../package.json");
 var Chan = require("./models/chan");
 var crypto = require("crypto");
@@ -89,7 +90,7 @@ function Client(manager, name, config) {
 	});
 
 	if (client.name) {
-		log.info("User '" + client.name + "' loaded");
+		log.info(`User ${colors.bold(client.name)} loaded`);
 	}
 }
 

--- a/src/clientManager.js
+++ b/src/clientManager.js
@@ -26,11 +26,26 @@ ClientManager.prototype.findClient = function(name, token) {
 	return false;
 };
 
-ClientManager.prototype.loadUsers = function() {
-	var users = this.getUsers();
-	for (var i in users) {
-		this.loadUser(users[i]);
-	}
+ClientManager.prototype.autoloadUsers = function() {
+	this.getUsers().forEach(name => this.loadUser(name));
+
+	fs.watch(Helper.USERS_PATH, _.debounce(() => {
+		const loaded = this.clients.map(c => c.name);
+		const updatedUsers = this.getUsers();
+
+		// New users created since last time users were loaded
+		_.difference(updatedUsers, loaded).forEach(name => this.loadUser(name));
+
+		// Existing users removed since last time users were loaded
+		_.difference(loaded, updatedUsers).forEach(name => {
+			const client = _.find(this.clients, {name: name});
+			if (client) {
+				client.quit();
+				this.clients = _.without(this.clients, client);
+				log.info("User '" + name + "' disconnected");
+			}
+		});
+	}, 1000, {maxWait: 10000}));
 };
 
 ClientManager.prototype.loadUser = function(name) {
@@ -144,28 +159,4 @@ ClientManager.prototype.removeUser = function(name) {
 		throw e;
 	}
 	return true;
-};
-
-ClientManager.prototype.autoload = function() {
-	var self = this;
-
-	fs.watch(Helper.USERS_PATH, _.debounce(() => {
-		var loaded = self.clients.map(c => c.name);
-		var added = _.difference(self.getUsers(), loaded);
-		added.forEach(name => self.loadUser(name));
-
-		var removed = _.difference(loaded, self.getUsers());
-		removed.forEach(name => {
-			var client = _.find(
-				self.clients, {
-					name: name
-				}
-			);
-			if (client) {
-				client.quit();
-				self.clients = _.without(self.clients, client);
-				log.info("User '" + name + "' disconnected");
-			}
-		});
-	}, 1000, {maxWait: 10000}));
 };

--- a/src/clientManager.js
+++ b/src/clientManager.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var _ = require("lodash");
+var colors = require("colors/safe");
 var fs = require("fs");
 var Client = require("./client");
 var Helper = require("./helper");
@@ -42,7 +43,7 @@ ClientManager.prototype.autoloadUsers = function() {
 			if (client) {
 				client.quit();
 				this.clients = _.without(this.clients, client);
-				log.info("User '" + name + "' disconnected");
+				log.info(`User ${colors.bold(name)} disconnected and removed`);
 			}
 		});
 	}, 1000, {maxWait: 10000}));

--- a/src/server.js
+++ b/src/server.js
@@ -88,10 +88,11 @@ in ${config.public ? "public" : "private"} mode`);
 	log.info(`Press Ctrl-C to stop\n`);
 
 	if (!config.public) {
-		manager.loadUsers();
-		if (config.autoload) {
-			manager.autoload();
+		if ("autoload" in config) {
+			log.warn(`Autoloading users is now always enabled. Please remove the ${colors.yellow("autoload")} option from your configuration file.`);
 		}
+
+		manager.autoloadUsers();
 	}
 };
 


### PR DESCRIPTION
This is really possible because @xPaw provided a really nice and natural way to watch user config files in #751, so there is now no need to be cheap about it (it used to be run every second, possibly why it could be disabled via settings?).

Similarly, we don't provide a setting for reconnecting to an IRC server, for letting users logged in after a server restart, etc. all of which have been added since the fork.

I also slightly improved the console logs:

Before | After
--- | ---
<img width="400" alt="screen shot 2016-12-07 at 00 59 49" src="https://cloud.githubusercontent.com/assets/113730/20956857/817c3a40-bc1a-11e6-8705-81c391a73c56.png"> | <img width="481" alt="screen shot 2016-12-07 at 01 02 10" src="https://cloud.githubusercontent.com/assets/113730/20956862/8506fd3a-bc1a-11e6-8249-873303faaa31.png">
