### PR TITLE
Better previews

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1993,20 +1993,20 @@ kbd {
 	opacity: 1;
 }
 
-#expand_preview div {
+#expand-preview div {
 	display: flex;
 	justify-content: center;
 	max-height: 100%;
 	overflow: hidden;
 }
 
-#expand_preview img {
+#expand-preview img {
 	max-height: 100%;
 	max-width: 100%;
 	object-fit: contain;
 }
 
-#expand_preview a {
+#expand-preview a {
 	display: inline-block;
 	margin: 0 auto;
 	padding: 10px;

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1165,7 +1165,7 @@ kbd {
 
 #chat .toggle-content .head {
 	font-weight: bold;
-	margin-bottom: 10px;
+	margin-bottom: 1vh;
 }
 
 #chat .toggle-content .body {

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1159,7 +1159,7 @@ kbd {
 	width: 100%;
 	top: 9vh;
 	height: 3vh;
-	background: linear-gradient(to bottom, rgba(245, 245, 245, .3) 0%, rgba(245, 245, 245, 1) 90%);
+	background: linear-gradient(to bottom, rgba(245, 245, 245, .3) 0%, rgba(245, 245, 245, 1) 100%);
 	content: " ";
 }
 

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -195,7 +195,9 @@ kbd {
 
 .context-menu-user:before { content: "\f007"; /* http://fontawesome.io/icon/user/ */ }
 .context-menu-chan:before { content: "\f0f6"; /* http://fontawesome.io/icon/file-text-o/ */ }
-.context-menu-close:before { content: "\f00d"; /* http://fontawesome.io/icon/times/ */ }
+
+.context-menu-close:before,
+.context-menu-hide-pref:before { content: "\f00d"; /* http://fontawesome.io/icon/times/ */ }
 
 #sidebar .chan.lobby:before,
 #chat .lobby .title:before { content: "\f0a0"; /* http://fontawesome.io/icon/hdd-o/ */ }
@@ -1093,7 +1095,7 @@ kbd {
 #chat .toggle-content {
 	background: #f5f5f5;
 	border-radius: 2px;
-	display: none;
+	display: inline-block;
 	color: #222;
 	font-size: 12px;
 	max-width: 100%;
@@ -1104,30 +1106,66 @@ kbd {
 
 #chat .toggle-content a {
 	color: inherit;
+	position: relative;
+	display: flex;
+	width: 100%;
+}
+
+#chat .toggle-content a:hover {
+	opacity: .7;
+}
+
+#chat .toggle-content.toggle-type-link {
+	display: -webkit-inline-flex;
+	display: inline-flex;
+	-webkit-align-items: stretch;
+	align-items: stretch;
+	overflow: hidden;
+	position: relative;
+	margin-bottom: 5px;
 }
 
 #chat .toggle-content img {
+	-webkit-transform: translateZ(0);
+	transform: translateZ(0);
 	max-width: 100%;
-	max-height: 128px;
+	max-height: 27vh;
 	display: block;
+	cursor: pointer;
+	transition: opacity .2s;
+}
+
+#chat .toggle-content img:hover {
+	opacity: .85;
 }
 
 #chat .toggle-content .thumb {
-	float: left;
-	margin-right: 6px;
-	max-width: 48px;
-	max-height: 32px;
+	max-height: 12vh;
+	max-width: 35%;
+	height: auto;
+	padding-right: 10px;
+	object-fit: contain;
+	align-self: center;
 }
 
-#chat .toggle-content .head,
-#chat .toggle-content .body {
-	white-space: nowrap;
-	text-overflow: ellipsis;
+#chat .toggle-content .info_wrap {
+	margin: auto 0;
+	max-height: 12vh;
 	overflow: hidden;
+}
+
+#chat .toggle-content.toggle-type-link a:after {
+	position: absolute;
+	width: 100%;
+	top: 9vh;
+	height: 3vh;
+	background: linear-gradient(to bottom, rgba(245, 245, 245, .3) 0%, rgba(245, 245, 245, 1) 90%);
+	content: " ";
 }
 
 #chat .toggle-content .head {
 	font-weight: bold;
+	margin-bottom: 10px;
 }
 
 #chat .toggle-content .body {
@@ -1924,6 +1962,55 @@ kbd {
 	#help .help-item .description {
 		display: block;
 	}
+
+	#chat .msg.toggle .time {
+		display: none;
+	}
+}
+
+.fullscreen {
+	-webkit-transform: translateZ(0);
+	transform: translateZ(0);
+	position: absolute;
+	width: 100%;
+	height: 100%;
+	background: rgba(0, 0, 0, .85);
+	visibility: hidden;
+	opacity: 0;
+	transition: opacity .3s, visibility .3s linear;
+	z-index: 999;
+	display: -webkit-flex;
+	display: flex;
+	-webkit-flex-direction: column;
+	flex-direction: column;
+	-webkit-justify-content: center;
+	justify-content: center;
+	text-align: center;
+}
+
+.fullscreen.display {
+	visibility: visible;
+	opacity: 1;
+}
+
+#expand_preview div {
+	display: flex;
+	justify-content: center;
+	max-height: 100%;
+	overflow: hidden;
+}
+
+#expand_preview img {
+	max-height: 100%;
+	max-width: 100%;
+	object-fit: contain;
+}
+
+#expand_preview a {
+	display: inline-block;
+	margin: 0 auto;
+	padding: 10px;
+	color: #ccc;
 }
 
 ::-webkit-scrollbar {

--- a/client/index.html
+++ b/client/index.html
@@ -902,7 +902,7 @@
 				</div>
 			</div>
 		</div>
-		<div id="expand_preview" class="fullscreen"></div>
+		<div id="expand-preview" class="fullscreen"></div>
 	</div>
 	</div>
 

--- a/client/index.html
+++ b/client/index.html
@@ -902,6 +902,7 @@
 				</div>
 			</div>
 		</div>
+		<div id="expand_preview" class="fullscreen"></div>
 	</div>
 	</div>
 

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -622,6 +622,15 @@ $(function() {
 	var contextMenuContainer = $("#context-menu-container");
 	var contextMenu = $("#context-menu");
 
+	$(window).on("popstate", function(event) {
+		var state = event.originalEvent.state;
+		var preview = $("#expand_preview");
+
+		if ((preview.hasClass("display") && (!state.clickTarget || state.clickTarget.indexOf("toggle-content") === -1))) {
+			preview.removeClass("display");
+		}
+	});
+
 	$("#main").on("click", function(e) {
 		if ($(e.target).is(".lt")) {
 			sidebarSlide.toggle(!sidebarSlide.isOpen());
@@ -630,11 +639,21 @@ $(function() {
 		}
 	});
 
-	viewport.on("click", "#expand_preview, .toggle-content img", function() {
+	viewport.on("click", "#expand_preview, .toggle-content img", function(e, data) {
 		var self = $(this);
 		var container = $("#expand_preview");
+		var state = {};
+
 		if (self.is("img")) {
+			if (!data || data.pushState !== false) {
+				state.scrollTop = $(window).scrollTop();
+				history.pushState(state, null, null); // save current scroll position
+				state.clickTarget = `#chat .chan.active .toggle-content[data-id="${self.parent().data("id")}"] > img`;
+				history.pushState(state, null, null);
+			}
 			container.html(templates.toggle_expand({link: self.attr("src")}));
+		} else {
+			history.back();
 		}
 		container.toggleClass("display");
 	});

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -624,7 +624,7 @@ $(function() {
 
 	$(window).on("popstate", function(event) {
 		var state = event.originalEvent.state;
-		var preview = $("#expand_preview");
+		var preview = $("#expand-preview");
 
 		if ((preview.hasClass("display") && (!state.clickTarget || state.clickTarget.indexOf("toggle-content") === -1))) {
 			preview.removeClass("display");
@@ -639,9 +639,9 @@ $(function() {
 		}
 	});
 
-	viewport.on("click", "#expand_preview, .toggle-content img", function(e, data) {
+	viewport.on("click", "#expand-preview, .toggle-content img", function(e, data) {
 		var self = $(this);
-		var container = $("#expand_preview");
+		var container = $("#expand-preview");
 		var state = {};
 
 		if (self.is("img")) {

--- a/client/themes/morning.css
+++ b/client/themes/morning.css
@@ -227,6 +227,10 @@ body {
 	color: #99a2b4;
 }
 
+#chat .toggle-content.toggle-type-link a:after {
+	background: linear-gradient(to bottom, rgba(36, 42, 51, .3) 0%, rgba(36, 42, 51, 1) 90%);
+}
+
 .btn-reconnect {
 	background: #e74c3c;
 	color: #fff;

--- a/client/themes/morning.css
+++ b/client/themes/morning.css
@@ -228,7 +228,7 @@ body {
 }
 
 #chat .toggle-content.toggle-type-link a:after {
-	background: linear-gradient(to bottom, rgba(36, 42, 51, .3) 0%, rgba(36, 42, 51, 1) 90%);
+	background: linear-gradient(to bottom, rgba(36, 42, 51, .3) 0%, rgba(36, 42, 51, 1) 100%);
 }
 
 .btn-reconnect {

--- a/client/themes/zenburn.css
+++ b/client/themes/zenburn.css
@@ -253,6 +253,10 @@ body {
 	color: #d2d39b;
 }
 
+#chat .toggle-content.toggle-type-link a:after {
+	background: linear-gradient(to bottom, rgba(147, 179, 163, .3) 0%, rgba(147, 179, 163, 1) 90%);
+}
+
 .btn-reconnect {
 	background: #e74c3c;
 	color: #fff;

--- a/client/themes/zenburn.css
+++ b/client/themes/zenburn.css
@@ -254,7 +254,7 @@ body {
 }
 
 #chat .toggle-content.toggle-type-link a:after {
-	background: linear-gradient(to bottom, rgba(147, 179, 163, .3) 0%, rgba(147, 179, 163, 1) 90%);
+	background: linear-gradient(to bottom, rgba(147, 179, 163, .3) 0%, rgba(147, 179, 163, 1) 100%);
 }
 
 .btn-reconnect {

--- a/client/views/index.js
+++ b/client/views/index.js
@@ -28,6 +28,7 @@ module.exports = {
 	msg_unhandled: require("./msg_unhandled.tpl"),
 	network: require("./network.tpl"),
 	toggle: require("./toggle.tpl"),
+	toggle_expand: require("./toggle_expand.tpl"),
 	unread_marker: require("./unread_marker.tpl"),
 	user: require("./user.tpl"),
 	user_filtered: require("./user_filtered.tpl"),

--- a/client/views/msg.tpl
+++ b/client/views/msg.tpl
@@ -10,7 +10,7 @@
 	{{#equal type "toggle"}}
 		<span class="text">
 			<div class="force-newline">
-				<button id="toggle-{{id}}" class="toggle-button" aria-label="Toggle prefetched media">···</button>
+				<button data-openid="{{id}}" class="toggle-button {{#if toggle.show}}hide{{/if}}" aria-label="Open prefetched media">···</button>
 			</div>
 			{{#if toggle}}
 				{{> toggle}}

--- a/client/views/toggle.tpl
+++ b/client/views/toggle.tpl
@@ -1,17 +1,17 @@
 {{#toggle}}
-<div class="toggle-content toggle-type-{{type}}">
+<div class="toggle-content toggle-type-{{type}} {{#unless show}}hide{{/unless}}" data-id="{{id}}">
 	{{#equal type "image"}}
-		<a href="{{link}}" target="_blank">
-			<img src="{{link}}">
-		</a>
+		<img src="{{link}}">
 	{{else}}
+		{{#if thumb}}
+			<img src="{{thumb}}" class="thumb">
+		{{/if}}
 		<a href="{{link}}" target="_blank">
-			{{#if thumb}}
-				<img src="{{thumb}}" class="thumb">
-			{{/if}}
-			<div class="head">{{head}}</div>
-			<div class="body">
-				{{body}}
+			<div class="info_wrap">
+				{{#if head}}<div class="head">{{head}}</div>{{/if}}
+				<div class="body">
+					{{body}}
+				</div>
 			</div>
 		</a>
 	{{/equal}}

--- a/client/views/toggle_expand.tpl
+++ b/client/views/toggle_expand.tpl
@@ -1,0 +1,6 @@
+<div>
+	<img src="{{link}}">
+</div>
+<a href="{{link}}" target="_blank">
+	Open in new tab
+</a>


### PR DESCRIPTION
# New design

![2017-05-03_05-10-07](https://cloud.githubusercontent.com/assets/3627488/25647535/7ef33b82-2fcb-11e7-91f3-1a1c956257a7.png)

- Pictures now have max-height in vh, so they are bigger/smaller depending on user screen size
- Site description is multiline again
- ~~Site previews now take all width (see #1084)~~
- Site thumbnail is ~2 times smaller than picture preview

# New features
1. When preview is shown, toggle button is hidden now (only if auto-expand is `on`):

![2017-05-03_06-49-00](https://cloud.githubusercontent.com/assets/3627488/25647675/caa62fc0-2fcc-11e7-8a18-8e0a130cdcc3.png)

It's still possible to hide it again using right click:

![2017-05-03_06-51-06](https://cloud.githubusercontent.com/assets/3627488/25647692/fbb8a08e-2fcc-11e7-9310-59651abdf7b1.png)

-------------------------------

2. Now it's possible to expand images from previews:

![2017-05-03_05-11-28](https://cloud.githubusercontent.com/assets/3627488/25647728/5d27bc24-2fcd-11e7-8f8d-b57c69e16b61.png)

![2017-05-03_05-07-47](https://cloud.githubusercontent.com/assets/3627488/25647732/67b3fab8-2fcd-11e7-8f7c-0b22e057e7e3.png)

This works both for pictures and site thumbnails. It's really awesome, believe me!

# Bugfixes
1. Finally fixed these options:
![2017-05-03_05-12-07](https://cloud.githubusercontent.com/assets/3627488/25647809/180ad06c-2fce-11e7-8fc3-11c955431259.png)
^^ content in backlog is now affected too.

--------------------------------
2. Extra space is removed (mobile only):

![2017-05-03_07-05-53](https://cloud.githubusercontent.com/assets/3627488/25647913/02205410-2fcf-11e7-837a-e8b5e55f29a5.png)


--------------------------------
# TODO

- [x] Revert site previews width
- [x] Bind "back" button to expanded previews (mobile)
- [x] Keep toggle button if auto-expand options are disabled
