### PR TITLE
Prevent message sending in lobbies

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -335,6 +335,14 @@ Client.prototype.inputLine = function(data) {
 
 	// This is either a normal message or a command escaped with a leading '/'
 	if (text.charAt(0) !== "/" || text.charAt(1) === "/") {
+		if (target.chan.type === Chan.Type.LOBBY) {
+			target.chan.pushMessage(this, new Msg({
+				type: Msg.Type.ERROR,
+				text: "Messages can not be sent to lobbies."
+			}));
+			return;
+		}
+
 		text = "say " + text.replace(/^\//, "");
 	} else {
 		text = text.substr(1);

--- a/src/plugins/inputs/action.js
+++ b/src/plugins/inputs/action.js
@@ -1,8 +1,20 @@
 "use strict";
 
+var Chan = require("../../models/chan");
+var Msg = require("../../models/msg");
+
 exports.commands = ["slap", "me"];
 
 exports.input = function(network, chan, cmd, args) {
+	if (chan.type !== Chan.Type.CHANNEL && chan.type !== Chan.Type.QUERY) {
+		chan.pushMessage(this, new Msg({
+			type: Msg.Type.ERROR,
+			text: `${cmd} command can only be used in channels and queries.`
+		}));
+
+		return;
+	}
+
 	var irc = network.irc;
 	var text;
 

--- a/src/plugins/inputs/invite.js
+++ b/src/plugins/inputs/invite.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var Chan = require("../../models/chan");
+var Msg = require("../../models/msg");
 
 exports.commands = ["invite"];
 
@@ -11,7 +12,10 @@ exports.input = function(network, chan, cmd, args) {
 		irc.raw("INVITE", args[0], args[1]); // Channel provided in the command
 	}	else if (args.length === 1 && chan.type === Chan.Type.CHANNEL) {
 		irc.raw("INVITE", args[0], chan.name); // Current channel
+	} else {
+		chan.pushMessage(this, new Msg({
+			type: Msg.Type.ERROR,
+			text: `${cmd} command can only be used in channels or by specifying a target.`
+		}));
 	}
-
-	return true;
 };

--- a/src/plugins/inputs/kick.js
+++ b/src/plugins/inputs/kick.js
@@ -1,8 +1,20 @@
 "use strict";
 
+var Chan = require("../../models/chan");
+var Msg = require("../../models/msg");
+
 exports.commands = ["kick"];
 
 exports.input = function(network, chan, cmd, args) {
+	if (chan.type !== Chan.Type.CHANNEL) {
+		chan.pushMessage(this, new Msg({
+			type: Msg.Type.ERROR,
+			text: `${cmd} command can only be used in channels.`
+		}));
+
+		return;
+	}
+
 	if (args.length !== 0) {
 		var irc = network.irc;
 		irc.raw("KICK", chan.name, args[0], args.slice(1).join(" "));

--- a/src/plugins/inputs/topic.js
+++ b/src/plugins/inputs/topic.js
@@ -1,8 +1,20 @@
 "use strict";
 
+var Chan = require("../../models/chan");
+var Msg = require("../../models/msg");
+
 exports.commands = ["topic"];
 
 exports.input = function(network, chan, cmd, args) {
+	if (chan.type !== Chan.Type.CHANNEL) {
+		chan.pushMessage(this, new Msg({
+			type: Msg.Type.ERROR,
+			text: `${cmd} command can only be used in channels.`
+		}));
+
+		return;
+	}
+
 	var irc = network.irc;
 	irc.raw("TOPIC", chan.name, args.join(" "));
 


### PR DESCRIPTION
Fixes #956.

Prevents `/me`, `/slap`, `/kick`, `/topic` being used in lobbies. Ideally some of these commands should support specifying target channel like `/invite`, but as they currently do not, it blocks and prints a message.