### PR TITLE
fix: count only message items for show-more

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -1189,7 +1189,7 @@ $(function() {
 
 	chat.on("click", ".show-more-button", function() {
 		var self = $(this);
-		var count = self.parent().next(".messages").children().length;
+		var count = self.parent().next(".messages").children(".msg").length;
 		socket.emit("more", {
 			target: self.data("id"),
 			count: count


### PR DESCRIPTION
the `messages` div contains a `date-marker` div and an `unread-marker` div. this causes the `count` variable to be 2 more than the expected value, which makes the show-more button skip two messages when loading history. this change filters the counted elements to fix this issue.