### PR TITLE
Restore Shout behavior in private windows

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -799,21 +799,38 @@ kbd {
 	width: 100%;
 }
 
+#windows .header .button,
 #chat .show-more-button {
 	background: #f4f4f4;
-	background-image: linear-gradient(#f4f4f4, #ececec);
+	transition: all .3s;
+	background-size: auto 200%;
+	background-position: 0 100%;
+	background-image: linear-gradient(#fefefe, #ececec);
 	border: 1px solid #d7d7d7;
 	border-bottom-color: #b7b7b7;
 	border-radius: 2px;
 	color: #555;
 	font-size: 12px;
+}
+
+#windows .header .button {
+	height: 25px;
+	line-height: 0;
+	padding: 0 10px;
+	float: right;
+	margin: 11px -8px 0 12px;
+}
+
+#chat .show-more-button {
 	height: 34px;
 	line-height: 0;
 	width: 100%;
 }
 
+#windows .header .button:hover,
 #chat .show-more-button:hover {
 	opacity: 1;
+	background-position: 0 0;
 }
 
 #chat .messages {

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -28,6 +28,8 @@ $(function() {
 
 	var ignoreSortSync = false;
 
+	var initHistoryLength = history.length;
+
 	var pop;
 	try {
 		pop = new Audio();
@@ -585,8 +587,10 @@ $(function() {
 	socket.on("part", function(data) {
 		var chanMenuItem = sidebar.find(".chan[data-id='" + data.chan + "']");
 
-		// When parting from the active channel/query, jump to the network's lobby
-		if (chanMenuItem.hasClass("active")) {
+		// When parting from the active channel/query, jump to the previous channel or to the network's lobby
+		if (history.length - initHistoryLength > 0) {
+			history.back();
+		} else if (chanMenuItem.hasClass("active")) {
 			chanMenuItem.parent(".network").find(".lobby").click();
 		}
 
@@ -1064,6 +1068,15 @@ $(function() {
 			opacity: 0.4
 		});
 		return false;
+	});
+
+	chat.on("click", "button.close", function() {
+		var id = $(this)
+			.closest(".chan")
+			.data("id");
+		sidebar.find(".chan[data-id='" + id + "']")
+			.find(".close")
+			.click();
 	});
 
 	contextMenu.on("click", ".context-menu-item", function() {

--- a/client/views/chat.tpl
+++ b/client/views/chat.tpl
@@ -7,6 +7,9 @@
 				<button class="rt" aria-label="Toggle user list"></button>
 			</span>
 		{{/equal}}
+		{{#equal type "query"}}
+			<button class="button close" aria-label="Close current chat">Close</button>
+		{{/equal}}
 		<button class="menu" aria-label="Open the context menu"></button>
 		<span class="title">{{name}}</span>
 		<span title="{{topic}}" class="topic">{{{parse topic}}}</span>


### PR DESCRIPTION
@astorije you may say "it's a feature" as much as you like, but for me it's a bug, which needs to be fixed :blush: 

So this PR:
- restores Shout behavior and sends user back to the previous channel when closing current one (window.history is used)
- restores Shout's `close` button in private window **only**

![2017-05-11_05-40-24](https://cloud.githubusercontent.com/assets/3627488/25930030/63690f30-360c-11e7-8775-f6b0fcb0ebd5.png)

Conflicts with #1148, #1117

Related: #1099, #489, #503

