### PR TITLE
hide ranks without search match #774

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -1105,13 +1105,29 @@ $(function() {
 	chat.on("input", ".search", function() {
 		var value = $(this).val().toLowerCase();
 		var names = $(this).closest(".users").find(".names");
-		names.find(".user").each(function() {
-			var btn = $(this);
-			var name = btn.text().toLowerCase().replace(/[+%@~]/, "");
-			if (name.indexOf(value) > -1) {
-				btn.show();
+		names.find(".user-mode").each(function() {
+			var namesToHide = [];
+			var userModeDiv = $(this);
+			var isDivToHide = true;
+			userModeDiv.find(".user").each(function() {
+				var btn = $(this);
+				var name = btn.text().toLowerCase().replace(/[+%@~]/, "");
+				if (name.indexOf(value) > -1) {
+					btn.show();
+					isDivToHide = false;
+				} else {
+					namesToHide.push(btn[0]);
+				}
+			});
+			if (isDivToHide) {
+				userModeDiv[0].style.display = "none";
 			} else {
-				btn.hide();
+				userModeDiv[0].style.display = "block";
+				var length = namesToHide.length;
+				var i;
+				for (i = 0; i < length; i++) {
+					namesToHide[i].style.display = "none";
+				}
 			}
 		});
 	});

--- a/src/plugins/irc-events/message.js
+++ b/src/plugins/irc-events/message.js
@@ -91,6 +91,9 @@ module.exports = function(irc, network) {
 		});
 		chan.pushMessage(client, msg, !self);
 
-		LinkPrefetch(client, chan, msg);
+		// No prefetch URLs unless are simple MESSAGE or ACTION types
+		if ([Msg.Type.MESSAGE, Msg.Type.ACTION].indexOf(data.type) !== -1) {
+			LinkPrefetch(client, chan, msg);
+		}
 	}
 };


### PR DESCRIPTION
This will hide the rank listings when no users are found to match the current search string. See issue #774 
My goal was to reduce modifications to DOM elements by hiding rank listings instead of hiding single usernames.