### PR TITLE
Automatically scroll up when reaching the top of the chat window

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -477,6 +477,8 @@ $(function() {
 
 		if (data.messages.length !== 100) {
 			scrollable.find(".show-more").removeClass("show");
+		} else {
+			scrollable.find(".show-more").addClass("show");
 		}
 
 		// Date change detect
@@ -1060,6 +1062,19 @@ $(function() {
 		}
 
 		focus();
+
+		let oldScrollTop = 0;
+		$("#chat .active .chat").on("scroll", function() {
+			const scrollTop = $(this).scrollTop();
+
+			// Make sure we are scrolling up and nearing the top
+			// FIXME Use a window percentage instead of a height in px
+			if (oldScrollTop > scrollTop && scrollTop < 200) {
+				$(this).find(".show-more.show .show-more-button").click();
+			}
+
+			oldScrollTop = scrollTop;
+		});
 	});
 
 	sidebar.on("click", "#sign-out", function() {
@@ -1190,6 +1205,7 @@ $(function() {
 	chat.on("click", ".show-more-button", function() {
 		var self = $(this);
 		var count = self.parent().next(".messages").children(".msg").length;
+		self.parent().removeClass("show");
 		socket.emit("more", {
 			target: self.data("id"),
 			count: count


### PR DESCRIPTION
Horrible attempt at fixing #495 and #207.

This is horrible and really buggy.
It feels really slow at the moment, which gets me to think it's attempting to load multiple times.
Also, this should not have to live in the `open` event handler but I couldn't make it work outside of it yet.
Also the top height should be determined in % and not in pixels.
Also when functional the physical button should not be necessary anymore.
Also when removing the button the "clear chat" shortcut will not work anymore (but one thing at a time).

I thought it could be a 10 minute hack but looks like I was too optimistic 😅.
Help welcome.