### PR TITLE
Use moment on the client to display friendly dates

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -841,7 +841,6 @@ kbd {
 #chat .unread-marker {
 	position: relative;
 	text-align: center;
-	opacity: .5;
 	margin: 0 10px;
 	z-index: 0;
 	font-weight: bold;
@@ -855,13 +854,13 @@ kbd {
 	left: 0;
 	right: 0;
 	top: 50%;
-	border-top: 1px solid #e74c3c;
+	border-top: 1px solid rgba(231, 76, 60, .5);
 }
 
 #chat .unread-marker-text:before {
 	content: "New messages";
 	background-color: white;
-	color: #e74c3c;
+	color: rgba(231, 76, 60, .5);
 	padding: 0 10px;
 }
 
@@ -872,7 +871,6 @@ kbd {
 #chat .date-marker {
 	position: relative;
 	text-align: center;
-	opacity: .5;
 	margin: 0 10px;
 	z-index: 0;
 	font-weight: bold;
@@ -886,13 +884,13 @@ kbd {
 	left: 0;
 	right: 0;
 	top: 50%;
-	border-top: 1px solid #006b3b;
+	border-top: 1px solid rgba(0, 107, 59, .5);
 }
 
 #chat .date-marker-text:before {
-	content: attr(data-date);
+	content: attr(data-label);
 	background-color: white;
-	color: #006b3b;
+	color: rgba(0, 107, 59, .5);
 	padding: 0 10px;
 }
 

--- a/client/js/libs/handlebars/friendlydate.js
+++ b/client/js/libs/handlebars/friendlydate.js
@@ -1,0 +1,13 @@
+"use strict";
+
+const moment = require("moment");
+
+module.exports = function(time) {
+	// See http://momentjs.com/docs/#/displaying/calendar-time/
+	return moment(new Date(time)).calendar(null, {
+		sameDay: "[Today]",
+		lastDay: "[Yesterday]",
+		lastWeek: "L", // Locale
+		sameElse: "L"
+	});
+};

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -3,6 +3,7 @@
 // vendor libraries
 require("jquery-ui/ui/widgets/sortable");
 const $ = require("jquery");
+const moment = require("moment");
 const Mousetrap = require("mousetrap");
 const URI = require("urijs");
 
@@ -1592,6 +1593,25 @@ $(function() {
 			toggleNotificationMarkers(false);
 		}
 	});
+
+	// Compute how many milliseconds are remaining until the next day starts
+	function msUntilNextDay() {
+		return moment().add(1, "day").startOf("day") - moment();
+	}
+
+	// Go through all Today/Yesterday date markers in the DOM and recompute their
+	// labels. When done, restart the timer for the next day.
+	function updateDateMarkers() {
+		$(".date-marker-text[data-label='Today'], .date-marker-text[data-label='Yesterday']")
+			.closest(".date-marker-container")
+			.each(function() {
+				$(this).replaceWith(templates.date_marker({msgDate: $(this).data("timestamp")}));
+			});
+
+		// This should always be 24h later but re-computing exact value just in case
+		setTimeout(updateDateMarkers, msUntilNextDay());
+	}
+	setTimeout(updateDateMarkers, msUntilNextDay());
 
 	// Only start opening socket.io connection after all events have been registered
 	socket.open();

--- a/client/themes/morning.css
+++ b/client/themes/morning.css
@@ -155,11 +155,6 @@ body {
 	border-color: #333c4a;
 }
 
-#chat .unread-marker,
-#chat .date-marker {
-	opacity: 1;
-}
-
 #chat .unread-marker-text:before {
 	background-color: #333c4a;
 }

--- a/client/themes/zenburn.css
+++ b/client/themes/zenburn.css
@@ -181,11 +181,6 @@ body {
 	border-color: #3f3f3f;
 }
 
-#chat .unread-marker,
-.date-marker {
-	opacity: 1;
-}
-
 #chat .unread-marker-text:before {
 	background-color: #3f3f3f;
 }

--- a/client/views/date-marker.tpl
+++ b/client/views/date-marker.tpl
@@ -1,3 +1,5 @@
-<div class="date-marker">
-	<span class="date-marker-text" data-date="{{localedate msgDate}}"></span>
+<div class="tooltipped tooltipped-s" aria-label="{{localedate msgDate}}">
+	<div class="date-marker">
+		<span class="date-marker-text" data-label="{{friendlydate msgDate}}"></span>
+	</div>
 </div>

--- a/client/views/date-marker.tpl
+++ b/client/views/date-marker.tpl
@@ -1,4 +1,4 @@
-<div class="tooltipped tooltipped-s" aria-label="{{localedate msgDate}}">
+<div class="date-marker-container tooltipped tooltipped-s" data-timestamp="{{msgDate}}" aria-label="{{localedate msgDate}}">
 	<div class="date-marker">
 		<span class="date-marker-text" data-label="{{friendlydate msgDate}}"></span>
 	</div>

--- a/test/client/js/libs/handlebars/friendlydateTest.js
+++ b/test/client/js/libs/handlebars/friendlydateTest.js
@@ -1,0 +1,24 @@
+"use strict";
+
+const expect = require("chai").expect;
+const moment = require("moment");
+const friendlydate = require("../../../../../client/js/libs/handlebars/friendlydate");
+
+describe("friendlydate Handlebars helper", () => {
+	it("should render 'Today' as a human-friendly date", () => {
+		const time = new Date().getTime();
+		expect(friendlydate(time)).to.equal("Today");
+	});
+
+	it("should render 'Yesterday' as a human-friendly date", () => {
+		const time = new Date().getTime() - 24 * 3600 * 1000;
+		expect(friendlydate(time)).to.equal("Yesterday");
+	});
+
+	it("should not render any friendly dates prior to the day before", () => {
+		[2, 7, 30, 365, 1000].forEach(day => {
+			const time = new Date().getTime() - 24 * 3600 * 1000 * day;
+			expect(friendlydate(time)).to.equal(moment(time).format("L"));
+		});
+	});
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,6 +14,7 @@ let config = {
 			"handlebars/runtime",
 			"jquery",
 			"jquery-ui/ui/widgets/sortable",
+			"moment",
 			"mousetrap",
 			"socket.io-client",
 			"urijs",


### PR DESCRIPTION
Some time ago, @MaxLeiter [said](https://github.com/thelounge/lounge/pull/765#issuecomment-263306173):

> Am just going to mention this here: once the client can access npm packages, we can use moments .calender() to create fuzzy time stamps (i.e. "Yesterday")

There was some discussion [in here](https://github.com/thelounge/lounge/pull/671) as well.

**Result:**

<img width="162" alt="screen shot 2017-04-19 at 02 04 08" src="https://cloud.githubusercontent.com/assets/113730/25166485/a2f39dec-24a9-11e7-98f2-be5a590c4dd6.png">

Also, unread and date markers are now half-transparent based on their colors and not parent opacity. This is necessary to display a non-half-transparent tooltip.

Vendor bundle is a bit bigger now, but I think it's for the best and we will most likely benefit from having Moment.js available on the client anyway.

⚠️ **Caveat:** At the moment, this does not refresh at midnight, so any date marker already on the page will stay at "Today" when they should switch to "Yesterday". I don't think this is a big deal but happy to get opinions. Either way, if people feel strongly about this, I'll happily accept help (extra commit on that branch?) as I'll be moving to something else tomorrow anyway 😅.