### PR TITLE
Use away-notify to show updates on users away state

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -208,6 +208,8 @@ kbd {
 #settings .extra-help,
 #settings #play::before,
 #form #submit::before,
+#chat .away .from::before,
+#chat .back .from::before,
 #chat .invite .from::before,
 #chat .join .from::before,
 #chat .kick .from::before,
@@ -257,6 +259,12 @@ kbd {
 #footer .sign-out::before { content: "\f011"; /* http://fontawesome.io/icon/power-off/ */ }
 
 #form #submit::before { content: "\f1d8"; /* http://fontawesome.io/icon/paper-plane/ */ }
+
+#chat .away .from::before,
+#chat .back .from::before {
+	content: "\f017"; /* http://fontawesome.io/icon/clock-o/ */
+	color: #7f8c8d;
+}
 
 #chat .invite .from::before {
 	content: "\f003"; /* http://fontawesome.io/icon/envelope-o/ */
@@ -1157,6 +1165,8 @@ kbd {
 }
 
 #chat .condensed .content,
+#chat .away .content,
+#chat .back .content,
 #chat .join .content,
 #chat .kick .content,
 #chat .mode .content,

--- a/client/index.html
+++ b/client/index.html
@@ -225,8 +225,8 @@
 							<div class="col-sm-12">
 								<h2>
 									Status messages
-									<span class="tooltipped tooltipped-n tooltipped-no-delay" aria-label="Joins, parts, kicks, nick changes, and mode changes">
-										<button class="extra-help" aria-label="Joins, parts, kicks, nick changes, and mode changes"></button>
+									<span class="tooltipped tooltipped-n tooltipped-no-delay" aria-label="Joins, parts, kicks, nick changes, away changes, and mode changes">
+										<button class="extra-help" aria-label="Joins, parts, kicks, nick changes, away changes, and mode changes"></button>
 									</span>
 								</h2>
 							</div>

--- a/client/js/condensed.js
+++ b/client/js/condensed.js
@@ -23,6 +23,12 @@ function updateText(condensed, addedTypes) {
 	constants.condensedTypes.forEach((type) => {
 		if (obj[type]) {
 			switch (type) {
+			case "away":
+				strings.push(obj[type] + (obj[type] > 1 ? " users have gone away" : " user has gone away"));
+				break;
+			case "back":
+				strings.push(obj[type] + (obj[type] > 1 ? " users have come back" : " user has come back"));
+				break;
 			case "join":
 				strings.push(obj[type] + (obj[type] > 1 ? " users have joined the channel" : " user has joined the channel"));
 				break;

--- a/client/js/constants.js
+++ b/client/js/constants.js
@@ -60,6 +60,8 @@ const commands = [
 ];
 
 const actionTypes = [
+	"away",
+	"back",
 	"ban_list",
 	"invite",
 	"join",
@@ -77,6 +79,8 @@ const actionTypes = [
 ];
 
 const condensedTypes = [
+	"away",
+	"back",
 	"join",
 	"part",
 	"quit",

--- a/client/views/actions/away.tpl
+++ b/client/views/actions/away.tpl
@@ -1,0 +1,3 @@
+{{> ../user_name nick=from}}
+is away
+<i class="away-message">({{{parse text}}})</i>

--- a/client/views/actions/back.tpl
+++ b/client/views/actions/back.tpl
@@ -1,0 +1,2 @@
+{{> ../user_name nick=from}}
+is back

--- a/client/views/index.js
+++ b/client/views/index.js
@@ -3,6 +3,8 @@
 module.exports = {
 	actions: {
 		action: require("./actions/action.tpl"),
+		away: require("./actions/away.tpl"),
+		back: require("./actions/back.tpl"),
 		ban_list: require("./actions/ban_list.tpl"),
 		channel_list: require("./actions/channel_list.tpl"),
 		ctcp: require("./actions/ctcp.tpl"),

--- a/src/client.js
+++ b/src/client.js
@@ -16,6 +16,7 @@ module.exports = Client;
 
 var id = 0;
 var events = [
+	"away",
 	"connection",
 	"unhandled",
 	"banlist",

--- a/src/models/msg.js
+++ b/src/models/msg.js
@@ -29,7 +29,9 @@ class Msg {
 
 Msg.Type = {
 	UNHANDLED: "unhandled",
+	AWAY: "away",
 	ACTION: "action",
+	BACK: "back",
 	ERROR: "error",
 	INVITE: "invite",
 	JOIN: "join",

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -7,6 +7,7 @@ module.exports = User;
 function User(attr, prefixLookup) {
 	_.defaults(this, attr, {
 		modes: [],
+		away: "",
 		mode: "",
 		nick: "",
 		lastMessage: 0,

--- a/src/plugins/irc-events/away.js
+++ b/src/plugins/irc-events/away.js
@@ -1,0 +1,30 @@
+"use strict";
+
+const _ = require("lodash");
+const Msg = require("../../models/msg");
+
+module.exports = function(irc, network) {
+	const client = this;
+	irc.on("away", (data) => {
+		const away = data.message;
+
+		network.channels.forEach((chan) => {
+			const user = _.find(chan.users, {nick: data.nick});
+
+			if (!user || user.away === away) {
+				return;
+			}
+
+			const msg = new Msg({
+				type: away ? Msg.Type.AWAY : Msg.Type.BACK,
+				text: away || "",
+				time: data.time,
+				from: data.nick,
+				mode: user.mode
+			});
+
+			chan.pushMessage(client, msg);
+			user.away = away;
+		});
+	});
+};


### PR DESCRIPTION
Probably need better wording for the settings option. Handles duplicate states (i.e. if someone goes away multiple times in a row it will only be shown once).

![image](https://i.imgur.com/X6hKkWg.png)