### PR TITLE
Display images with unknown size in prefetch (#1162)

### DIFF
--- a/defaults/config.js
+++ b/defaults/config.js
@@ -78,6 +78,14 @@ module.exports = {
 	prefetchMaxImageSize: 512,
 
 	//
+	// Display images with unknown size in prefetch.
+	//
+	// @type     boolean
+	// @default  false
+	//
+	prefetchUndefinedImageSize: false,
+
+	//
 	// Display network
 	//
 	// If set to false network settings will not be shown in the login form.

--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -64,7 +64,8 @@ function parse(msg, url, res, client) {
 	case "image/gif":
 	case "image/jpg":
 	case "image/jpeg":
-		if (res.size < (Helper.config.prefetchMaxImageSize * 1024)) {
+		if ((res.size === undefined && Helper.config.prefetchUndefinedImageSize) ||
+			(res.size < (Helper.config.prefetchMaxImageSize * 1024))) {
 			toggle.type = "image";
 		} else {
 			return;


### PR DESCRIPTION
Images served via scripts usually don't have size header.