### PR TITLE
Remove autocompletion section from the help page

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -529,52 +529,7 @@
 							</div>
 						</div>
 
-						<h2>Autocompletion</h2>
-
-						<p>
-							Start typing the following characters followed by any letter to
-							trigger the autocompletion dropdown:
-						</p>
-
-						<div class="help-item">
-							<div class="subject">
-								<code>@</code>
-							</div>
-							<div class="description">
-								<p>Nickname</p>
-							</div>
-						</div>
-
-						<div class="help-item">
-							<div class="subject">
-								<code>#</code>
-							</div>
-							<div class="description">
-								<p>Channel</p>
-							</div>
-						</div>
-
-						<div class="help-item">
-							<div class="subject">
-								<code>/</code>
-							</div>
-							<div class="description">
-								<p>Commands (see list of commands below)</p>
-							</div>
-						</div>
-
-						<div class="help-item">
-							<div class="subject">
-								<code>:</code>
-							</div>
-							<div class="description">
-								<p>Emoji</p>
-							</div>
-						</div>
-
 						<h2>Commands</h2>
-
-						<p>All commands can be autocompleted with <kbd>tab</kbd>.</p>
 
 						<div class="help-item">
 							<div class="subject">


### PR DESCRIPTION
Rationale for this is that the whole point of autocompletion is to be intuitive and show up naturally when starting to type something else. Helper for this is just extra noise user does not need.

For example, all commands start with `/`, so obviously starting to type a command will trigger autocomplete. This is true for channels as well.
Emoji are a bit particular because all systems that support emoji open their completion with `:`.
The only not-so-intuitive completion strategy is for nicks because it is not so common to start them with `@` on IRC, but as long as we keep tab completion after any set of characters, this is fine. It will be even nicer once regular tab completion uses the same autocompletion dropdown.