### PR TITLE
Unread marker takes hidden messages into account.

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -444,7 +444,9 @@ $(function() {
 			]);
 
 		if (data.msg.self
-			|| container.find("div:visible").last().hasClass("unread-marker")) {
+			|| container.find("div:visible").last().hasClass("unread-marker")
+			|| (container.find("div:visible").last().hasClass("date-marker")
+				&& container.find("div:visible").last().prev().hasClass("unread-marker"))) {
 			container
 				.find(".unread-marker")
 				.appendTo(container);

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -442,11 +442,11 @@ $(function() {
 				target,
 				data
 			]);
-
+		var lastVisible = container.find("div:visible").last();
 		if (data.msg.self
-			|| container.find("div:visible").last().hasClass("unread-marker")
-			|| (container.find("div:visible").last().hasClass("date-marker")
-				&& container.find("div:visible").last().prev().hasClass("unread-marker"))) {
+			|| lastVisible.hasClass("unread-marker")
+			|| (lastVisible.hasClass("date-marker")
+				&& lastVisible.prev().hasClass("unread-marker"))) {
 			container
 				.find(".unread-marker")
 				.appendTo(container);

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -443,7 +443,8 @@ $(function() {
 				data
 			]);
 
-		if (data.msg.self) {
+		if (data.msg.self
+			|| container.find("div:visible").last().hasClass("unread-marker")) {
 			container
 				.find(".unread-marker")
 				.appendTo(container);


### PR DESCRIPTION
Stops showing the unread messages marker when there are hidden joins/parts/quits/nick changes which is rather annoying. Would close #604, went with the solution suggested by xPaw.