### PR TITLE
Add autocomplete strategy for foreground and background colors

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1533,6 +1533,10 @@ kbd {
 	display: inline-block;
 }
 
+.textcomplete-item .irc-bg {
+	display: block;
+}
+
 /**
   * Tooltips v0.5.3
   * See http://primercss.io/tooltips/

--- a/client/js/constants.js
+++ b/client/js/constants.js
@@ -1,5 +1,24 @@
 "use strict";
 
+const colorCodeMap = [
+	["00", "White"],
+	["01", "Black"],
+	["02", "Blue"],
+	["03", "Green"],
+	["04", "Red"],
+	["05", "Brown"],
+	["06", "Magenta"],
+	["07", "Orange"],
+	["08", "Yellow"],
+	["09", "Light Green"],
+	["10", "Cyan"],
+	["11", "Light Cyan"],
+	["12", "Light Blue"],
+	["13", "Pink"],
+	["14", "Grey"],
+	["15", "Light Grey"],
+];
+
 const commands = [
 	"/away",
 	"/back",
@@ -35,5 +54,6 @@ const commands = [
 ];
 
 module.exports = {
+	colorCodeMap: colorCodeMap,
 	commands: commands
 };

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -111,6 +111,25 @@ $(function() {
 		index: 1
 	};
 
+	const foregroundColorStrategy = {
+		id: "foreground-colors",
+		match: /\x03(\d{0,2}|[A-Za-z ]{0,10})$/,
+		search(term, callback) {
+			term = term.toLowerCase();
+			const matchingColorCodes = constants.colorCodeMap
+				.filter(i => i[0].startsWith(term) || i[1].toLowerCase().startsWith(term));
+
+			callback(matchingColorCodes);
+		},
+		template(value) {
+			return `<span class="irc-fg${parseInt(value[0], 10)}">${value[1]}</span>`;
+		},
+		replace(value) {
+			return "\x03" + value[0];
+		},
+		index: 1
+	};
+
 	socket.on("auth", function(data) {
 		var login = $("#sign-in");
 		var token;
@@ -724,7 +743,7 @@ $(function() {
 			chat.find(".chan.active .chat").trigger("msg.sticky"); // fix growing
 		})
 		.tab(completeNicks, {hint: false})
-		.textcomplete([emojiStrategy, nicksStrategy, chanStrategy, commandStrategy], {
+		.textcomplete([emojiStrategy, nicksStrategy, chanStrategy, commandStrategy, colorStrategy], {
 			dropdownClassName: "textcomplete-menu",
 			placement: "top"
 		}).on({

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -130,6 +130,26 @@ $(function() {
 		index: 1
 	};
 
+	const backgroundColorStrategy = {
+		id: "background-colors",
+		match: /\x03(\d{2}),(\d{0,2}|[A-Za-z ]{0,10})$/,
+		search(term, callback, match) {
+			term = term.toLowerCase();
+			const matchingColorCodes = constants.colorCodeMap
+				.filter(i => i[0].startsWith(term) || i[1].toLowerCase().startsWith(term))
+				.map(pair => pair.concat(match[1])); // Needed to pass fg color to `template`...
+
+			callback(matchingColorCodes);
+		},
+		template(value) {
+			return `<span class="irc-fg${parseInt(value[2], 10)} irc-bg irc-bg${parseInt(value[0], 10)}">${value[1]}</span>`;
+		},
+		replace(value) {
+			return "\x03$1," + value[0];
+		},
+		index: 2
+	};
+
 	socket.on("auth", function(data) {
 		var login = $("#sign-in");
 		var token;
@@ -743,7 +763,10 @@ $(function() {
 			chat.find(".chan.active .chat").trigger("msg.sticky"); // fix growing
 		})
 		.tab(completeNicks, {hint: false})
-		.textcomplete([emojiStrategy, nicksStrategy, chanStrategy, commandStrategy, colorStrategy], {
+		.textcomplete([
+			emojiStrategy, nicksStrategy, chanStrategy, commandStrategy,
+			foregroundColorStrategy, backgroundColorStrategy
+		], {
 			dropdownClassName: "textcomplete-menu",
 			placement: "top"
 		}).on({


### PR DESCRIPTION
Addresses #1105

~~One limitation of this is it only works for foreground color. Making it support background color as well is not impossible, but it's more efforts and I can't spend them on that right now. I still think the current PR adds some value anyway!~~ Well, not anymore it doesn't.

Color labels were taken from https://modern.ircdocs.horse/formatting.html#colors, which we link to from the client.

![autocomplete-colors2](https://cloud.githubusercontent.com/assets/113730/25563663/f05089ce-2da0-11e7-9a2d-c5c7e212c2d1.gif)
