### PR TITLE
Fix wrong font size in help center labels

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1327,6 +1327,7 @@ kbd {
 #help .help-item .subject,
 #help .help-item .description {
 	display: table-cell;
+	font-size: 14px;
 	padding-bottom: 15px;
 }
 
@@ -1337,7 +1338,6 @@ kbd {
 }
 
 #help .help-item .description p {
-	font-size: 14px;
 	margin-bottom: 0;
 }
 


### PR DESCRIPTION
This only concerns plain texts, not `<code>` or `<kbd>`.

This is veeery subtle at the moment (which is why I missed it) but I noticed the labels were in 16px when testing #787 that currently has texts in the labels (that will change, but still, makes `/` and `+` using the correct size).

Before | After
--- | ---
<img width="444" alt="screen shot 2017-03-30 at 02 18 05" src="https://cloud.githubusercontent.com/assets/113730/24490156/5850cafe-14ef-11e7-9732-f411af8573ec.png"> | <img width="434" alt="screen shot 2017-03-30 at 02 18 23" src="https://cloud.githubusercontent.com/assets/113730/24490155/584ff714-14ef-11e7-863c-6e9e1335af40.png">
