### PR TITLE
Allow autocompleting full emoji short names

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -48,7 +48,7 @@ $(function() {
 
 	const emojiStrategy = {
 		id: "emoji",
-		match: /\B:([-+\w]*)$/,
+		match: /\B:([-+\w]*):?$/,
 		search(term, callback) {
 			callback(Object.keys(emojiMap).filter(name => name.indexOf(term) === 0));
 		},


### PR DESCRIPTION
`:fu:<tab>` now works, where previously it didn't.