### PR TITLE
Disable (temporarily) client ping timeouts

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -261,6 +261,7 @@ Client.prototype.connect = function(args) {
 		auto_reconnect: true,
 		auto_reconnect_wait: 10000 + Math.floor(Math.random() * 1000), // If multiple users are connected to the same network, randomize their reconnections a little
 		auto_reconnect_max_retries: 360, // At least one hour (plus timeouts) worth of reconnections
+		ping_interval: 0, // Disable client ping timeouts due to buggy implementation
 		webirc: webirc,
 	});
 


### PR DESCRIPTION
Currently client pings are causing us some issue due to the way it's implemented in irc-fw. As I expect a full fix to take some time to be implemented I propose we disable it.