### PR TITLE
Add nyc and Webpack config files to the files ignored when releasing

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -12,8 +12,9 @@ test/
 .eslintrc.yml
 .gitattributes
 .gitignore
-.istanbul.yml
+.nycrc
 .npmignore
 .stylelintrc
 .travis.yml
 appveyor.yml
+webpack.config.js


### PR DESCRIPTION
Comparing https://unpkg.com/thelounge@2.1.0/ and https://unpkg.com/thelounge@2.2.0/, these have slipped in.

The `nyc` one can replace the `istanbul` one since #850, and I don't believe there is any impact when not shipping the Webpack one.