### PR TITLE
Do not build json3 module with Webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "start-dev": "npm-run-all --parallel watch start",
     "build": "npm-run-all build:*",
     "build:font-awesome": "node scripts/build-fontawesome.js",
-    "build:webpack": "webpack",
+    "build:webpack": "webpack --progress",
     "watch": "webpack --watch",
     "test": "npm-run-all -c test:* lint",
     "test:mocha": "mocha",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -60,6 +60,9 @@ let config = {
 			},
 		]
 	},
+	externals: {
+		json3: "JSON", // socket.io uses json3.js, but we do not target any browsers that need it
+	},
 	plugins: [
 		new webpack.optimize.CommonsChunkPlugin("js/bundle.vendor.js")
 	]


### PR DESCRIPTION
Both of these are only used by `socket.io` and it contributes an unnecessary amount of size in the final vendor chunk. It removes 23kB from the final vendor chunk in production build.