### PR TITLE
Fade out for long usernames.

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -911,6 +911,9 @@ kbd {
 	padding-right: 10px;
 	text-align: right;
 	width: 134px;
+	overflow: hidden;
+	white-space: nowrap;
+	position: relative;
 }
 
 #chat .text {
@@ -1808,6 +1811,25 @@ kbd {
 
 .irc-italic {
 	font-style: italic;
+}
+
+@media (min-width: 480px) {
+	/* Fade out for long usernames */
+
+	#chat .from {
+		padding-left: 10px;
+	}
+
+	#chat .from:after {
+		position: absolute;
+		right: 0;
+		width: 10px;
+		height: 100%;
+		background: linear-gradient(to right, rgba(255, 255, 255, .5) 0%, rgba(255, 255, 255, 1) 100%);
+		content: " ";
+	}
+
+	/* End fade out for long usernames */
 }
 
 @media (max-width: 768px) {

--- a/client/themes/morning.css
+++ b/client/themes/morning.css
@@ -253,3 +253,9 @@ body {
 }
 
 /* End form elements */
+
+@media (min-width: 480px) {
+	#chat .from:after {
+		background: linear-gradient(to right, rgba(51, 60, 74, .5) 0%, rgba(51, 60, 74, 1) 100%);
+	}
+}

--- a/client/themes/zenburn.css
+++ b/client/themes/zenburn.css
@@ -279,3 +279,9 @@ body {
 }
 
 /* End form elements */
+
+@media (min-width: 480px) {
+	#chat .from:after {
+		background: linear-gradient(to right, rgba(63, 63, 63, .5) 0%, rgba(63, 63, 63, 1) 100%);
+	}
+}


### PR DESCRIPTION
Issue: #577

I get that [text-overflow: fade](https://developer.mozilla.org/en/docs/Web/CSS/text-overflow) is better solution, but who knows when we can use it. So this a temporary fix, until `fade` option will be available.

![2017-05-11_03-07-04](https://cloud.githubusercontent.com/assets/3627488/25926905/d53d9e80-35fa-11e7-8c03-370958b2999d.png)