### PR TITLE
Add humans.txt file

### DIFF
--- a/client/humans.txt
+++ b/client/humans.txt
@@ -1,0 +1,19 @@
+
+/* Thanks to everyone who contributed to the lounge project! */
+
+https://github.com/thelounge/lounge/graphs/contributors
+
+
+/* Maintainers */
+
+* @astorije: UX, (future) package system, overall overview of the entire project, releases
+* @maxpoulin64 (Max-P on the IRC channel): Performance, bugs
+* @xPaw: IRC core
+* @YaManicKill: (future) package system, overall overview of the entire project
+* @MaxLeiter: In charge of maintaining the repository for the lounge-bot as well as the demo.
+* @williamboman (Impaloo on the IRC channel): Oversees the Docker container
+
+
+/* Shout */
+
+* @erming: Creator of the original Shout project.

--- a/client/index.html
+++ b/client/index.html
@@ -13,6 +13,8 @@
 
 	<title>The Lounge</title>
 
+	<link type="text/plain" rel="author" href="humans.txt" />
+
 	<link rel="stylesheet" href="css/bootstrap.css">
 	<link rel="stylesheet" href="css/style.css">
 	<link id="theme" rel="stylesheet" href="<%= theme %>">


### PR DESCRIPTION
Added a static [humans.txt](http://humanstxt.org/) file that mentions the contributors and maintainers of thelounge.
Also added an author `<link>` in index.html, pointing to this file.

Got maintainer lines from [here](https://github.com/thelounge/lounge/wiki/Maintainers'-corner#maintainers-and-responsibilities).