### PR TITLE
Seconds-to-human-readable-range Handlebars helper and tests

### DIFF
--- a/client/js/libs/handlebars/humanReadableRange.js
+++ b/client/js/libs/handlebars/humanReadableRange.js
@@ -1,0 +1,47 @@
+"use strict";
+
+Handlebars.registerHelper(
+	"humanReadableRange", function(seconds) {
+		var plural = function(number) {
+			return (number === 1) ? "" : "s";
+		};
+
+		if (seconds === 0) {
+			return "0 seconds";
+		}
+
+		var result = [];
+
+		var weeks = Math.floor(seconds / 604800);
+		if (weeks) {
+			result.push(weeks + " week" + plural(weeks));
+		}
+
+		var days = Math.floor((seconds %= 604800) / 86400);
+		if (days) {
+			result.push(days + " day" + plural(days));
+		}
+
+		var hours = Math.floor((seconds %= 86400) / 3600);
+		if (hours) {
+			result.push(hours + " hour" + plural(hours));
+		}
+
+		var minutes = Math.floor((seconds %= 3600) / 60);
+		if (minutes) {
+			result.push(minutes + " minute" + plural(minutes));
+		}
+
+		var remainingSeconds = seconds % 60;
+		if (remainingSeconds) {
+			result.push(remainingSeconds + " second" + plural(remainingSeconds));
+		}
+
+		var lastItem = result.pop();
+
+		if (result.length > 0) {
+			return result.join(", ") + " and " + lastItem;
+		}
+		return lastItem;
+	}
+);

--- a/client/views/actions/whois.tpl
+++ b/client/views/actions/whois.tpl
@@ -33,3 +33,9 @@
 	is away <i>({{whois.away}})</i>
 </div>
 {{/if}}
+{{#if whois.idle}}
+<div>
+	<span role="button" class="user {{colorClass whois.nick}}" data-name="{{whois.nick}}">{{whois.nick}}</span>
+	has been idle for {{humanReadableRange whois.idle}}.
+</div>
+{{/if}}

--- a/test/client/js/libs/handlebars/humanReadableRangeTest.js
+++ b/test/client/js/libs/handlebars/humanReadableRangeTest.js
@@ -1,0 +1,28 @@
+"use strict";
+
+const Handlebars = global.Handlebars = require("handlebars");
+const expect = require("chai").expect;
+
+require("../../../../../client/js/libs/handlebars/humanReadableRange");
+
+describe("humanReadableRange Handlebars helper", () => {
+	const template = Handlebars.compile("{{humanReadableRange range}}");
+
+	it("should build a simple range", () => {
+		expect(template({range: 30})).to.equal("30 seconds");
+	});
+
+	it("should not display zero values", () => {
+		expect(template({range: 86400 * 3 + 120})).to.equal("3 days and 2 minutes");
+	});
+
+	it("should pluralize things properly", () => {
+		expect(template({range: 3600})).to.equal("1 hour");
+		expect(template({range: 3600 * 2})).to.equal("2 hours");
+	});
+
+	it("should use commas and 'and' in complex expressions", () => {
+		expect(template({range: 604800 + 86400 + 3600 + 60 + 1}))
+			.to.equal("1 week, 1 day, 1 hour, 1 minute and 1 second");
+	});
+});


### PR DESCRIPTION
This is something I did in #721 but ended up canceling for a different approach. Moved it here for archiving purposes as it will never make it to the git history.
If code and/or tests are ever any useful, this is my shot at keeping it written down somewhere.

Result of this was:

<img width="391" alt="screen shot 2016-10-27 at 01 27 29" src="https://cloud.githubusercontent.com/assets/113730/19755516/90087b24-9be4-11e6-9d27-3173a376cc90.png">
<img width="419" alt="screen shot 2016-10-27 at 01 28 10" src="https://cloud.githubusercontent.com/assets/113730/19755540/a7cc9cf4-9be4-11e6-8a6d-a8aae0aed9f5.png">
