### PR TITLE
Disable tabindex on userlist search input

### DIFF
--- a/client/views/chat.tpl
+++ b/client/views/chat.tpl
@@ -23,7 +23,7 @@
 	<aside class="sidebar">
 		<div class="users">
 			<div class="count">
-				<input type="search" class="search" aria-label="Search among the user list">
+				<input type="search" class="search" aria-label="Search among the user list" tabindex="-1">
 			</div>
 			<div class="names names-filtered"></div>
 			<div class="names names-original"></div>


### PR DESCRIPTION
Fixes #1036. Disables tabbing to it since I can't be bothered to figure out a proper fix, our tabbing (outside of input) is pretty broken anyway.