### PR TITLE
Help window with supported commands and shortcuts

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -57,7 +57,8 @@ a:hover {
 }
 
 h1,
-h2 {
+h2,
+h3 {
 	font: inherit;
 	line-height: inherit;
 	margin: 0;
@@ -77,6 +78,33 @@ button {
 	margin: 0;
 	outline: none;
 	padding: 0;
+}
+
+code,
+kbd {
+	font-family: Consolas, Menlo, Monaco, "Lucida Console", "DejaVu Sans Mono", "Courier New", monospace;
+}
+
+code {
+	font-size: 12px;
+	padding: 2px 4px;
+	color: #e74c3c;
+	background-color: #f9f2f4;
+	border-radius: 2px;
+}
+
+kbd {
+	display: inline-block;
+	font-size: 11px;
+	line-height: 10px;
+	padding: 3px 5px;
+	color: #555;
+	vertical-align: middle;
+	background-color: #fcfcfc;
+	border: solid 1px #ccc;
+	border-bottom-color: #bbb;
+	border-radius: 3px;
+	box-shadow: inset 0 -1px 0 #bbb;
 }
 
 .btn {
@@ -185,6 +213,7 @@ button {
 #footer .sign-in:before { content: "\f023"; /* http://fontawesome.io/icon/lock/ */ }
 #footer .connect:before { content: "\f067"; /* http://fontawesome.io/icon/plus/ */ }
 #footer .settings:before { content: "\f013"; /* http://fontawesome.io/icon/cog/ */ }
+#footer .help:before { content: "\f059"; /* http://fontawesome.io/icon/question/ */ }
 #footer .sign-out:before { content: "\f011"; /* http://fontawesome.io/icon/power-off/ */ }
 
 #form #cycle-nicks:before { content: "\f007"; /* http://fontawesome.io/icon/user/ */ }
@@ -654,6 +683,12 @@ button {
 	font-size: 22px;
 	margin: 30px 0 10px;
 	padding-bottom: 7px;
+}
+
+#windows .window h3 {
+	color: #7f8c8d;
+	font-size: 18px;
+	margin: 20px 0 10px;
 }
 
 #windows .active {
@@ -1296,6 +1331,27 @@ button {
 	margin-top: .2em;
 }
 
+#help .help-item {
+	display: table-row;
+}
+
+#help .help-item .subject,
+#help .help-item .description {
+	display: table-cell;
+	padding-bottom: 15px;
+}
+
+#help .help-item .subject {
+	white-space: nowrap;
+	padding-right: 10px;
+	min-width: 150px;
+}
+
+#help .help-item .description p {
+	font-size: 14px;
+	margin-bottom: 0;
+}
+
 #form {
 	background: #eee;
 	border-top: 1px solid #ddd;
@@ -1812,6 +1868,15 @@ button {
 	#chat .date-marker,
 	#chat .unread-marker {
 		margin: 0;
+	}
+
+	#help .help-item .subject {
+		display: inline-block;
+		padding-bottom: 4px;
+	}
+
+	#help .help-item .description {
+		display: block;
 	}
 }
 

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1289,13 +1289,8 @@ kbd {
 	margin: 4px 10px 0 0;
 }
 
-#settings .about,
 #settings #play {
 	color: #7f8c8d;
-}
-
-#settings .about small {
-	margin-left: 2px;
 }
 
 #settings #play {
@@ -1305,12 +1300,6 @@ kbd {
 
 #settings #play:hover {
 	opacity: .8;
-}
-
-#settings .about {
-	font-size: 14px;
-	padding-top: 2px;
-	line-height: 1.8;
 }
 
 #settings #change-password .error,
@@ -1350,6 +1339,11 @@ kbd {
 #help .help-item .description p {
 	font-size: 14px;
 	margin-bottom: 0;
+}
+
+#help .about {
+	font-size: 14px;
+	line-height: 1.8;
 }
 
 #form {

--- a/client/index.html
+++ b/client/index.html
@@ -37,6 +37,7 @@
 			<span class="tooltipped tooltipped-n" aria-label="Sign in"><button class="icon sign-in" data-target="#sign-in" aria-label="Sign in"></button></span>
 			<span class="tooltipped tooltipped-n" aria-label="Connect to network"><button class="icon connect" data-target="#connect" aria-label="Connect to network"></button></span>
 			<span class="tooltipped tooltipped-n" aria-label="Client settings"><button class="icon settings" data-target="#settings" aria-label="Client settings"></button></span>
+			<span class="tooltipped tooltipped-n" aria-label="Help"><button class="icon help" data-target="#help" aria-label="Help"></button></span>
 			<span class="tooltipped tooltipped-n" aria-label="Sign out"><button class="icon sign-out" id="sign-out" aria-label="Sign out"></button></span>
 		</footer>
 		<div id="main">
@@ -372,6 +373,337 @@
 									<a href="https://thelounge.github.io/" target="_blank">Website</a><br>
 									<a href="https://thelounge.github.io/docs/" target="_blank">Documentation</a><br>
 									<a href="https://github.com/thelounge/lounge/issues/new" target="_blank">Report a bug</a>
+								</p>
+							</div>
+						</div>
+					</div>
+				</div>
+
+				<div id="help" class="window">
+					<div class="header">
+						<button class="lt" aria-label="Toggle channel list"></button>
+					</div>
+					<div class="container">
+						<h1 class="title">Help</h1>
+
+						<h2>Keyboard Shortcuts</h2>
+
+						<h3>On Windows / Linux</h3>
+
+						<div class="help-item">
+							<div class="subject">
+								<kbd>Ctrl</kbd> + <kbd>↑</kbd> / <kbd>↓</kbd>
+							</div>
+							<div class="description">
+								<p>Switch to the previous/next window in the channel list</p>
+							</div>
+						</div>
+
+						<div class="help-item">
+							<div class="subject">
+								<kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>L</kbd>
+							</div>
+							<div class="description">
+								<p>Clear the current screen</p>
+							</div>
+						</div>
+
+						<h3>On macOS</h3>
+
+						<div class="help-item">
+							<div class="subject">
+								<kbd>⌘</kbd> + <kbd>↑</kbd> / <kbd>↓</kbd>
+							</div>
+							<div class="description">
+								<p>Switch to the previous/next window in the channel list</p>
+							</div>
+						</div>
+
+						<div class="help-item">
+							<div class="subject">
+								<kbd>⌘</kbd> + <kbd>K</kbd>
+							</div>
+							<div class="description">
+								<p>Clear the current screen</p>
+							</div>
+						</div>
+
+						<h2>Commands</h2>
+
+						<div class="help-item">
+							<div class="subject">
+								<code>/away [message]</code>
+							</div>
+							<div class="description">
+								<p>Mark yourself as away with an optional message.</p>
+							</div>
+						</div>
+
+						<div class="help-item">
+							<div class="subject">
+								<code>/back</code>
+							</div>
+							<div class="description">
+								<p>Remove your away status (set with <code>/away</code>).</p>
+							</div>
+						</div>
+
+						<div class="help-item">
+							<div class="subject">
+								<code>/clear</code>
+							</div>
+							<div class="description">
+								<p>Clear the current screen.</p>
+							</div>
+						</div>
+
+						<div class="help-item">
+							<div class="subject">
+								<code>/connect host [port]</code>
+							</div>
+							<div class="description">
+								<p>
+									Connect to a new IRC network. If <code>port</code> starts with
+									a <code>+</code> sign, the connection will be made secure
+									using TLS.
+								</p>
+								<p>Alias: <code>/server</code></p>
+							</div>
+						</div>
+
+						<div class="help-item">
+							<div class="subject">
+								<code>/ctcp target cmd [args]</code>
+							</div>
+							<div class="description">
+								<p>
+									Send a <abbr title="Client-to-client protocol">CTCP</abbr>
+									request. Read more about this on
+									<a href="https://en.wikipedia.org/wiki/Client-to-client_protocol">the dedicated Wikipedia article</a>.
+								</p>
+							</div>
+						</div>
+
+						<div class="help-item">
+							<div class="subject">
+								<code>/deop nick [...nick]</code>
+							</div>
+							<div class="description">
+								<p>
+									Remove op (<code>-o</code>) from one or several users in the
+									current channel.
+								</p>
+							</div>
+						</div>
+
+						<div class="help-item">
+							<div class="subject">
+								<code>/devoice nick [...nick]</code>
+							</div>
+							<div class="description">
+								<p>
+									Remove voice (<code>-v</code>) from one or several users in
+									the current channel.
+								</p>
+							</div>
+						</div>
+
+						<div class="help-item">
+							<div class="subject">
+								<code>/disconnect [message]</code>
+							</div>
+							<div class="description">
+								<p>
+									Disconnect from the current network with an
+									optionally-provided message.
+								</p>
+							</div>
+						</div>
+
+						<div class="help-item">
+							<div class="subject">
+								<code>/invite nick [channel]</code>
+							</div>
+							<div class="description">
+								<p>
+									Invite a user to the specified channel. If
+									<code>channel</code> is ommitted, user will be invited to the
+									current channel.
+								</p>
+							</div>
+						</div>
+
+						<div class="help-item">
+							<div class="subject">
+								<code>/join channel</code>
+							</div>
+							<div class="description">
+								<p>Join a channel.</p>
+							</div>
+						</div>
+
+						<div class="help-item">
+							<div class="subject">
+								<code>/kick nick</code>
+							</div>
+							<div class="description">
+								<p>Kick a user from the current channel.</p>
+							</div>
+						</div>
+
+						<div class="help-item">
+							<div class="subject">
+								<code>/list</code>
+							</div>
+							<div class="description">
+								<p>Retrieve a list of available channels on this network.</p>
+							</div>
+						</div>
+
+						<div class="help-item">
+							<div class="subject">
+								<code>/me message</code>
+							</div>
+							<div class="description">
+								<p>
+									Send an action message to the current channel. The Lounge will
+									display it inline, as if the message was posted in the third
+									person.
+								</p>
+							</div>
+						</div>
+
+						<div class="help-item">
+							<div class="subject">
+								<code>/mode flags [args]</code>
+							</div>
+							<div class="description">
+								<p>
+									Set the given flags to the current channel if the active
+									window is a channel, another user if the active window is a
+									private message window, or yourself if the current window is a
+									server window.
+								</p>
+							</div>
+						</div>
+
+						<div class="help-item">
+							<div class="subject">
+								<code>/msg channel message</code>
+							</div>
+							<div class="description">
+								<p>Send a message to the specified channel.</p>
+							</div>
+						</div>
+
+						<div class="help-item">
+							<div class="subject">
+								<code>/nick newnick</code>
+							</div>
+							<div class="description">
+								<p>Change your nickname on the current network.</p>
+							</div>
+						</div>
+
+						<div class="help-item">
+							<div class="subject">
+								<code>/notice channel message</code>
+							</div>
+							<div class="description">
+								<p>Sends a notice message to the specified channel.</p>
+							</div>
+						</div>
+
+						<div class="help-item">
+							<div class="subject">
+								<code>/op nick [...nick]</code>
+							</div>
+							<div class="description">
+								<p>
+									Give op (<code>+o</code>) to one or several users in the
+									current channel.
+								</p>
+							</div>
+						</div>
+
+						<div class="help-item">
+							<div class="subject">
+								<code>/part</code>
+							</div>
+							<div class="description">
+								<p>Close the current channel or private message window.</p>
+								<p>Aliases: <code>/close</code>, <code>/leave</code></p>
+							</div>
+						</div>
+
+						<div class="help-item">
+							<div class="subject">
+								<code>/query nick</code>
+							</div>
+							<div class="description">
+								<p>Send a private message to the specified user.</p>
+							</div>
+						</div>
+
+						<div class="help-item">
+							<div class="subject">
+								<code>/quit [message]</code>
+							</div>
+							<div class="description">
+								<p>
+									Disconnect from the current network with an optional message.
+								</p>
+							</div>
+						</div>
+
+						<div class="help-item">
+							<div class="subject">
+								<code>/raw message</code>
+							</div>
+							<div class="description">
+								<p>Send a raw message to the current IRC network.</p>
+								<p>Aliases: <code>/quote</code>, <code>/send</code></p>
+							</div>
+						</div>
+
+						<div class="help-item">
+							<div class="subject">
+								<code>/slap nick</code>
+							</div>
+							<div class="description">
+								<p>Slap someone in the current channel with a trout!</p>
+							</div>
+						</div>
+
+						<div class="help-item">
+							<div class="subject">
+								<code>/topic newtopic</code>
+							</div>
+							<div class="description">
+								<p>Set the topic in the current channel.</p>
+							</div>
+						</div>
+
+						<div class="help-item">
+							<div class="subject">
+								<code>/voice nick [...nick]</code>
+							</div>
+							<div class="description">
+								<p>
+									Give voice (<code>+v</code>) to one or several users in the
+									current channel.
+								</p>
+							</div>
+						</div>
+
+						<div class="help-item">
+							<div class="subject">
+								<code>/whois nick</code>
+							</div>
+							<div class="description">
+								<p>
+									Retrieve information about the given user on the current
+									network.
 								</p>
 							</div>
 						</div>

--- a/client/index.html
+++ b/client/index.html
@@ -357,24 +357,6 @@
 							<div class="col-sm-12">
 								<textarea class="input" name="userStyles" id="user-specified-css-input" placeholder="You can override any style with CSS here"></textarea>
 							</div>
-							<div class="col-sm-12">
-								<h2>About The Lounge</h2>
-							</div>
-							<div class="col-sm-12">
-								<p class="about">
-									<% if (gitCommit) { %>
-										The Lounge is running from source
-										(<a href="https://github.com/thelounge/lounge/tree/<%= gitCommit %>" target="_blank"><code><%= gitCommit %></code></a>).<br>
-									<% } else { %>
-										The Lounge is in version <strong><%= version %></strong>
-										(<a href="https://github.com/thelounge/lounge/releases/tag/v<%= version %>" target="_blank">See release notes</a>).<br>
-									<% } %>
-
-									<a href="https://thelounge.github.io/" target="_blank">Website</a><br>
-									<a href="https://thelounge.github.io/docs/" target="_blank">Documentation</a><br>
-									<a href="https://github.com/thelounge/lounge/issues/new" target="_blank">Report a bug</a>
-								</p>
-							</div>
 						</div>
 					</div>
 				</div>
@@ -707,6 +689,22 @@
 								</p>
 							</div>
 						</div>
+
+						<h2>About The Lounge</h2>
+
+						<p class="about">
+							<% if (gitCommit) { %>
+								The Lounge is running from source
+								(<a href="https://github.com/thelounge/lounge/tree/<%= gitCommit %>" target="_blank"><code><%= gitCommit %></code></a>).<br>
+							<% } else { %>
+								The Lounge is in version <strong><%= version %></strong>
+								(<a href="https://github.com/thelounge/lounge/releases/tag/v<%= version %>" target="_blank">See release notes</a>).<br>
+							<% } %>
+
+							<a href="https://thelounge.github.io/" target="_blank">Website</a><br>
+							<a href="https://thelounge.github.io/docs/" target="_blank">Documentation</a><br>
+							<a href="https://github.com/thelounge/lounge/issues/new" target="_blank">Report a bug</a>
+						</p>
 					</div>
 				</div>
 			</div>

--- a/client/themes/crypto.css
+++ b/client/themes/crypto.css
@@ -18,6 +18,11 @@ body {
 	font: 16px Inconsolata-g, monospace;
 }
 
+code,
+kbd {
+	font-family: Inconsolata-g, monospace;
+}
+
 a,
 #chat a {
 	color: #00ff0e;
@@ -28,9 +33,12 @@ a:hover,
 	color: #3eff48;
 }
 
-#windows .window h2 {
+#windows .window h2,
+#windows .window h3 {
 	color: #666;
-	font: regular 14px Lato, sans-serif;
+}
+
+#windows .window h2 {
 	border-bottom: none;
 }
 
@@ -39,7 +47,6 @@ a:hover,
 }
 
 #sign-in label {
-	font: 14px Lato, sans-serif;
 	color: #666;
 }
 


### PR DESCRIPTION
This addresses https://github.com/thelounge/lounge/issues/764, but it was not the starting point of this PR: I am currently [rewriting the documentation](https://github.com/thelounge/thelounge.github.io/tree/astorije/better-docs) (PR incoming) and the existing one only has [Commands](https://thelounge.github.io/docs/client/commands.html) and [Keyboard Shortcuts](https://thelounge.github.io/docs/client/keyboard_shortcuts.html).
The website is not the best place for these and it makes more sense to have them available directly in the UI.

I also rewrote a lot of them to make them clearer and/or more up-to-date with the current state of the project.

**⚠️ This is not intended to be perfect before merging.**
My current and only goal for this PR is to move the 2 pages from the website to the UI, with correct description. There are many ways to go nuts with this: display shortcuts for the current platform only, hide the keyboard shortcuts on mobile, etc. This PR will not address any of these. I'll let future contributors help with that while I'm moving forward with the improvements on the documentation 😄

### TODO

- [ ] Fill the blank for `/ctcp` command. Any suggestion for this?
- [ ] Go through all the language with a fresh set of eyes and review with native speakers

### Screenshots

Icon in the sidebar | Command examples | Shortcuts + About | Whole page
--- | --- | --- | ---
<img width="236" alt="sidebar" src="https://cloud.githubusercontent.com/assets/113730/23395544/32570a92-fd5d-11e6-955f-7d3c0f8933dd.png"> | <img width="444" alt="help commands" src="https://cloud.githubusercontent.com/assets/113730/23395543/3256a41c-fd5d-11e6-9198-130ee128f6e5.png"> | <img width="449" alt="shortcuts about" src="https://cloud.githubusercontent.com/assets/113730/23395542/32558fe6-fd5d-11e6-8b10-419807db257f.png"> | ![help](https://cloud.githubusercontent.com/assets/113730/23395572/5cd4050e-fd5d-11e6-853d-41a36a802ae5.gif)

