### PR TITLE
Un-ellipsis placeholder and use ES6 template

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -1040,7 +1040,7 @@ $(function() {
 
 		var placeholder = "";
 		if (chan.data("type") === "channel" || chan.data("type") === "query") {
-			placeholder = "Write to " + chan.data("title") + "...";
+			placeholder = `Write to ${chan.data("title")}`;
 		}
 		input.attr("placeholder", placeholder);
 


### PR DESCRIPTION
I'm not sure what I was thinking in https://github.com/thelounge/lounge/pull/832 but I am really annoyed by the looks of it in practice.
Plus that way there is a bit of extra room in case screen isn't wide enough. Very unlikely, but if it happens, that would be a few missing chars at best, so why not.

Also hey, first ES6 feature on the client right there.