### PR TITLE
Use require() instead of import in client code

### DIFF
--- a/client/.eslintrc.yml
+++ b/client/.eslintrc.yml
@@ -1,3 +1,0 @@
----
-parserOptions:
-  sourceType: module

--- a/client/js/libs/handlebars/colorClass.js
+++ b/client/js/libs/handlebars/colorClass.js
@@ -1,3 +1,5 @@
+"use strict";
+
 // Generates a string from "color-1" to "color-32" based on an input string
 module.exports = function(str) {
 	var hash = 0;

--- a/client/js/libs/handlebars/diff.js
+++ b/client/js/libs/handlebars/diff.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var diff;
 
 module.exports = function(a, opt) {

--- a/client/js/libs/handlebars/equal.js
+++ b/client/js/libs/handlebars/equal.js
@@ -1,3 +1,5 @@
+"use strict";
+
 module.exports = function(a, b, opt) {
 	a = a.toString();
 	b = b.toString();

--- a/client/js/libs/handlebars/localedate.js
+++ b/client/js/libs/handlebars/localedate.js
@@ -1,3 +1,5 @@
+"use strict";
+
 module.exports = function(time) {
 	return new Date(time).toLocaleDateString();
 };

--- a/client/js/libs/handlebars/localetime.js
+++ b/client/js/libs/handlebars/localetime.js
@@ -1,3 +1,5 @@
+"use strict";
+
 module.exports = function(time) {
 	return new Date(time).toLocaleString();
 };

--- a/client/js/libs/handlebars/modes.js
+++ b/client/js/libs/handlebars/modes.js
@@ -1,3 +1,5 @@
+"use strict";
+
 module.exports = function(mode) {
 	var modes = {
 		"~": "owner",

--- a/client/js/libs/handlebars/parse.js
+++ b/client/js/libs/handlebars/parse.js
@@ -1,5 +1,7 @@
-import Handlebars from "handlebars/runtime";
-import URI from "urijs";
+"use strict";
+
+const Handlebars = require("handlebars/runtime");
+const URI = require("urijs");
 
 module.exports = function(text) {
 	text = Handlebars.Utils.escapeExpression(text);

--- a/client/js/libs/handlebars/roundBadgeNumber.js
+++ b/client/js/libs/handlebars/roundBadgeNumber.js
@@ -1,3 +1,5 @@
+"use strict";
+
 module.exports = function(count) {
 	if (count < 1000) {
 		return count;

--- a/client/js/libs/handlebars/tojson.js
+++ b/client/js/libs/handlebars/tojson.js
@@ -1,3 +1,5 @@
+"use strict";
+
 module.exports = function(context) {
 	return window.JSON.stringify(context);
 };

--- a/client/js/libs/handlebars/tz.js
+++ b/client/js/libs/handlebars/tz.js
@@ -1,3 +1,5 @@
+"use strict";
+
 module.exports = function(time) {
 	time = new Date(time);
 	var h = time.getHours();

--- a/client/js/libs/handlebars/users.js
+++ b/client/js/libs/handlebars/users.js
@@ -1,3 +1,5 @@
+"use strict";
+
 module.exports = function(count) {
 	return count + " " + (count === 1 ? "user" : "users");
 };

--- a/client/js/libs/slideout.js
+++ b/client/js/libs/slideout.js
@@ -1,7 +1,9 @@
+"use strict";
+
 /**
  * Simple slideout menu implementation.
  */
-export default function slideoutMenu(viewport, menu) {
+module.exports = function slideoutMenu(viewport, menu) {
 	var touchStartPos = null;
 	var touchCurPos = null;
 	var touchStartTime = 0;
@@ -98,4 +100,4 @@ export default function slideoutMenu(viewport, menu) {
 			return menuIsOpen;
 		}
 	};
-}
+};

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -1,18 +1,20 @@
+"use strict";
+
 // vendor libraries
-import "jquery-ui/ui/widgets/sortable";
-import $ from "jquery";
-import io from "socket.io-client";
-import Mousetrap from "mousetrap";
-import URI from "urijs";
+require("jquery-ui/ui/widgets/sortable");
+const $ = require("jquery");
+const io = require("socket.io-client");
+const Mousetrap = require("mousetrap");
+const URI = require("urijs");
 
 // our libraries
-import "./libs/jquery/inputhistory";
-import "./libs/jquery/stickyscroll";
-import "./libs/jquery/tabcomplete";
-import helpers_parse from "./libs/handlebars/parse";
-import helpers_roundBadgeNumber from "./libs/handlebars/roundBadgeNumber";
-import slideoutMenu from "./libs/slideout";
-import templates from "../views";
+require("./libs/jquery/inputhistory");
+require("./libs/jquery/stickyscroll");
+require("./libs/jquery/tabcomplete");
+const helpers_parse = require("./libs/handlebars/parse");
+const helpers_roundBadgeNumber = require("./libs/handlebars/roundBadgeNumber");
+const slideoutMenu = require("./libs/slideout");
+const templates = require("../views");
 
 $(function() {
 	var path = window.location.pathname + "socket.io/";

--- a/client/views/index.js
+++ b/client/views/index.js
@@ -1,3 +1,5 @@
+"use strict";
+
 module.exports = {
 	actions: {
 		action: require("./actions/action.tpl"),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -71,6 +71,7 @@ let config = {
 
 if (process.env.NODE_ENV === "production") {
 	config.plugins.push(new webpack.optimize.UglifyJsPlugin({
+		sourceMap: true,
 		comments: false
 	}));
 } else {


### PR DESCRIPTION
Closes #895.

Got bitten by `Block-scoped declarations (let, const, function, class) not yet supported outside strict mode` while working on #972 and to get strict mode gotta drop `sourceType` in eslint.