### PR TITLE
Setup ESLint to make sure an EOF feed is always present

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -15,6 +15,7 @@ rules:
   comma-dangle: 0
   curly: [2, all]
   dot-notation: 2
+  eol-last: 2
   eqeqeq: 2
   handle-callback-err: 2
   indent: [2, tab, { "MemberExpression": 1 }]


### PR DESCRIPTION
Noticed this was missing when reviewing #986.