### PR TITLE
Fix wrong order between screenshot and badges on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,4 @@
 # The Lounge
-<p align="center">
-	<img src="https://cloud.githubusercontent.com/assets/5481612/19623041/9bbaec40-9888-11e6-9961-8f3e0493ba30.png" width="550" />
-</p>
 
 [![#thelounge IRC channel on freenode](https://img.shields.io/badge/freenode-%23thelounge-BA68C8.svg)](https://avatar.playat.ch:1000/)
 [![npm version](https://img.shields.io/npm/v/thelounge.svg)](https://www.npmjs.org/package/thelounge)
@@ -36,6 +33,10 @@ project forked it under a new name: “The Lounge”.
 This fork aims to be community managed, meaning that the decisions are taken
 in a collegial fashion, and that a bunch of maintainers should be able to make
 the review process quicker and more streamlined.
+
+<p align="center">
+	<img src="https://cloud.githubusercontent.com/assets/5481612/19623041/9bbaec40-9888-11e6-9961-8f3e0493ba30.png" width="550">
+</p>
 
 ## Installation and usage
 


### PR DESCRIPTION
Branch for #694 was not exactly up-to-date with `master` when merged, and badges were moved below the title in #713, so we missed that at review time.

### Results

Before | After
--- | ---
<img width="1002" alt="screen shot 2016-12-09 at 00 45 30" src="https://cloud.githubusercontent.com/assets/113730/21039146/ab351bb4-bda9-11e6-875a-7b0fb879f718.png"> | <img width="998" alt="screen shot 2016-12-09 at 00 48 37" src="https://cloud.githubusercontent.com/assets/113730/21039148/aeaa0aa2-bda9-11e6-8900-af45275417cb.png">
