### PR TITLE
Implement fuzzy-matching for the user list

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1219,6 +1219,10 @@ kbd {
 	content: "Users";
 }
 
+#chat .user-mode-search:before {
+	content: "Search Results";
+}
+
 #loading {
 	font-size: 14px;
 	z-index: 1;

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -768,6 +768,9 @@ kbd {
 	overflow: auto;
 	-webkit-overflow-scrolling: touch;
 	position: absolute;
+}
+
+#chat .channel .chat {
 	right: 180px;
 }
 
@@ -789,18 +792,6 @@ kbd {
 	transition: all .4s;
 	-webkit-transform: translateZ(0);
 	transform: translateZ(0);
-}
-
-#chat .lobby .chat,
-#chat .special .chat,
-#chat .query .chat {
-	right: 0;
-}
-
-#chat .lobby .sidebar,
-#chat .special .sidebar,
-#chat .query .sidebar {
-	display: none;
 }
 
 #chat .show-more {
@@ -1178,6 +1169,10 @@ kbd {
 	position: absolute;
 	top: 48px;
 	width: 100%;
+}
+
+#chat .names-filtered {
+	display: none;
 }
 
 #chat .names .user {

--- a/client/js/libs/handlebars/users.js
+++ b/client/js/libs/handlebars/users.js
@@ -1,5 +1,0 @@
-"use strict";
-
-module.exports = function(count) {
-	return count + " " + (count === 1 ? "user" : "users");
-};

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -1068,7 +1068,7 @@ $(function() {
 	});
 
 	chat.on("input", ".search", function() {
-		const value = $(this).val().toLowerCase();
+		const value = $(this).val();
 		const names = $(this).closest(".users").find(".names");
 
 		names.find(".user").each((i, el) => {
@@ -1078,7 +1078,7 @@ $(function() {
 		const fuzzyOptions = {
 			pre: "<b>",
 			post: "</b>",
-			extract: el => $(el).text().toLowerCase().replace(/[+%@~]/, "")
+			extract: el => $(el).text()
 		};
 
 		fuzzy.filter(
@@ -1086,8 +1086,7 @@ $(function() {
 			names.find(".user").toArray(),
 			fuzzyOptions
 		).forEach(el => {
-			const firstChar = $(el.original).text()[0].replace(/[^+%@~]/, "");
-			$(el.original).html(firstChar + el.string).show();
+			$(el.original).html(el.string).show();
 		});
 	});
 

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -1069,11 +1069,15 @@ $(function() {
 
 	chat.on("input", ".search", function() {
 		const value = $(this).val();
-		const names = $(this).closest(".users").find(".names");
+		const parent = $(this).closest(".users");
+		const names = parent.find(".names-original");
+		const container = parent.find(".names-filtered");
 
-		names.find(".user").each((i, el) => {
-			$(el).text($(el).text().replace(/<\/?b>;/, "")).hide();
-		});
+		if (!value.length) {
+			container.hide();
+			names.show();
+			return;
+		}
 
 		const fuzzyOptions = {
 			pre: "<b>",
@@ -1081,13 +1085,14 @@ $(function() {
 			extract: el => $(el).text()
 		};
 
-		fuzzy.filter(
+		const result = fuzzy.filter(
 			value,
 			names.find(".user").toArray(),
 			fuzzyOptions
-		).forEach(el => {
-			$(el.original).html(el.string).show();
-		});
+		);
+
+		names.hide();
+		container.html(templates.user_filtered({matches: result})).show();
 	});
 
 	chat.on("msg", ".messages", function(e, target, msg) {

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -258,7 +258,10 @@ $(function() {
 
 	function renderChannel(data) {
 		renderChannelMessages(data);
-		renderChannelUsers(data);
+
+		if (data.type === "channel") {
+			renderChannelUsers(data);
+		}
 	}
 
 	function renderChannelMessages(data) {
@@ -318,7 +321,19 @@ $(function() {
 			return (oldSortOrder[a] || Number.MAX_VALUE) - (oldSortOrder[b] || Number.MAX_VALUE);
 		});
 
-		users.html(templates.user(data)).data("nicks", nicks);
+		const search = users
+			.find(".search")
+			.attr("placeholder", nicks.length + " " + (nicks.length === 1 ? "user" : "users"));
+
+		users
+			.find(".names-original")
+			.html(templates.user(data))
+			.data("nicks", nicks);
+
+		// Refresh user search
+		if (search.val().length) {
+			search.trigger("input");
+		}
 	}
 
 	function renderNetworks(data) {

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -6,6 +6,7 @@ const $ = require("jquery");
 const moment = require("moment");
 const Mousetrap = require("mousetrap");
 const URI = require("urijs");
+const fuzzy = require("fuzzy");
 
 // our libraries
 require("./libs/jquery/inputhistory");
@@ -1067,16 +1068,26 @@ $(function() {
 	});
 
 	chat.on("input", ".search", function() {
-		var value = $(this).val().toLowerCase();
-		var names = $(this).closest(".users").find(".names");
-		names.find(".user").each(function() {
-			var btn = $(this);
-			var name = btn.text().toLowerCase().replace(/[+%@~]/, "");
-			if (name.indexOf(value) > -1) {
-				btn.show();
-			} else {
-				btn.hide();
-			}
+		const value = $(this).val().toLowerCase();
+		const names = $(this).closest(".users").find(".names");
+
+		names.find(".user").each((i, el) => {
+			$(el).text($(el).text().replace(/<\/?b>;/, "")).hide();
+		});
+
+		const fuzzyOptions = {
+			pre: "<b>",
+			post: "</b>",
+			extract: el => $(el).text().toLowerCase().replace(/[+%@~]/, "")
+		};
+
+		fuzzy.filter(
+			value,
+			names.find(".user").toArray(),
+			fuzzyOptions
+		).forEach(el => {
+			const firstChar = $(el.original).text()[0].replace(/[^+%@~]/, "");
+			$(el.original).html(firstChar + el.string).show();
 		});
 	});
 

--- a/client/views/chat.tpl
+++ b/client/views/chat.tpl
@@ -19,8 +19,16 @@
 		</div>
 		<div class="messages"></div>
 	</div>
+	{{#equal type "channel"}}
 	<aside class="sidebar">
-		<div class="users"></div>
+		<div class="users">
+			<div class="count">
+				<input type="search" class="search" aria-label="Search among the user list">
+			</div>
+			<div class="names names-filtered"></div>
+			<div class="names names-original"></div>
+		</div>
 	</aside>
+	{{/equal}}
 </div>
 {{/each}}

--- a/client/views/index.js
+++ b/client/views/index.js
@@ -30,4 +30,5 @@ module.exports = {
 	toggle: require("./toggle.tpl"),
 	unread_marker: require("./unread_marker.tpl"),
 	user: require("./user.tpl"),
+	user_filtered: require("./user_filtered.tpl"),
 };

--- a/client/views/user.tpl
+++ b/client/views/user.tpl
@@ -1,19 +1,11 @@
-{{#if users.length}}
-<div class="count">
-	<input class="search" placeholder="{{users users.length}}" aria-label="Search among the user list">
-</div>
-<div class="names names-filtered"></div>
-{{/if}}
-<div class="names names-original">
-	{{#diff "reset"}}{{/diff}}
-	{{#each users}}
-		{{#diff mode}}
-		{{#unless @first}}
-			</div>
-		{{/unless}}
-		<div class="user-mode {{modes mode}}">
-		{{/diff}}
-		<span role="button" class="user {{colorClass name}}" data-name="{{name}}">{{mode}}{{name}}</span>
-	{{/each}}
-	</div>
+{{#diff "reset"}}{{/diff}}
+{{#each users}}
+	{{#diff mode}}
+	{{#unless @first}}
+		</div>
+	{{/unless}}
+	<div class="user-mode {{modes mode}}">
+	{{/diff}}
+	<span role="button" class="user {{colorClass name}}" data-name="{{name}}">{{mode}}{{name}}</span>
+{{/each}}
 </div>

--- a/client/views/user.tpl
+++ b/client/views/user.tpl
@@ -2,8 +2,9 @@
 <div class="count">
 	<input class="search" placeholder="{{users users.length}}" aria-label="Search among the user list">
 </div>
+<div class="names names-filtered"></div>
 {{/if}}
-<div class="names">
+<div class="names names-original">
 	{{#diff "reset"}}{{/diff}}
 	{{#each users}}
 		{{#diff mode}}

--- a/client/views/user_filtered.tpl
+++ b/client/views/user_filtered.tpl
@@ -1,0 +1,5 @@
+<div class="user-mode user-mode-search">
+{{#each matches}}
+	<span role="button" class="{{original.className}}">{{{string}}}</span>
+{{/each}}
+</div>

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "chai": "3.5.0",
     "eslint": "3.19.0",
     "font-awesome": "4.7.0",
+    "fuzzy": "0.1.3",
     "handlebars": "4.0.6",
     "handlebars-loader": "1.5.0",
     "jquery": "3.2.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,6 +18,7 @@ let config = {
 			"mousetrap",
 			"socket.io-client",
 			"urijs",
+			"fuzzy",
 		],
 	},
 	devtool: "source-map",


### PR DESCRIPTION
I have been wishing for something like this for a while, then wanted to look at it when #851 was opened.
It is a fuzzy-finder for the user list, where matching parts of the results are being emphasized. It is the same mechanism than fuzzy-finders on GitHub, Atom, etc.

This PR is in a horrible state, partly because of recent addition of Webpack, partly because of how the user list is managed (state entirely in DOM, in a "rendered" way, i.e. mode and nick are concatenated and source data is not kept around).

I added `fuzzy.js` in this PR only because for the love of me I'm having so much trouble with Webpack! It's of course not meant to stay, but until then it's there for who wants to try. Help welcome if anyone wants to save me from my own stupidity!

## TODO

- [x] Use package from npm
- [x] Highly improve the code, ugly for now. Happy to discuss how to improve it (I personally would love to have a global state outside the DOM that gets used to render the list, but maybe I'm dreaming too much)
- [ ] Potentially improve performance. It's probably not efficient at all right now, but I didn't find any slowness on `#freenode` (1.5k users). Maybe more of an issue on mobile.
- [ ] Write tests for it. This relies on #66 so it might come later.
- [x] Have CI builds pass
- [ ] Squash commits

Note that this PR is not meant to solve other issues, such as #544.

## Result

![fuzzy_userlist](https://cloud.githubusercontent.com/assets/113730/21560282/71609e5e-ce2a-11e6-83a6-e352eea95653.gif)
