### PR TITLE
Add colon to first param in unhandled template, closes #797

### DIFF
--- a/client/views/msg_unhandled.tpl
+++ b/client/views/msg_unhandled.tpl
@@ -5,7 +5,9 @@
 	<span class="from">[{{command}}]</span>
 	<span class="text">
 		{{#each params}}
-			<span>{{this}}</span>
+			<span>
+				{{this}}{{#equal ../command "421"}}{{#if @first}}:{{/if}}{{/equal}}
+			</span>
 		{{/each}}
 	</span>
 </div>


### PR DESCRIPTION
![image](https://i.imgur.com/Lxk8Png.png) 

becomes

![image](https://i.imgur.com/Rkv5Piy.png)

The capitalization difference is due to the server, not the PR. Only effects unknown commands.