### PR TITLE
bcrypt: switch to faster JS implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "node": ">=4.2.0"
   },
   "dependencies": {
-    "bcrypt-nodejs": "0.0.3",
+    "bcryptjs": "2.4.3",
     "cheerio": "0.22.0",
     "colors": "1.1.2",
     "commander": "2.9.0",

--- a/src/helper.js
+++ b/src/helper.js
@@ -6,7 +6,7 @@ var path = require("path");
 var os = require("os");
 var fs = require("fs");
 var net = require("net");
-var bcrypt = require("bcrypt-nodejs");
+var bcrypt = require("bcryptjs");
 
 var Helper = {
 	config: null,


### PR DESCRIPTION
Closes #982.

Results from [evaluating](https://hastebin.redwill.se/zosomugoxi) `bcrypt`, `bcryptjs`, `bcrypt-nodejs` (via their async API) on a Raspberry Pi 3 with 3 rounds;

```sh
[bcrypt] Computing 58 password hashes.
[bcrypt] total: 282.228ms

[bcryptjs] Computing 58 password hashes.
[bcryptjs] total: 2483.178ms

[bcrypt-nodejs] Computing 58 password hashes.
[bcrypt-nodejs] total: 394372.514ms

```

`bcrypt-nodejs` performs really bad, and `bcrypt` is quite a heavy dependency.