### PR TITLE
Exclude Webpack config from coverage report

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -3,7 +3,8 @@
   "exclude": [
     "client/js/bundle.js",
     "client/js/bundle.vendor.js",
-    "test/"
+    "test/",
+    "webpack.config.js"
   ],
   "reporter": [
     "lcov",


### PR DESCRIPTION
There is effectively nothing we can or should test in this config file, so worth excluding I believe.

Also, I noticed that the `coverage/` folder is in the list of covered file as opposed to what I thought to be true in https://github.com/thelounge/lounge/pull/989/commits/2bcbb62af0af93db08c32ecfdd7f8db70dd1584c. I will ping their team to know what's going on (EDIT: done [here](https://github.com/istanbuljs/nyc/pull/502#issuecomment-295098720)).