### PR TITLE
Fix channel sorting messing up the order

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -422,7 +422,7 @@ Client.prototype.sort = function(data) {
 	switch (data.type) {
 	case "networks":
 		this.networks.sort((a, b) => {
-			return order.indexOf(a.id) > order.indexOf(b.id);
+			return order.indexOf(a.id) - order.indexOf(b.id);
 		});
 
 		// Sync order to connected clients
@@ -437,7 +437,7 @@ Client.prototype.sort = function(data) {
 		}
 
 		network.channels.sort((a, b) => {
-			return order.indexOf(a.id) > order.indexOf(b.id);
+			return order.indexOf(a.id) - order.indexOf(b.id);
 		});
 
 		// Sync order to connected clients


### PR DESCRIPTION
Fixes #1088.

How it sorted after PR #1064:
![](https://i.imgur.com/FQtW8bR.png)

After fix:
![](https://i.imgur.com/ykhfTkX.png)
