### PR TITLE
Fix `run_pr.sh` script

### DIFF
--- a/scripts/run-pr.sh
+++ b/scripts/run-pr.sh
@@ -10,5 +10,6 @@ fi
 git fetch https://github.com/thelounge/lounge.git refs/pull/${1}/head
 git checkout FETCH_HEAD
 npm install
+npm run build
 npm test || true
 npm start


### PR DESCRIPTION
`npm run build` is now mandatory as of #858.
Very straightforward change for dev-only.