### PR TITLE
Issue 1019: Show MOTD by default

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -605,7 +605,7 @@ $(function() {
 		join: true,
 		links: true,
 		mode: true,
-		motd: false,
+		motd: true,
 		nick: true,
 		notification: true,
 		notifyAllMessages: false,


### PR DESCRIPTION
Resolves https://github.com/thelounge/lounge/issues/1019.

Testing done:  I have built in a development environment on Slackware 14.2 with

```sh
npm install
NODE_ENV=production npm run build
npm start
```

I then opened an Incognito Window of Google Chrome to http://localhost:9000/ and logged into Freenode.  The MOTD was enabled and shown by default.

Google Chrome was packaged from Slackware's extra directory (on DVD), and nodejs came from slackbuilds.org

I still need to figure out how to tweak npm2tgz so that I can build a custom package.