### PR TITLE
Restrict extra parentheses inside argument list of a function call/definition/etc.

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -43,6 +43,7 @@ rules:
   space-before-function-paren: [2, never]
   space-in-parens: [2, never]
   space-infix-ops: 2
+  space-in-parens: 2
   spaced-comment: [2, always]
   strict: 2
 


### PR DESCRIPTION
Things like `console.log( "Hello world" );` are now prohibited.

While I was playing with #977 and the dependency it refers to, I noticed we allow these for now (but thankfully we have none in-repo).