### PR TITLE
Fix Zenburn and Morning channel list font color.

### DIFF
--- a/client/themes/morning.css
+++ b/client/themes/morning.css
@@ -212,6 +212,10 @@ body {
 	color: #84ce88 !important;
 }
 
+#chat table.channel-list td {
+	color: #ccc;
+}
+
 /* Embeds */
 #chat .toggle-content,
 #chat .toggle-button {

--- a/client/themes/zenburn.css
+++ b/client/themes/zenburn.css
@@ -238,6 +238,10 @@ body {
 	color: #8cd0d3 !important;
 }
 
+#chat table.channel-list td {
+	color: #ccc;
+}
+
 /* Embeds */
 #chat .toggle-content,
 #chat .toggle-button {


### PR DESCRIPTION
Before:
![screenshot from 2017-04-06 16-44-26](https://cloud.githubusercontent.com/assets/7511094/24760286/856719ae-1ae8-11e7-885d-2ce71288e2e6.png)
![screenshot from 2017-04-06 16-44-13](https://cloud.githubusercontent.com/assets/7511094/24760287/856f6b04-1ae8-11e7-9c2f-3440cbd58241.png)

After:
![screenshot from 2017-04-06 16-44-52](https://cloud.githubusercontent.com/assets/7511094/24760295/8a373ff4-1ae8-11e7-80cb-95660e135a6d.png)
![screenshot from 2017-04-06 16-44-43](https://cloud.githubusercontent.com/assets/7511094/24760296/8a3a280e-1ae8-11e7-81bf-72c2c8bdd82e.png)


Still very hard to use but atleast readable now.