### PR TITLE
Adds http to https redirect option

### DIFF
--- a/defaults/config.js
+++ b/defaults/config.js
@@ -272,6 +272,16 @@ module.exports = {
 		enable: false,
 
 		//
+		// Enable HTTP to HTTPS redirect port.
+		// port number to enable
+		// null to disable
+		//
+		// @type     int
+		// @default  null
+		//
+		http_redirect_port: null,
+
+		//
 		// Path to the key.
 		//
 		// @type     string

--- a/src/server.js
+++ b/src/server.js
@@ -73,6 +73,15 @@ in ${config.public ? "public" : "private"} mode`);
 		authFunction = ldapAuth;
 	}
 
+	if (config.https.http_redirect_port) {
+		// Redirect from httpt to https
+		var http = require("http");
+		http.createServer(function(req, res) {
+			res.writeHead(301, {Location: "https://" + req.headers.host + req.url});
+			res.end();
+		}).listen(config.https.http_redirect_port);
+	}
+
 	var sockets = io(server, {
 		serveClient: false,
 		transports: config.transports


### PR DESCRIPTION
I know, correct way is to use reverse proxy. I reroute ports, http and https ports, to 2 random ports to my rasperry pi, one listens lounge, other redirects, no root access required. Maybe its useful?