### PR TITLE
Improve channels list.

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1022,6 +1022,10 @@ kbd {
 	border-bottom: #eee 1px solid;
 }
 
+#chat table.channel-list .channel {
+	width: 80px;
+}
+
 #chat table.channel-list .channel,
 #chat table.channel-list .topic {
 	text-align: left;
@@ -1029,6 +1033,7 @@ kbd {
 
 #chat table.channel-list .users {
 	text-align: center;
+	width: 50px;
 }
 
 #chat table.channel-list td.channel .inline-channel {

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -421,6 +421,10 @@ $(function() {
 		var target = "#chan-" + data.chan;
 		var container = chat.find(target + " .messages");
 
+		if (data.msg.type === "channel_list") {
+			$(container).empty();
+		}
+
         // Check if date changed
 		var prevMsg = $(container.find(".msg")).last();
 		var prevMsgTime = new Date(prevMsg.attr("data-time"));
@@ -1050,7 +1054,7 @@ $(function() {
 		}
 
 		var chanChat = chan.find(".chat");
-		if (chanChat.length > 0) {
+		if (chanChat.length > 0 && chan.data("type") !== "special") {
 			chanChat.sticky();
 		}
 

--- a/src/plugins/irc-events/list.js
+++ b/src/plugins/irc-events/list.js
@@ -5,7 +5,7 @@ var Msg = require("../../models/msg");
 
 module.exports = function(irc, network) {
 	var client = this;
-	var MAX_CHANS = 1000;
+	var MAX_CHANS = 500;
 
 	irc.on("channel list start", function() {
 		network.chanCache = [];
@@ -23,7 +23,9 @@ module.exports = function(irc, network) {
 	irc.on("channel list end", function() {
 		updateListStatus(new Msg({
 			type: "channel_list",
-			channels: network.chanCache.slice(0, MAX_CHANS)
+			channels: network.chanCache.sort(function(a, b) {
+				return b.num_users - a.num_users;
+			}).slice(0, MAX_CHANS)
 		}));
 
 		if (network.chanCache.length > MAX_CHANS) {


### PR DESCRIPTION
- Set fixed width to channel and users column.
- Sort by number of users in channel.
- Executing /list multiple times wont show multiple tables. (Also clears loading message)
- Scroll to top after /list is finished.
- Limit channels to 500. Scrolling through 1k is very slow on my system.

![screenshot from 2017-04-06 18-27-22](https://cloud.githubusercontent.com/assets/7511094/24765075/bfad54c6-1af6-11e7-8551-6f37cf8dda37.png)
