### PR TITLE
Use HTTPS version to the IRC color guide

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -404,7 +404,7 @@
 								</p>
 								<p>
 									A color reference can be found
-									<a href="http://modern.ircdocs.horse/formatting.html#colors" target="_blank" rel="noopener">here</a>.
+									<a href="https://modern.ircdocs.horse/formatting.html#colors" target="_blank" rel="noopener">here</a>.
 								</p>
 							</div>
 						</div>
@@ -480,7 +480,7 @@
 								</p>
 								<p>
 									A color reference can be found
-									<a href="http://modern.ircdocs.horse/formatting.html#colors" target="_blank" rel="noopener">here</a>.
+									<a href="https://modern.ircdocs.horse/formatting.html#colors" target="_blank" rel="noopener">here</a>.
 								</p>
 							</div>
 						</div>


### PR DESCRIPTION
@DanielOaks very nicely and blazingly quickly set up HTTPS (see https://github.com/ircdocs/modern-irc/issues/38) so we can now direct our users to that version!
