### PR TITLE
Correctly append date marker when receiving a message

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -432,7 +432,7 @@ $(function() {
 		}
 
 		if (prevMsgTime.toDateString() !== msgTime.toDateString()) {
-			prevMsg.append(templates.date_marker({msgDate: msgTime}));
+			prevMsg.after(templates.date_marker({msgDate: msgTime}));
 		}
 
         // Add message to the container


### PR DESCRIPTION
Chat flexbox revealed a bug we've had since date marker introduction. It would append the date marker inside the text message container, instead of appending after it.