### PR TITLE
Use Referrer-Policy header instead of CSP referrer

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -131,7 +131,8 @@ function index(req, res, next) {
 			return css.slice(0, -4);
 		});
 		var template = _.template(file);
-		res.setHeader("Content-Security-Policy", "default-src *; connect-src 'self' ws: wss:; style-src * 'unsafe-inline'; script-src 'self'; child-src 'self'; object-src 'none'; form-action 'none'; referrer no-referrer;");
+		res.setHeader("Content-Security-Policy", "default-src *; connect-src 'self' ws: wss:; style-src * 'unsafe-inline'; script-src 'self'; child-src 'self'; object-src 'none'; form-action 'none';");
+		res.setHeader("Referrer-Policy", "no-referrer");
 		res.setHeader("Content-Type", "text/html");
 		res.writeHead(200);
 		res.end(template(data));


### PR DESCRIPTION
According to MDN:

> `referrer`
>   Used to specify information in the referer (sic) header for links away from a page.
>   Use the Referrer-Policy header instead.

See:

- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/referrer
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy

This fixes the following warning in JS console:

<img width="421" alt="screen shot 2017-04-06 at 02 26 38" src="https://cloud.githubusercontent.com/assets/113730/24740689/7dcfa3f0-1a70-11e7-9377-8a0f72866529.png">

**Note that I have merely switched from the old to new format, I have not tested security implications of this.** My understanding is there should be no implications beyond renaming it, but I could be wrong.