### PR TITLE
Fix network layout displaying the scrollbar incorrectly

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -762,6 +762,7 @@ kbd {
 #chat .chat {
 	bottom: 0;
 	left: 0;
+	right: 0;
 	overflow: auto;
 	-webkit-overflow-scrolling: touch;
 	position: absolute;


### PR DESCRIPTION
This was introduced by [this change R773](https://github.com/thelounge/lounge/pull/856/files#diff-97db1f70168fb5f12457b238ff6052b5R773) (and L794-798): a right position got introduced for all channel containers, but default position for other types of containers was absent before this script.

Before | After
--- | ---
<img width="1013" alt="screen shot 2017-04-26 at 23 32 08" src="https://cloud.githubusercontent.com/assets/113730/25458026/97e5cf26-2ad8-11e7-8a31-8f595764b535.png"> | <img width="1014" alt="screen shot 2017-04-26 at 23 30 33" src="https://cloud.githubusercontent.com/assets/113730/25458015/8b28559c-2ad8-11e7-9815-95305729890d.png">
