### PR TITLE
Prompt admin for user log at user creation

### DIFF
--- a/src/clientManager.js
+++ b/src/clientManager.js
@@ -82,7 +82,7 @@ ClientManager.prototype.getUsers = function() {
 	return users;
 };
 
-ClientManager.prototype.addUser = function(name, password) {
+ClientManager.prototype.addUser = function(name, password, enableLog) {
 	var users = this.getUsers();
 	if (users.indexOf(name) !== -1) {
 		return false;
@@ -96,7 +96,7 @@ ClientManager.prototype.addUser = function(name, password) {
 		var user = {
 			user: name,
 			password: password || "",
-			log: false,
+			log: enableLog,
 			networks: []
 		};
 		fs.writeFileSync(

--- a/src/command-line/add.js
+++ b/src/command-line/add.js
@@ -24,17 +24,26 @@ program
 				return;
 			}
 			if (!err) {
-				add(manager, name, password);
+				log.prompt({
+					text: "Save logs to disk?",
+					default: "yes"
+				}, function(err2, enableLog) {
+					if (!err2) {
+						add(
+							manager,
+							name,
+							password,
+							enableLog.charAt(0).toLowerCase() === "y"
+						);
+					}
+				});
 			}
 		});
 	});
 
-function add(manager, name, password) {
+function add(manager, name, password, enableLog) {
 	var hash = Helper.password.hash(password);
-	manager.addUser(
-		name,
-		hash
-	);
+	manager.addUser(name, hash, enableLog);
 
 	log.info(`User ${colors.bold(name)} created.`);
 	log.info(`User file located at ${colors.green(Helper.getUserConfigPath(name))}.`);


### PR DESCRIPTION
I feel like more and more people are asking where to get channel logs on the IRC channel. We usually tell them to go enable the logs for individual users, but at that point it's already too late as logging was not enabled.

~~This ensures new users have logs enabled by default when using `lounge add <username>`. What do people think? I also feel this should be a prompt after asking for password (`Enable user logging? (yes)`). Happy to hear opinions.~~

This prompts admin about it, which defaults to being enabled. The prompt is rather forgiving, as `yes`, `y`, `Y`, etc. will be evaluated to `true` and everything else to `false`. It is fairly standard in CLIs to really care about the first letter when it's a yes/no type of question.