### PR TITLE
Process received messages in queue

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -14,7 +14,6 @@ const emojiMap = require("./libs/simplemap.json");
 require("./libs/jquery/inputhistory");
 require("./libs/jquery/stickyscroll");
 require("./libs/jquery/tabcomplete");
-const helpers_roundBadgeNumber = require("./libs/handlebars/roundBadgeNumber");
 const slideoutMenu = require("./libs/slideout");
 const templates = require("../views");
 const socket = require("./socket");
@@ -28,20 +27,6 @@ $(function() {
 	var chat = $("#chat");
 
 	$(document.body).data("app-name", document.title);
-
-	var pop;
-	try {
-		pop = new Audio();
-		pop.src = "audio/pop.ogg";
-	} catch (e) {
-		pop = {
-			play: $.noop
-		};
-	}
-
-	$("#play").on("click", function() {
-		pop.play();
-	});
 
 	// Autocompletion Strategies
 
@@ -635,77 +620,6 @@ $(function() {
 
 		names.hide();
 		container.html(templates.user_filtered({matches: result})).show();
-	});
-
-	chat.on("msg", ".messages", function(e, target, msg) {
-		var unread = msg.unread;
-		msg = msg.msg;
-
-		if (msg.self) {
-			return;
-		}
-
-		var button = sidebar.find(".chan[data-target='" + target + "']");
-		if (msg.highlight || (options.notifyAllMessages && msg.type === "message")) {
-			if (!document.hasFocus() || !$(target).hasClass("active")) {
-				if (options.notification) {
-					try {
-						pop.play();
-					} catch (exception) {
-						// On mobile, sounds can not be played without user interaction.
-					}
-				}
-				utils.toggleNotificationMarkers(true);
-
-				if (options.desktopNotifications && Notification.permission === "granted") {
-					var title;
-					var body;
-
-					if (msg.type === "invite") {
-						title = "New channel invite:";
-						body = msg.from + " invited you to " + msg.channel;
-					} else {
-						title = msg.from;
-						if (!button.hasClass("query")) {
-							title += " (" + button.data("title").trim() + ")";
-						}
-						if (msg.type === "message") {
-							title += " says:";
-						}
-						body = msg.text.replace(/\x03(?:[0-9]{1,2}(?:,[0-9]{1,2})?)?|[\x00-\x1F]|\x7F/g, "").trim();
-					}
-
-					try {
-						var notify = new Notification(title, {
-							body: body,
-							icon: "img/logo-64.png",
-							tag: target
-						});
-						notify.addEventListener("click", function() {
-							window.focus();
-							button.click();
-							this.close();
-						});
-					} catch (exception) {
-						// `new Notification(...)` is not supported and should be silenced.
-					}
-				}
-			}
-		}
-
-		if (button.hasClass("active")) {
-			return;
-		}
-
-		if (!unread) {
-			return;
-		}
-
-		var badge = button.find(".badge").html(helpers_roundBadgeNumber(unread));
-
-		if (msg.highlight) {
-			badge.addClass("highlight");
-		}
 	});
 
 	chat.on("click", ".show-more-button", function() {

--- a/client/js/render.js
+++ b/client/js/render.js
@@ -24,22 +24,27 @@ module.exports = {
 
 function buildChannelMessages(data) {
 	return data.messages.reduce(function(docFragment, message) {
-		appendMessage(docFragment, data.id, data.type, message.type, buildChatMessage({
-			chan: data.id,
-			msg: message
-		}));
+		appendMessage(
+			docFragment,
+			data.id,
+			data.type,
+			message.type,
+			buildChatMessage({
+				chan: data.id,
+				msg: message
+			}),
+			docFragment.children("div.msg").last()
+		);
 		return docFragment;
 	}, $(document.createDocumentFragment()));
 }
 
-function appendMessage(container, chan, chanType, messageType, msg) {
+function appendMessage(container, chan, chanType, messageType, msg, lastChild) {
 	// TODO: To fix #1432, statusMessage option should entirely be implemented in CSS
 	if (constants.condensedTypes.indexOf(messageType) === -1 || chanType !== "channel" || options.statusMessages !== "condensed") {
 		container.append(msg);
 		return;
 	}
-
-	const lastChild = container.children("div.msg").last();
 
 	if (lastChild && $(lastChild).hasClass("condensed")) {
 		lastChild.append(msg);

--- a/client/js/socket-events/msg.js
+++ b/client/js/socket-events/msg.js
@@ -63,6 +63,7 @@ function processReceivedMessages() {
 	});
 
 	while (messageQueue[0] !== undefined) {
+		// Only process a single channel per "tick"
 		if (target !== null && target !== messageQueue[0].chan) {
 			processOnIdle(processReceivedMessages);
 			break;
@@ -86,26 +87,25 @@ function processReceivedMessages() {
 
 		// Check if date changed
 		const prevMsgTime = new Date(previousMessage.attr("data-time"));
-		const msgTime = new Date(msg.attr("data-time"));
+		const msgTime = new Date(data.msg.time);
 
 		if (previousMessage.length === 0 || prevMsgTime.toDateString() !== msgTime.toDateString()) {
-			// TODO: Condensed stuff
-			var parent = previousMessage.parent();
-			if (parent.hasClass("condensed")) {
-				previousMessage = parent;
-			}
-
 			documentFragment.append(templates.date_marker({msgDate: msgTime}));
 		}
 
 		// Add message to the container
-		previousMessage = msg;
-		render.appendMessage( // TODO: condensed stuff
+		const parent = previousMessage.parent();
+		
+		// TODO: Fix condensed messages
+		previousMessage = parent.hasClass("condensed") ? parent : msg;
+
+		render.appendMessage(
 			documentFragment,
 			data.chan,
 			$(target).attr("data-type"),
 			data.msg.type,
-			msg
+			msg,
+			previousMessage
 		);
 
 		const lastVisible = container.find("div:visible").last();

--- a/client/js/socket-events/msg.js
+++ b/client/js/socket-events/msg.js
@@ -3,74 +3,217 @@
 const $ = require("jquery");
 const socket = require("../socket");
 const render = require("../render");
-const chat = $("#chat");
+const options = require("../options");
+const utils = require("../utils");
 const templates = require("../../views");
+const helpers_roundBadgeNumber = require("../libs/handlebars/roundBadgeNumber");
+
+const sidebar = $("#sidebar");
+const chat = $("#chat");
+const messageQueue = [];
+let lastNotificationSoundPlay = 0;
+
+let processOnIdle;
+if (window.requestIdleCallback) {
+	processOnIdle = (callback) => {
+		window.requestIdleCallback(callback, {timeout: 2000});
+	};
+} else {
+	processOnIdle = (callback) => callback();
+}
+
+let pop;
+try {
+	pop = new Audio();
+	pop.src = "audio/pop.ogg";
+} catch (e) {
+	pop = {
+		play: $.noop
+	};
+}
+
+$("#play").on("click", () => pop.play());
 
 socket.on("msg", function(data) {
-	const msg = render.buildChatMessage(data);
-	const targetId = data.chan;
-	const target = "#chan-" + targetId;
-	const channel = chat.find(target);
-	const container = channel.find(".messages");
+	messageQueue.push(data);
+
+	if (messageQueue.length === 1) {
+		processOnIdle(processReceivedMessages);
+	}
+});
+
+function processReceivedMessages() {
+	let target = null;
+	let channel;
+	let container;
+	let previousMessage;
+	let documentFragment;
 
 	const activeChannelId = chat.find(".chan.active").data("id");
 
-	if (data.msg.type === "channel_list" || data.msg.type === "ban_list") {
-		$(container).empty();
-	}
-
-	// Check if date changed
-	let prevMsg = $(container.find(".msg")).last();
-	const prevMsgTime = new Date(prevMsg.attr("data-time"));
-	const msgTime = new Date(msg.attr("data-time"));
-
-	// It's the first message in a channel/query
-	if (prevMsg.length === 0) {
-		container.append(templates.date_marker({msgDate: msgTime}));
-	}
-
-	if (prevMsgTime.toDateString() !== msgTime.toDateString()) {
-		var parent = prevMsg.parent();
-		if (parent.hasClass("condensed")) {
-			prevMsg = parent;
+	// TODO: sorting too much?
+	messageQueue.sort((a, b) => {
+		if (a.chan === b.chan) {
+			return a.msg.id - b.msg.id;
 		}
-		prevMsg.after(templates.date_marker({msgDate: msgTime}));
-	}
 
-	// Add message to the container
-	render.appendMessage(
-		container,
-		data.chan,
-		$(target).attr("data-type"),
-		data.msg.type,
-		msg
-	);
+		// TODO: Prioritize active channel?
 
-	container.trigger("msg", [
-		target,
-		data
-	]).trigger("keepToBottom");
+		return a.chan - b.chan;
+	});
 
-	var lastVisible = container.find("div:visible").last();
-	if (data.msg.self
-		|| lastVisible.hasClass("unread-marker")
-		|| (lastVisible.hasClass("date-marker")
-		&& lastVisible.prev().hasClass("unread-marker"))) {
-		container
-			.find(".unread-marker")
-			.appendTo(container);
-	}
+	while (messageQueue[0] !== undefined) {
+		if (target !== null && target !== messageQueue[0].chan) {
+			processOnIdle(processReceivedMessages);
+			break;
+		}
 
-	// Message arrived in a non active channel, trim it to 100 messages
-	if (activeChannelId !== targetId && container.find(".msg").slice(0, -100).remove().length) {
-		channel.find(".show-more").addClass("show");
+		const data = messageQueue.shift();
+		const msg = render.buildChatMessage(data);
 
-		// Remove date-seperators that would otherwise
-		// be "stuck" at the top of the channel
-		channel.find(".date-marker-container").each(function() {
-			if ($(this).next().hasClass("date-marker-container")) {
-				$(this).remove();
+		if (target === null) {
+			target = data.chan;
+			channel = chat.find("#chan-" + target);
+			container = channel.find(".messages");
+
+			if (data.msg.type === "channel_list" || data.msg.type === "ban_list") {
+				container.empty();
 			}
-		});
+
+			documentFragment = $(document.createDocumentFragment());
+			previousMessage = container.find(".msg").last();
+		}
+
+		// Check if date changed
+		const prevMsgTime = new Date(previousMessage.attr("data-time"));
+		const msgTime = new Date(msg.attr("data-time"));
+
+		if (previousMessage.length === 0 || prevMsgTime.toDateString() !== msgTime.toDateString()) {
+			// TODO: Condensed stuff
+			var parent = previousMessage.parent();
+			if (parent.hasClass("condensed")) {
+				previousMessage = parent;
+			}
+
+			documentFragment.append(templates.date_marker({msgDate: msgTime}));
+		}
+
+		// Add message to the container
+		previousMessage = msg;
+		render.appendMessage( // TODO: condensed stuff
+			documentFragment,
+			data.chan,
+			$(target).attr("data-type"),
+			data.msg.type,
+			msg
+		);
+
+		const lastVisible = container.find("div:visible").last();
+		if (data.msg.self
+			|| lastVisible.hasClass("unread-marker")
+			|| (lastVisible.hasClass("date-marker")
+			&& lastVisible.prev().hasClass("unread-marker"))) {
+			const unreadMarker = container.find(".unread-marker") || documentFragment.find(".unread-marker");
+
+			unreadMarker.appendTo(documentFragment);
+		}
+
+		if (!data.msg.self) {
+			notifyChannelMessage("#chan-" + target, data);
+		}
 	}
-});
+
+	if (container) {
+		container
+			.append(documentFragment)
+			.trigger("keepToBottom");
+
+		// Message arrived in a non active channel, trim it to 100 messages
+		if (activeChannelId !== target && container.find(".msg").slice(0, -100).remove().length) {
+			channel.find(".show-more").addClass("show");
+
+			// Remove date-seperators that would otherwise
+			// be "stuck" at the top of the channel
+			channel.find(".date-marker-container").each(function() {
+				if ($(this).next().hasClass("date-marker-container")) {
+					$(this).remove();
+				}
+			});
+		}
+	}
+}
+
+function notifyChannelMessage(target, msg) {
+	const unread = msg.unread;
+	msg = msg.msg;
+
+	const button = sidebar.find(".chan[data-target='" + target + "']");
+	if (msg.highlight || (options.notifyAllMessages && msg.type === "message")) {
+		if (!document.hasFocus() || !$(target).hasClass("active")) {
+			const time = Date.now();
+
+			if (options.notification && (time - lastNotificationSoundPlay) > 500) {
+				// Fixes "The play() request was interrupted by a call to pause()"
+				lastNotificationSoundPlay = time;
+
+				try {
+					pop.play();
+				} catch (exception) {
+					// On mobile, sounds can not be played without user interaction.
+				}
+			}
+
+			utils.toggleNotificationMarkers(true);
+
+			if (options.desktopNotifications && Notification.permission === "granted") {
+				let title;
+				let body;
+
+				if (msg.type === "invite") {
+					title = "New channel invite:";
+					body = msg.from + " invited you to " + msg.channel;
+				} else {
+					title = msg.from;
+					if (!button.hasClass("query")) {
+						title += " (" + button.data("title").trim() + ")";
+					}
+					if (msg.type === "message") {
+						title += " says:";
+					}
+					body = msg.text.replace(/\x03(?:[0-9]{1,2}(?:,[0-9]{1,2})?)?|[\x00-\x1F]|\x7F/g, "").trim();
+				}
+
+				try {
+					const notify = new Notification(title, {
+						body: body,
+						icon: "img/logo-64.png",
+						tag: target
+					});
+					notify.addEventListener("click", function() {
+						window.focus();
+						button.click();
+						this.close();
+					});
+				} catch (exception) {
+					// `new Notification(...)` is not supported and should be silenced.
+				}
+			}
+		}
+	}
+
+	if (button.hasClass("active")) {
+		return;
+	}
+
+	if (!unread) {
+		return;
+	}
+
+	const badge = button
+		.find(".badge")
+		.html(helpers_roundBadgeNumber(unread));
+
+	if (msg.highlight) {
+		badge.addClass("highlight");
+	}
+}


### PR DESCRIPTION
Creating early PR to gather feedback. Want to hear what  @thelounge/maintainers think.

Connecting to ZNC with history playback no longer freezes my browser, and appends messages in small queues instead of as-soon-as-received.

What I want to achieve is to process multiple messages for one channel at once, and append them at once (document fragments). Thus reducing DOM manipulations and style recalculations. This should also prioritise currently active channel.

- [x] Sort messages per channel
- [ ] Prioritize currently active channel
  - [ ] How does this handle for PMs/whois which force a new window to appear?
- [x] Use document fragments to append multiple messages at once
- [x] Trigger events (notifications, sticky scroll) once per processed channel
  - [ ] Look more into notifications
- [x] #96 Remove 10 second interval timer to hide messages in hidden channels
- [x] Limit notification sound to play every 500 milliseconds
- [ ] Fix condensed stuff
