### PR TITLE
Update arg parsing and default 'lounge' to 'lounge --help'

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "homepage": "https://thelounge.github.io/",
   "scripts": {
     "coverage": "nyc mocha",
-    "start": "node index",
+    "start": "node index start",
     "start-dev": "npm-run-all --parallel watch start",
     "build": "npm-run-all build:*",
     "build:font-awesome": "node scripts/build-fontawesome.js",

--- a/src/command-line/index.js
+++ b/src/command-line/index.js
@@ -9,11 +9,9 @@ var fsextra = require("fs-extra");
 var path = require("path");
 var Helper = require("../helper");
 
-program.version(Helper.getVersion(), "-v, --version");
-program.option("");
-program.option("    --home <path>" , "home path");
-
-var argv = program.parseOptions(process.argv);
+program.version(Helper.getVersion(), "-v, --version")
+	.option("-h, --home <path>", "path to configuration folder")
+	.parseOptions(process.argv);
 
 Helper.setHome(program.home || process.env.LOUNGE_HOME);
 
@@ -40,8 +38,8 @@ require("./remove");
 require("./reset");
 require("./edit");
 
-program.parse(argv.args);
+program.parse(process.argv);
 
 if (!program.args.length) {
-	program.parse(process.argv.concat("start"));
+	program.help();
 }

--- a/src/command-line/start.js
+++ b/src/command-line/start.js
@@ -8,11 +8,11 @@ var Helper = require("../helper");
 
 program
 	.command("start")
-	.option("-H, --host <ip>", "host")
-	.option("-P, --port <port>", "port")
-	.option("-B, --bind <ip>", "bind")
-	.option("    --public", "mode")
-	.option("    --private", "mode")
+	.option("-H, --host <ip>", "set the IP address or hostname for the web server to listen on")
+	.option("-P, --port <port>", "set the port to listen on")
+	.option("-B, --bind <ip>", "set the local IP to bind to for outgoing connections")
+	.option("    --public", "start in public mode")
+	.option("    --private", "start in private mode")
 	.description("Start the server")
 	.action(function(options) {
 		var users = new ClientManager().getUsers();


### PR DESCRIPTION
This PR does 2 things: 
1. Updates ```lounge``` with no arguments to default to ```lounge --help```.
2. Parse the command line arguments (fix [#925](https://github.com/thelounge/lounge/issues/925)).