### PR TITLE
Fix body height

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -31,7 +31,7 @@
 
 html,
 body {
-	height: 100vh;
+	height: 100%;
 }
 
 body {


### PR DESCRIPTION
#821 fixed #793, but it appears since then, Chrome has changed the behaviour back to what it was befor ethe fix, so 2.2.0 on Chrome 56+ is even more broken.

Only needs 1 reviewer.