### PR TITLE
Show seconds in timestamp

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -901,8 +901,7 @@ kbd {
 
 #chat .time {
 	color: #ddd;
-	text-align: right;
-	width: 46px;
+	padding-left: 10px;
 }
 
 #chat .from {

--- a/client/index.html
+++ b/client/index.html
@@ -249,6 +249,12 @@
 									Show quits
 								</label>
 							</div>
+							<div class="col-sm-6">
+								<label class="opt">
+									<input type="checkbox" name="showSeconds">
+									Show seconds in timestamp
+								</label>
+							</div>
 							<div class="col-sm-12">
 								<h2>Visual Aids</h2>
 							</div>

--- a/client/js/constants.js
+++ b/client/js/constants.js
@@ -54,7 +54,13 @@ const commands = [
 	"/whois"
 ];
 
+const timeFormats = {
+	msgDefault: "HH:mm",
+	msgWithSeconds: "HH:mm:ss"
+};
+
 module.exports = {
 	colorCodeMap: colorCodeMap,
+	timeFormats: timeFormats,
 	commands: commands
 };

--- a/client/js/libs/handlebars/tz.js
+++ b/client/js/libs/handlebars/tz.js
@@ -1,7 +1,10 @@
 "use strict";
 
 const moment = require("moment");
+const constants = require("../../constants");
 
 module.exports = function(time) {
-	return moment(time).format("HH:mm");
+	const options = require("../../options");
+	const format = options.showSeconds ? constants.timeFormats.msgWithSeconds : constants.timeFormats.msgDefault;
+	return moment(time).format(format);
 };

--- a/client/js/options.js
+++ b/client/js/options.js
@@ -3,6 +3,7 @@ const $ = require("jquery");
 const settings = $("#settings");
 const userStyles = $("#user-specified-css");
 const storage = require("./localStorage");
+const tz = require("./libs/handlebars/tz");
 
 const windows = $("#windows");
 const chat = $("#chat");
@@ -19,6 +20,7 @@ const options = $.extend({
 	notifyAllMessages: false,
 	part: true,
 	quit: true,
+	showSeconds: false,
 	theme: $("#theme").attr("href").replace(/^themes\/(.*).css$/, "$1"), // Extracts default theme name, set on the server configuration
 	thumbnails: true,
 	userStyles: userStyles.text(),
@@ -79,6 +81,10 @@ settings.on("change", "input, select, textarea", function() {
 			// Ensure we don't have empty string in the list of highlights
 			// otherwise, users get notifications for everything
 			return h !== "";
+		});
+	} else if (name === "showSeconds") {
+		chat.find(".msg > .time").each(function() {
+			$(this).text(tz($(this).parent().data("time")));
 		});
 	}
 }).find("input")


### PR DESCRIPTION
Just a simple option in settings (disabled by default):

![2017-05-06_21-46-37](https://cloud.githubusercontent.com/assets/3627488/25775084/814f4d80-32a5-11e7-93be-48c7917ecf90.png)

Here how it looks:

![2017-05-06_21-40-54](https://cloud.githubusercontent.com/assets/3627488/25775088/917437a2-32a5-11e7-9310-15f530ee2632.png)

Related issue: #98