### PR TITLE
Alternative way to use http and https on same port

### DIFF
--- a/defaults/config.js
+++ b/defaults/config.js
@@ -272,6 +272,16 @@ module.exports = {
 		enable: false,
 
 		//
+		// Enable HTTP to HTTPS redirect port.
+		// port number to enable
+		// null to disable
+		//
+		// @type     int
+		// @default  null
+		//
+		http_redirect_port: null,
+
+		//
 		// Path to the key.
 		//
 		// @type     string

--- a/defaults/config.js
+++ b/defaults/config.js
@@ -22,6 +22,15 @@ module.exports = {
 	host: undefined,
 
 	//
+	// hostname for the web server to redirect.
+	// Setting this to undefined will disable hostname redirecting.
+	//
+	// @type     string
+	// @default  undefined
+	//
+	hostname: undefined,
+
+	//
 	// Set the port to listen on.
 	//
 	// @type     int
@@ -270,16 +279,6 @@ module.exports = {
 		// @default  false
 		//
 		enable: false,
-
-		//
-		// Enable HTTP to HTTPS redirect port.
-		// port number to enable
-		// null to disable
-		//
-		// @type     int
-		// @default  null
-		//
-		http_redirect_port: null,
 
 		//
 		// Path to the key.

--- a/src/server.js
+++ b/src/server.js
@@ -149,8 +149,8 @@ function allRequests(req, res, next) {
 	if (Helper.config.hostname && Helper.config.hostname !== req.hostname) {
 		return res.redirect(302, `http://${Helper.config.hostname}${req.originalUrl}`);
 	}
-	if (Helper.config.hostname && Helper.config.https.enable && req.protocol === "http") {
-		return res.redirect(302, `https://${Helper.config.hostname}${req.originalUrl}`);
+	if (Helper.config.https.enable && req.protocol === "http") {
+		return res.redirect(302, `https://${req.hostname}${req.originalUrl}`);
 	}
 	res.setHeader("X-Content-Type-Options", "nosniff");
 	return next();

--- a/src/server.js
+++ b/src/server.js
@@ -73,6 +73,15 @@ in ${config.public ? "public" : "private"} mode`);
 		authFunction = ldapAuth;
 	}
 
+	if (config.https.http_redirect_port) {
+		// Redirect from httpt to https
+		var http = require("http");
+		http.createServer(function(req, res) {
+			res.writeHead(301, {Location: "https://" + req.headers.host + req.url});
+			res.end();
+		}).listen(config.https.http_redirect_port);
+	}
+
 	var sockets = io(server, {
 		serveClient: false,
 		transports: config.transports


### PR DESCRIPTION
@astorije closed last pull request https://github.com/thelounge/lounge/pull/996 and i found a new way to fix the problem. So there it is. If hostname is set, it will redirect to that hostname. Http works same way, https is changed. On https, server now allows both http and https connections on same port. If connection is not secure, redirects to https. Its important, that same lounge server can response different hostnames, thats the reason why i dont use host as base in config file, because it locks me with one hostname. 

Other then that, now i let router redirect both 80 and 443 ports to 9000 on my pi lounge server. -1 port open, added bit security.