### PR TITLE
Switch to bcryptjs and make password comparison async

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "node": ">=4.2.0"
   },
   "dependencies": {
-    "bcrypt-nodejs": "0.0.3",
+    "bcryptjs": "2.4.3",
     "cheerio": "0.22.0",
     "colors": "1.1.2",
     "commander": "2.9.0",

--- a/src/helper.js
+++ b/src/helper.js
@@ -6,7 +6,7 @@ var path = require("path");
 var os = require("os");
 var fs = require("fs");
 var net = require("net");
-var bcrypt = require("bcrypt-nodejs");
+var bcrypt = require("bcryptjs");
 
 var Helper = {
 	config: null,
@@ -125,5 +125,5 @@ function passwordHash(password) {
 }
 
 function passwordCompare(password, expected) {
-	return bcrypt.compareSync(password, expected);
+	return bcrypt.compare(password, expected);
 }

--- a/test/tests/passwords.js
+++ b/test/tests/passwords.js
@@ -10,14 +10,27 @@ describe("Client passwords", function() {
 		// Generated with third party tool to test implementation
 		let comparedPassword = Helper.password.compare(inputPassword, "$2a$11$zrPPcfZ091WNfs6QrRHtQeUitlgrJcecfZhxOFiQs0FWw7TN3Q1oS");
 
-		expect(comparedPassword).to.be.true;
+		return comparedPassword.then(result => {
+			expect(result).to.be.true;
+		});
+	});
+
+	it("wrong hashed password should not match", function() {
+		// Compare against a fake hash
+		let comparedPassword = Helper.password.compare(inputPassword, "$2a$11$zrPPcfZ091WRONGPASSWORDitlgrJcecfZhxOFiQs0FWw7TN3Q1oS");
+
+		return comparedPassword.then(result => {
+			expect(result).to.be.false;
+		});
 	});
 
 	it("freshly hashed password should match", function() {
 		let hashedPassword = Helper.password.hash(inputPassword);
 		let comparedPassword = Helper.password.compare(inputPassword, hashedPassword);
 
-		expect(comparedPassword).to.be.true;
+		return comparedPassword.then((result) => {
+			expect(result).to.be.true;
+		});
 	});
 
 	it("shout passwords should be marked as old", function() {


### PR DESCRIPTION
Closes #982 

Changed to faster brcypt implementation (brcyptjs) for better performance and made the compare call async so it does not timeout anymore. The check still takes ages on resource constraint devices as on the older models of the raspberry pi but it is usable now, you just need a little patience ;)

Performance comparison of the different bcrypt implementations can be found here: https://github.com/thelounge/lounge/pull/983