### PR TITLE
Enable client socket reconnection

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1369,8 +1369,20 @@ kbd {
 }
 
 #connection-error {
+	display: none;
+	text-align: center;
+	position: absolute;
+	bottom: 0;
+	width: 100%;
+	height: 45px;
+	line-height: 45px;
+	background: rgba(255, 0, 0, .5);
 	color: #fff;
-	font-size: 20px;
+	cursor: default;
+}
+
+#connection-error.shown {
+	display: block;
 }
 
 [contenteditable]:focus {
@@ -1924,10 +1936,6 @@ kbd {
 
 	#help .help-item .description {
 		display: block;
-	}
-
-	#connection-error {
-		font-size: 5vw;
 	}
 }
 

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1369,11 +1369,8 @@ kbd {
 }
 
 #connection-error {
-	display: none;
-}
-
-#connection-error.shown {
-	display: block;
+	color: #fff;
+	font-size: 20px;
 }
 
 [contenteditable]:focus {
@@ -1927,6 +1924,10 @@ kbd {
 
 	#help .help-item .description {
 		display: block;
+	}
+
+	#connection-error {
+		font-size: 5vw;
 	}
 }
 

--- a/client/index.html
+++ b/client/index.html
@@ -74,6 +74,7 @@
 							</span>
 						</div>
 					</form>
+					<div id="connection-error">Client connection lost, reconnecting...</div>
 				</div>
 				<div id="sign-in" class="window">
 					<form class="container" method="post" action="">
@@ -856,7 +857,6 @@
 				</div>
 			</div>
 		</div>
-		<div id="connection-error" class="fullscreen">Client connection lost, reconnecting...</div>
 	</div>
 	</div>
 

--- a/client/index.html
+++ b/client/index.html
@@ -60,7 +60,6 @@
 				</div>
 				<div id="chat-container" class="window">
 					<div id="chat"></div>
-					<button id="connection-error" class="btn btn-reconnect">Client connection lost &mdash; Click here to reconnect</button>
 					<form id="form" method="post" action="">
 						<div class="input">
 							<span id="nick">
@@ -857,6 +856,7 @@
 				</div>
 			</div>
 		</div>
+		<div id="connection-error" class="fullscreen">Client connection lost, reconnecting...</div>
 	</div>
 	</div>
 

--- a/client/js/libs/jquery/inputhistory.js
+++ b/client/js/libs/jquery/inputhistory.js
@@ -31,6 +31,9 @@ import jQuery from "jquery";
 		
 		var i = 0;
 		self.on("keydown", function(e) {
+			if (self.data("disabled")) {
+				return;
+			}
 			var key = e.which;
 			switch (key) {
 			case 13: // Enter

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -220,6 +220,32 @@ $(function() {
 	});
 
 	socket.on("init", function(data) {
+		if (!$("#loading").length) {
+			var channels = $.map(data.networks, function(n) {
+				return n.channels;
+			});
+
+			channels.forEach(function(channel) {
+				renderChannel(channel);
+				if (channel.unread > 0 && channel.type === "channel") {
+					var badge = sidebar.find(".chan[data-title='" + channel.name + "'] .badge");
+					badge.text(channel.unread);
+					if (channel.highlight) {
+						badge.addClass("highlight");
+					}
+				}
+			});
+
+			if (sidebar.find(".highlight").length) {
+				toggleNotificationMarkers(true);
+			}
+
+			$("#connection-error").removeClass("display");
+			$("#input").removeAttr("disabled");
+
+			return;
+		}
+
 		$("#loading-page-message").text("Rendering…");
 
 		if (data.networks.length === 0) {
@@ -369,7 +395,7 @@ $(function() {
 
 	function renderChannelMessages(data) {
 		var documentFragment = buildChannelMessages(data.id, data.messages);
-		var channel = chat.find("#chan-" + data.id + " .messages").append(documentFragment);
+		var channel = chat.find("#chan-" + data.id + " .messages").html(documentFragment);
 
 		if (data.firstUnread > 0) {
 			var first = channel.find("#msg-" + data.firstUnread);

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -240,8 +240,9 @@ $(function() {
 				toggleNotificationMarkers(true);
 			}
 
-			$("#connection-error").removeClass("display");
-			$("#input").removeAttr("disabled");
+			$("#connection-error").removeClass("shown");
+			$("#submit").removeAttr("disabled");
+			$("#input").data("disabled", false);
 
 			return;
 		}
@@ -804,6 +805,11 @@ $(function() {
 			},
 			"textComplete:hide": function() {
 				$(this).data("autocompleting", false);
+			},
+			keydown: function() {
+				if (event.which === 13 && !event.shiftKey) {
+					event.preventDefault();
+				}
 			}
 		});
 

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -227,12 +227,10 @@ $(function() {
 
 			channels.forEach(function(channel) {
 				renderChannel(channel);
-				if (channel.unread > 0 && channel.type === "channel") {
-					var badge = sidebar.find(".chan[data-title='" + channel.name + "'] .badge");
-					badge.text(channel.unread);
-					if (channel.highlight) {
-						badge.addClass("highlight");
-					}
+				var badge = sidebar.find(".chan[data-title='" + channel.name + "'] .badge");
+				badge.text(channel.unread ? channel.unread : "");
+				if (channel.highlight) {
+					badge.addClass("highlight");
 				}
 			});
 

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -221,8 +221,11 @@ $(function() {
 
 	socket.on("init", function(data) {
 		const loaded = $("#loading").length === 0;
+		let previousActive = 0;
 
-		if (!loaded) {
+		if (loaded) {
+			previousActive = sidebar.find(".active").data("id");
+		} else {
 			$("#loading-page-message").text("Rendering…");
 		}
 
@@ -250,18 +253,24 @@ $(function() {
 			$("#sign-in").remove();
 		}
 
-		var id = data.active;
-		var target = sidebar.find("[data-id='" + id + "']").trigger("click", {
-			replaceHistory: true
-		});
-		if (target.length === 0) {
-			var first = sidebar.find(".chan")
-				.eq(0)
-				.trigger("click");
-			if (first.length === 0) {
-				$("#footer").find(".connect").trigger("click", {
-					pushState: false,
-				});
+		let previousTarget = sidebar.find("[data-id='" + previousActive + "']");
+
+		if (loaded && previousTarget.length > 0) {
+			previousTarget.addClass("active");
+		} else {
+			let id = data.active;
+			let target = sidebar.find("[data-id='" + id + "']").trigger("click", {
+				replaceHistory: true
+			});
+			if (target.length === 0) {
+				let first = sidebar.find(".chan")
+					.eq(0)
+					.trigger("click");
+				if (first.length === 0) {
+					$("#footer").find(".connect").trigger("click", {
+						pushState: false,
+					});
+				}
 			}
 		}
 	});

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -461,7 +461,7 @@ $(function() {
 
 	function renderNetworks(data, append) {
 		const loaded = $("#loading").length === 0;
-		let channels = {};
+		let channelsAppend;
 
 		if (loaded) {
 			let channelsNew = [];
@@ -470,7 +470,7 @@ $(function() {
 			}).get();
 
 			// reconnection, add only new channels
-			channels = $.map(data.networks, function(n) {
+			channelsAppend = $.map(data.networks, function(n) {
 				return $.map(n.channels, function(c) {
 					channelsNew.push(c.id);
 					return channelsCurrent.indexOf(c.id) > -1 ? null : c;
@@ -485,9 +485,6 @@ $(function() {
 				});
 			}
 		} else {
-			channels = $.map(data.networks, function(n) {
-				return n.channels;
-			});
 			sidebar.find(".empty").hide();
 		}
 
@@ -501,9 +498,13 @@ $(function() {
 			sidebar.find(".networks").html(renderedNetworks);
 		}
 
+		let channels = $.map(data.networks, function(n) {
+			return n.channels;
+		});
+
 		chat.append(
 			templates.chat({
-				channels: channels
+				channels: loaded ? channelsAppend : channels
 			})
 		);
 		channels.forEach(renderChannel);

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -234,7 +234,7 @@ $(function() {
 				pushState: false,
 			});
 		} else {
-			renderNetworks(data);
+			renderNetworks(data, false);
 		}
 
 		if (loaded) {
@@ -458,7 +458,7 @@ $(function() {
 		}
 	}
 
-	function renderNetworks(data) {
+	function renderNetworks(data, append) {
 		const loaded = $("#loading").length === 0;
 		let channels = {};
 
@@ -477,22 +477,28 @@ $(function() {
 			});
 
 			// remove old
-			let diff = channelsCurrent.filter(x => channelsNew.indexOf(x) < 0);
-			diff.forEach(function(id) {
-				sidebar.find(".chan[data-id='" + id + "'] .close").click();
-			});
+			if (!append) {
+				let diff = channelsCurrent.filter(x => channelsNew.indexOf(x) < 0);
+				diff.forEach(function(id) {
+					chat.find(".chan[data-id='" + id + "']").remove();
+				});
+			}
 		} else {
 			channels = $.map(data.networks, function(n) {
 				return n.channels;
 			});
+			sidebar.find(".empty").hide();
 		}
 
-		sidebar.find(".empty").hide();
-		sidebar.find(".networks").html(
-			templates.network({
-				networks: data.networks
-			})
-		);
+		let renderedNetworks = templates.network({
+			networks: data.networks
+		});
+
+		if (append) {
+			sidebar.find(".networks").append(renderedNetworks);
+		} else {
+			sidebar.find(".networks").html(renderedNetworks);
+		}
 
 		chat.append(
 			templates.chat({
@@ -606,7 +612,7 @@ $(function() {
 	});
 
 	socket.on("network", function(data) {
-		renderNetworks(data);
+		renderNetworks(data, true);
 
 		sidebar.find(".chan")
 			.last()

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -1226,6 +1226,10 @@ $(function() {
 
 	chat.on("click", ".show-more-button", function() {
 		var self = $(this);
+		if ($("#connection-error").is(".shown")) {
+			self.data("loading", true);
+			return;
+		}
 		var count = self.parent().next(".messages").children(".msg").length;
 		self.prop("disabled", true);
 		socket.emit("more", {

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -239,7 +239,8 @@ $(function() {
 
 		if (loaded) {
 			$("#connection-error").removeClass("shown");
-			$("#submit").removeAttr("disabled");
+			$("#submit").prop("disabled", false);
+			$(".show-more-button").prop("disabled", false);
 			$("#input").data("disabled", false);
 		} else {
 			if (data.token && $("#sign-in-remember").is(":checked")) {
@@ -1241,10 +1242,6 @@ $(function() {
 
 	chat.on("click", ".show-more-button", function() {
 		var self = $(this);
-		if ($("#connection-error").is(".shown")) {
-			self.data("loading", true);
-			return;
-		}
 		var count = self.parent().next(".messages").children(".msg").length;
 		self.prop("disabled", true);
 		socket.emit("more", {

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -388,11 +388,14 @@ $(function() {
 	}
 
 	function renderChannelMessages(data) {
-		var documentFragment = buildChannelMessages(data.id, data.messages);
-		var channel = chat.find("#chan-" + data.id + " .messages").html(documentFragment);
+		let documentFragment = buildChannelMessages(data.id, data.messages);
+		let channel = chat.find("#chan-" + data.id + " .messages").html(documentFragment);
+		let more = chat.find("#chan-" + data.id + " .show-more");
+
+		more.toggleClass("show", (data.messages.length === 100));
 
 		if (data.firstUnread > 0) {
-			var first = channel.find("#msg-" + data.firstUnread);
+			let first = channel.find("#msg-" + data.firstUnread);
 
 			// TODO: If the message is far off in the history, we still need to append the marker into DOM
 			if (!first.length) {

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -512,7 +512,16 @@ $(function() {
 		);
 		channels.forEach(renderChannel);
 
-		if (!loaded) {
+		if (loaded) {
+			let activeChan = chat.find(".chan.active");
+			socket.emit(
+				"open",
+				activeChan.data("id")
+			);
+			activeChan.find(".badge")
+				.removeClass("highlight")
+				.empty();
+		} else {
 			confirmExit();
 		}
 

--- a/client/js/socket.js
+++ b/client/js/socket.js
@@ -7,7 +7,8 @@ const path = window.location.pathname + "socket.io/";
 const socket = io({
 	path: path,
 	autoConnect: false,
-	reconnection: false
+	timeout: 20000,
+	reconnection: true
 });
 
 [
@@ -18,22 +19,8 @@ const socket = io({
 ].forEach(function(e) {
 	socket.on(e, function(data) {
 		$("#loading-page-message").text("Connection failed: " + data);
-		$("#connection-error").addClass("shown").one("click", function() {
-			window.onbeforeunload = null;
-			window.location.reload();
-		});
-
-		// Disables sending a message by pressing Enter. `off` is necessary to
-		// cancel `inputhistory`, which overrides hitting Enter. `on` is then
-		// necessary to avoid creating new lines when hitting Enter without Shift.
-		// This is fairly hacky but this solution is not permanent.
-		$("#input").off("keydown").on("keydown", function(event) {
-			if (event.which === 13 && !event.shiftKey) {
-				event.preventDefault();
-			}
-		});
-		// Hides the "Send Message" button
-		$("#submit").remove();
+		$("#connection-error").addClass("display");
+		$("#input").attr("disabled", "disabled");
 
 		console.error(data);
 	});

--- a/client/js/socket.js
+++ b/client/js/socket.js
@@ -7,7 +7,7 @@ const path = window.location.pathname + "socket.io/";
 const socket = io({
 	path: path,
 	autoConnect: false,
-	timeout: 30000,
+	timeout: 40000,
 	reconnection: true
 });
 

--- a/client/js/socket.js
+++ b/client/js/socket.js
@@ -20,7 +20,8 @@ const socket = io({
 	socket.on(e, function(data) {
 		$("#loading-page-message").text("Connection failed: " + data);
 		$("#connection-error").addClass("shown");
-		$("#submit").attr("disabled", "disabled");
+		$("#submit").prop("disabled", true);
+		$(".show-more-button").prop("disabled", true);
 		$("#input").data("disabled", true);
 
 		console.error(data);

--- a/client/js/socket.js
+++ b/client/js/socket.js
@@ -7,7 +7,7 @@ const path = window.location.pathname + "socket.io/";
 const socket = io({
 	path: path,
 	autoConnect: false,
-	timeout: 20000,
+	timeout: 30000,
 	reconnection: true
 });
 
@@ -19,8 +19,9 @@ const socket = io({
 ].forEach(function(e) {
 	socket.on(e, function(data) {
 		$("#loading-page-message").text("Connection failed: " + data);
-		$("#connection-error").addClass("display");
-		$("#input").attr("disabled", "disabled");
+		$("#connection-error").addClass("shown");
+		$("#submit").attr("disabled", "disabled");
+		$("#input").data("disabled", true);
 
 		console.error(data);
 	});


### PR DESCRIPTION
Changes:
- socket reconnect option -> `true`
- "click to reconnect" button is replaced with "reconnecting" banner
- socket timeout is increased a bit `20000` -> `40000` 

Here how it looks:
![timeout_banner](https://cloud.githubusercontent.com/assets/3627488/26452805/f83a2582-4169-11e7-9e6d-6937c137b4fc.png)

On reconnect "init" event is parsed and channels are re-rendered. 
The input field is still accessible while the banner is displayed (message sending is disabled).

Still testing it, looks good so far.

Related: #1174, #421, #267

### TODO
- [x] disable "load more" button on reconnection
- [x] fix channels sync
- [x] ~~check embed reload on re-rendering (not sure if they are really reloaded)~~ cached
- [x] fix network/channel leave on server restart
- [x] fix "load more" button when connection is lost on "more" event / on 100 loaded messages
-  do something about performance drop
- [x] fix "new messages" marker


