### PR TITLE
Fix chat layout on small devices when users list is hidden

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1856,6 +1856,10 @@ kbd {
 		display: block;
 	}
 
+	#chat .channel .chat {
+		right: 0;
+	}
+
 	#chat .sidebar {
 		right: -180px;
 	}


### PR DESCRIPTION
Fixes #1092.

This effectively makes the user list an overlay on small devices, instead of making message container smaller.