### PR TITLE
Replace jquery-ui with sortablejs

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -446,14 +446,14 @@ kbd {
 	padding-bottom: 10px;
 }
 
-#sidebar .chan:first-child {
+#sidebar .lobby {
 	color: #84ce88;
 	font-size: 15px;
 	font-weight: bold;
 }
 
-#sidebar .chan:first-child:hover,
-#sidebar .chan:first-child.active {
+#sidebar .lobby:hover,
+#sidebar .lobby.active {
 	color: #c0f8c3;
 }
 

--- a/client/views/chan.tpl
+++ b/client/views/chan.tpl
@@ -1,7 +1,5 @@
-{{#each channels}}
 <div data-id="{{id}}" data-target="#chan-{{id}}" data-title="{{name}}" class="chan {{type}}">
 	<span class="badge{{#if highlight}} highlight{{/if}}">{{#if unread}}{{roundBadgeNumber unread}}{{/if}}</span>
 	<button class="close" aria-label="Close"></button>
 	<span class="name" title="{{name}}">{{name}}</span>
 </div>
-{{/each}}

--- a/client/views/network.tpl
+++ b/client/views/network.tpl
@@ -1,5 +1,10 @@
 {{#each networks}}
 <section id="network-{{id}}" class="network" data-id="{{id}}" data-nick="{{nick}}" data-options="{{tojson serverOptions}}">
-	{{> chan}}
+	{{> chan lobby}}
+	<div class="channel-list">
+	{{#each chans}}
+		{{> chan}}
+	{{/each}}
+	</div>
 </section>
 {{/each}}

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "request": "2.81.0",
     "semver": "5.3.0",
     "socket.io": "1.7.3",
+    "sortablejs": "1.5.1",
     "spdy": "3.4.4"
   },
   "devDependencies": {
@@ -67,7 +68,6 @@
     "handlebars": "4.0.6",
     "handlebars-loader": "1.4.0",
     "jquery": "3.2.1",
-    "jquery-ui": "1.12.1",
     "mocha": "3.2.0",
     "mousetrap": "1.6.1",
     "npm-run-all": "4.0.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,7 @@ let config = {
 		"js/bundle.vendor.js": [
 			"handlebars/runtime",
 			"jquery",
-			"jquery-ui/ui/widgets/sortable",
+			"sortablejs",
 			"mousetrap",
 			"socket.io-client",
 			"urijs",


### PR DESCRIPTION
closes #932

This might use some cleanup, although lint reports no issues. I tried not to break anything, the changeset is pretty small as is.

`bundle.vendor.js` size for production build with this change is 209kb. The version running on my server is at 245kb - saving over 30kb is probably worthwhile doing.