### PR TITLE
Fix broken nick autocomplete caused by #856

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -1380,7 +1380,7 @@ $(function() {
 	}
 
 	function completeNicks(word) {
-		const users = chat.find(".active").find(".users");
+		const users = chat.find(".active").find(".names-original");
 		const words = users.data("nicks");
 
 		return $.grep(


### PR DESCRIPTION
Since #856 changed the structure of the userlist, it couldn't find the users to use to autocomplete