### PR TITLE
Use correct channel when pushing link prefetch messages

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -24,7 +24,6 @@ var events = [
 	"mode",
 	"motd",
 	"message",
-	"link",
 	"names",
 	"nick",
 	"part",

--- a/src/plugins/irc-events/message.js
+++ b/src/plugins/irc-events/message.js
@@ -1,7 +1,8 @@
 "use strict";
 
-var Chan = require("../../models/chan");
-var Msg = require("../../models/msg");
+const Chan = require("../../models/chan");
+const Msg = require("../../models/msg");
+const LinkPrefetch = require("./link");
 
 module.exports = function(irc, network) {
 	var client = this;
@@ -89,5 +90,7 @@ module.exports = function(irc, network) {
 			highlight: highlight
 		});
 		chan.pushMessage(client, msg, !self);
+
+		LinkPrefetch(client, chan, msg);
 	}
 };

--- a/test/plugins/link.js
+++ b/test/plugins/link.js
@@ -21,14 +21,14 @@ describe("Link plugin", function() {
 	});
 
 	it("should be able to fetch basic information about URLs", function(done) {
-		link.call(this.irc, this.irc, this.network);
+		let message = this.irc.createMessage({
+			text: "http://localhost:9002/basic"
+		});
+
+		link(this.irc, this.network.channels[0], message);
 
 		this.app.get("/basic", function(req, res) {
 			res.send("<title>test</title>");
-		});
-
-		this.irc.createMessage({
-			message: "http://localhost:9002/basic"
 		});
 
 		this.irc.once("toggle", function(data) {

--- a/test/util.js
+++ b/test/util.js
@@ -18,12 +18,12 @@ util.inherits(MockClient, EventEmitter);
 
 MockClient.prototype.createMessage = function(opts) {
 	var message = _.extend({
-		message: "dummy message",
+		text: "dummy message",
 		nick: "test-user",
 		target: "#test-channel"
 	}, opts);
 
-	this.emit("privmsg", message);
+	return message;
 };
 
 module.exports = {


### PR DESCRIPTION
Fixes #781 by using the same code flow as the channel messages themselves, instead of assuming the wrong target.