### PR TITLE
Display MOTD by default on client

### DIFF
--- a/client/js/options.js
+++ b/client/js/options.js
@@ -13,7 +13,7 @@ const options = $.extend({
 	join: true,
 	links: true,
 	mode: true,
-	motd: false,
+	motd: true,
 	nick: true,
 	notification: true,
 	notifyAllMessages: false,


### PR DESCRIPTION
Fixes #1019 (again).

This was changed in https://github.com/thelounge/lounge/pull/1052 by @KlipperKyle but this change was lost during the switch to `options` module in #1066.