### PR TITLE
Stop refreshing the page on every socket.io error

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1302,6 +1302,7 @@ button {
 	-webkit-flex: 0 0 auto;
 	flex: 0 0 auto;
 	padding: 5px;
+	position: relative;
 }
 
 #windows #form .input {
@@ -1315,6 +1316,27 @@ button {
 	display: flex;
 	-webkit-align-items: flex-end;
 	align-items: flex-end;
+}
+
+#connection-error {
+	display: none;
+	align-items: center;
+	justify-content: center;
+	line-height: 1;
+	background: #f44336;
+	color: #fff;
+	position: absolute;
+	width: 100%;
+	height: 100%;
+	top: 0;
+	left: 0;
+	padding: 5px;
+	z-index: 30;
+	cursor: pointer;
+}
+
+#connection-error.shown {
+	display: flex;
 }
 
 [contenteditable]:focus {

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1302,7 +1302,6 @@ button {
 	-webkit-flex: 0 0 auto;
 	flex: 0 0 auto;
 	padding: 5px;
-	position: relative;
 }
 
 #windows #form .input {
@@ -1320,23 +1319,10 @@ button {
 
 #connection-error {
 	display: none;
-	align-items: center;
-	justify-content: center;
-	line-height: 1;
-	background: #f44336;
-	color: #fff;
-	position: absolute;
-	width: 100%;
-	height: 100%;
-	top: 0;
-	left: 0;
-	padding: 5px;
-	z-index: 30;
-	cursor: pointer;
 }
 
 #connection-error.shown {
-	display: flex;
+	display: block;
 }
 
 [contenteditable]:focus {

--- a/client/index.html
+++ b/client/index.html
@@ -58,6 +58,7 @@
 				<div id="chat-container" class="window">
 					<div id="chat"></div>
 					<form id="form" method="post" action="">
+						<div id="connection-error"><span>Client connection lost. Click to reconnect.</span></div>
 						<div class="input">
 							<span id="nick">
 								<span id="nick-value" spellcheck="false"></span><!-- Comments here remove spaces between elements

--- a/client/index.html
+++ b/client/index.html
@@ -57,8 +57,8 @@
 				</div>
 				<div id="chat-container" class="window">
 					<div id="chat"></div>
+					<button id="connection-error" class="btn btn-reconnect">Client connection lost &mdash; Click here to reconnect</button>
 					<form id="form" method="post" action="">
-						<div id="connection-error"><span>Client connection lost. Click to reconnect.</span></div>
 						<div class="input">
 							<span id="nick">
 								<span id="nick-value" spellcheck="false"></span><!-- Comments here remove spaces between elements

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -89,6 +89,18 @@ $(function() {
 				window.location.reload();
 			});
 
+			// Disables sending a message by pressing Enter. `off` is necessary to
+			// cancel `inputhistory`, which overrides hitting Enter. `on` is then
+			// necessary to avoid creating new lines when hitting Enter without Shift.
+			// This is fairly hacky but this solution is not permanent.
+			$("#input").off("keydown").on("keydown", function(event) {
+				if (event.which === 13 && !event.shiftKey) {
+					event.preventDefault();
+				}
+			});
+			// Hides the "Send Message" button
+			$("#submit").remove();
+
 			console.error(data);
 		});
 	});

--- a/client/themes/crypto.css
+++ b/client/themes/crypto.css
@@ -58,6 +58,14 @@ a:hover,
 	background: #00ff0e;
 }
 
+.btn-reconnect {
+	background: #f00;
+	color: #fff;
+	border: 0;
+	border-radius: 0;
+	margin: 0;
+}
+
 #settings .opt {
 	line-height: 20px;
 	font-size: 12px;

--- a/client/themes/example.css
+++ b/client/themes/example.css
@@ -46,6 +46,14 @@ body {
 	border-radius: 2px;
 }
 
+.btn-reconnect {
+	background: #e74c3c;
+	color: #fff;
+	border: 0;
+	border-radius: 0;
+	margin: 0;
+}
+
 @media (max-width: 768px) {
 	#sidebar {
 		left: -220px;

--- a/client/themes/morning.css
+++ b/client/themes/morning.css
@@ -227,3 +227,11 @@ body {
 #chat .toggle-content .body {
 	color: #99a2b4;
 }
+
+.btn-reconnect {
+	background: #e74c3c;
+	color: #fff;
+	border: 0;
+	border-radius: 0;
+	margin: 0;
+}

--- a/client/themes/zenburn.css
+++ b/client/themes/zenburn.css
@@ -253,3 +253,11 @@ body {
 #chat .toggle-content .body {
 	color: #d2d39b;
 }
+
+.btn-reconnect {
+	background: #e74c3c;
+	color: #fff;
+	border: 0;
+	border-radius: 0;
+	margin: 0;
+}


### PR DESCRIPTION
Partial fix for #421 to allow users to read messages and whatnot after the initial page load. From my own experience this is much more desired than instantly reloading the page and hitting a network error page instead. This PR does not introduce reconnections as that would require a lot more changes.

![10-093226601](https://cloud.githubusercontent.com/assets/613331/21072472/bf21ff9c-becc-11e6-8262-466f52ab70d0.png)
