### PR TITLE
Reset notification markers on document focus

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -1595,14 +1595,11 @@ $(function() {
 		$("#viewport .lt").toggleClass("notified", newState);
 	}
 
-	document.addEventListener(
-		"visibilitychange",
-		function() {
-			if (sidebar.find(".highlight").length === 0) {
-				toggleNotificationMarkers(false);
-			}
+	$(document).on("visibilitychange focus", () => {
+		if (sidebar.find(".highlight").length === 0) {
+			toggleNotificationMarkers(false);
 		}
-	);
+	});
 
 	// Only start opening socket.io connection after all events have been registered
 	socket.open();


### PR DESCRIPTION
Fixes #837.

If you have lounge open on a second monitor, receive a notification and switch to lounge, the favicon will stay red. This PR fixes that.