### PR TITLE
Make sure multiline chains of calls are correctly indented

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -17,7 +17,7 @@ rules:
   dot-notation: 2
   eqeqeq: 2
   handle-callback-err: 2
-  indent: [2, tab]
+  indent: [2, tab, { "MemberExpression": 1 }]
   key-spacing: [2, {beforeColon: false, afterColon: true}]
   keyword-spacing: [2, {before: true, after: true}]
   linebreak-style: [2, unix]


### PR DESCRIPTION
See http://eslint.org/docs/rules/indent#memberexpression for more info.

Without this option, the following examples are passing ESLint:

```js
foo()
.bar(); // 0 tabs

foo()
		.bar() // 2 tabs
	.baz(); // 1 tab

foo()
  .bar() // 2 spaces
	.baz(); // 1 tab
```

I noticed this issue while reviewing #929, which passed CI with:

```js
program
	.option("    --private", "mode")
  .parse(process.argv)
	.description("Start the server")
```