### PR TITLE
Change default maxHistory to 10000

### DIFF
--- a/defaults/config.js
+++ b/defaults/config.js
@@ -160,11 +160,11 @@ module.exports = {
 	//
 	// Defines the maximum number of history lines that will be kept in
 	// memory per channel/query, in order to reduce the memory usage of
-	// the server. Negative means unlimited.
+	// the server. Setting this to -1 will keep unlimited amount.
 	//
 	// @type     integer
-	// @default  -1
-	maxHistory: -1,
+	// @default  10000
+	maxHistory: 10000,
 
 	//
 	// Default values for the 'Connect' form.


### PR DESCRIPTION
We (currently?) have no reason to keep an infinite amount of messages in memory. Keeping 10k messages by default should be fine enough (100 show more button clicks).