### PR TITLE
Add Node.js v7, current stable, to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
-- 6
-- 4
+- 7 # Current stable
+- 6 # Active LTS until 2018-04-18
+- 4 # Active LTS until 2017-04-01
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
We are seeing more and more people installing on Node v7 so it's important to ensure `npm install` will pass correctly and our (limited but growing) test suite as well.

This was previously attempted in #752 but I am re-opening this as I think we should make sure everything works fine with both LTS + current stable version. Overhead of a third version on Travis CI is inexistent so no optimization needed here.