### PR TITLE
Add slug with command to unhandled messages

### DIFF
--- a/client/js/libs/handlebars/slugify.js
+++ b/client/js/libs/handlebars/slugify.js
@@ -1,0 +1,5 @@
+"use strict";
+
+module.exports = function(orig) {
+	return orig.toLowerCase().replace(/[^a-z0-9]/, "-");
+};

--- a/client/views/chan.tpl
+++ b/client/views/chan.tpl
@@ -1,5 +1,5 @@
 {{#each channels}}
-<div data-id="{{id}}" data-target="#chan-{{id}}" data-title="{{name}}" class="chan {{type}}">
+<div data-id="{{id}}" data-target="#chan-{{id}}" data-title="{{name}}" class="chan {{type}} chan-{{slugify name}}">
 	<span class="badge{{#if highlight}} highlight{{/if}}">{{#if unread}}{{roundBadgeNumber unread}}{{/if}}</span>
 	<button class="close" aria-label="Close"></button>
 	<span class="name" title="{{name}}">{{name}}</span>

--- a/client/views/msg_unhandled.tpl
+++ b/client/views/msg_unhandled.tpl
@@ -1,4 +1,4 @@
-<div class="msg {{type}}{{#if self}} self{{/if}}{{#if highlight}} highlight{{/if}}" data-time="{{time}}">
+<div class="msg msg-{{slugify command}} {{type}}{{#if self}} self{{/if}}{{#if highlight}} highlight{{/if}}" data-time="{{time}}">
 	<span class="time tooltipped tooltipped-e" aria-label="{{localetime time}}">
 		{{tz time}}
 	</span>

--- a/client/views/network.tpl
+++ b/client/views/network.tpl
@@ -1,5 +1,5 @@
 {{#each networks}}
-<section id="network-{{id}}" class="network" data-id="{{id}}" data-nick="{{nick}}" data-options="{{tojson serverOptions}}">
+<section id="network-{{id}}" class="network name-{{slugify name}} network-{{slugify serverOptions.NETWORK}}" data-id="{{id}}" data-nick="{{nick}}" data-options="{{tojson serverOptions}}">
 	{{> chan}}
 </section>
 {{/each}}

--- a/src/models/network.js
+++ b/src/models/network.js
@@ -25,6 +25,7 @@ function Network(attr) {
 		irc: null,
 		serverOptions: {
 			PREFIX: [],
+			NETWORK: "",
 		},
 		chanCache: [],
 	});

--- a/src/plugins/irc-events/connection.js
+++ b/src/plugins/irc-events/connection.js
@@ -120,7 +120,7 @@ module.exports = function(irc, network) {
 	});
 
 	irc.on("server options", function(data) {
-		if (network.serverOptions.PREFIX === data.options.PREFIX) {
+		if (network.serverOptions.PREFIX === data.options.PREFIX && network.serverOptions.NETWORK === data.options.NETWORK) {
 			return;
 		}
 
@@ -131,6 +131,7 @@ module.exports = function(irc, network) {
 		});
 
 		network.serverOptions.PREFIX = data.options.PREFIX;
+		network.serverOptions.NETWORK = data.options.NETWORK;
 
 		client.emit("network_changed", {
 			network: network.id,


### PR DESCRIPTION
This PR implements #814, essentially adding a class like `msg-002` to all `unhandled` messages. This allows themes to treat those messages specially (when otherwise, all they could say was "that message is an unhandled message".

Looks like this:

![lounge-unhandled](https://cloud.githubusercontent.com/assets/251281/21292889/5eb02046-c55f-11e6-93a3-4ca26e0628a4.PNG)
