### PR TITLE
Simplify introduction on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,36 +7,15 @@
 [![Dependencies Status](https://img.shields.io/david/thelounge/lounge.svg)](https://david-dm.org/thelounge/lounge)
 [![Developer Dependencies Status](https://img.shields.io/david/dev/thelounge/lounge.svg)](https://david-dm.org/thelounge/lounge?type=dev)
 
-__What is it?__
+The Lounge is a modern web IRC client designed for self-hosting.
 
-The Lounge is a web IRC client that you host on your own server.
-
-*This is the official, community-managed fork of @erming's great initiative, the [Shout](https://github.com/erming/shout) project.*
-
-__What features does it have?__
-
-- Multiple user support
-- Stays connected even when you close the browser
-- Connect from multiple devices at once
-- Responsive layout — works well on your smartphone
-- _.. and more!_
-
-__Why the fork?__
-
-We felt that the original [Shout](https://github.com/erming/shout) project
-"stagnated" a little because its original author wanted it to remain his pet
-project (which is a perfectly fine thing!).
-
-A bunch of people, excited about doing things a bit differently than the upstream
-project forked it under a new name: “The Lounge”.
-
-This fork aims to be community managed, meaning that the decisions are taken
-in a collegial fashion, and that a bunch of maintainers should be able to make
-the review process quicker and more streamlined.
+To learn more about configuration, usage and features of The Lounge, take a look at [the website](https://thelounge.github.io).
 
 <p align="center">
 	<img src="https://cloud.githubusercontent.com/assets/5481612/19623041/9bbaec40-9888-11e6-9961-8f3e0493ba30.png" width="550">
 </p>
+
+The Lounge is the official and community-managed fork of [Shout](https://github.com/erming/shout), by [Mattias Erming](https://github.com/erming).
 
 ## Installation and usage
 


### PR DESCRIPTION
Features listed here are the same as on Shout repo, in same order, participating to the feeling of fork with nothing new. Instead of listing features here, we should refer to the website and improve it to make it as current as possible (there was some recent action there, and more coming, so it is reasonable to point there).

Also, this "Why the fork?" section was useful right when we forked, but now it gives unnecessary and lengthy information (it is now the most verbose section of the README!). The Lounge has enough momentum as that point to be treated as its own project.

Finally, shortening this section moves the screenshot back up on the page, and mobile view now has more context in the description.

Before | After
--- | ---
<img width="800" alt="screen shot 2016-12-11 at 04 16 18" src="https://cloud.githubusercontent.com/assets/113730/21079209/a4cc2a96-bf58-11e6-966f-fcef1aa1f8ca.png"> | <img width="798" alt="screen shot 2016-12-11 at 04 16 04" src="https://cloud.githubusercontent.com/assets/113730/21079212/a833461a-bf58-11e6-9ce3-a9b5492926d1.png">
