### PR TITLE
Fix `-h` help option alias shadowed by a similar alias for `--home`

### DIFF
--- a/src/command-line/index.js
+++ b/src/command-line/index.js
@@ -10,7 +10,7 @@ var path = require("path");
 var Helper = require("../helper");
 
 program.version(Helper.getVersion(), "-v, --version")
-	.option("-h, --home <path>", "path to configuration folder")
+	.option("--home <path>", "path to configuration folder")
 	.parseOptions(process.argv);
 
 Helper.setHome(program.home || process.env.LOUNGE_HOME);


### PR DESCRIPTION
In v2.2.1 (and in pretty much every software out there, really), `-h` was an alias of `--help`. By adding it as an alias of `--home`, it is now shown twice in the help. This screenshot is `lounge --help` in different case:

On `master` | In `v2.2.1` | After this fix
--- | --- | ---
<img width="466" alt="screen shot 2017-03-13 at 01 02 42" src="https://cloud.githubusercontent.com/assets/113730/23842264/69485f0c-0789-11e7-86a9-b016f743586e.png"> | <img width="411" alt="screen shot 2017-03-13 at 01 02 21" src="https://cloud.githubusercontent.com/assets/113730/23842295/a88cd760-0789-11e7-98cf-8751f895f4df.png"> | <img width="465" alt="screen shot 2017-03-13 at 01 02 56" src="https://cloud.githubusercontent.com/assets/113730/23842296/aa78e88e-0789-11e7-8c48-564610dbea69.png">

This is a regression introduced by #929 and I discovered it as I was preparing the release for v2.2.2, so this is blocking the release 😿.

