### PR TITLE
Option to force https on prefetch

### DIFF
--- a/defaults/config.js
+++ b/defaults/config.js
@@ -78,6 +78,14 @@ module.exports = {
 	prefetchMaxImageSize: 512,
 
 	//
+	// Always rewrite http to https
+	//
+	// @type     boolean
+	// @default  false
+	//
+	prefetchForceSSL: false,
+
+	//
 	// Display network
 	//
 	// If set to false network settings will not be shown in the login form.

--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -31,35 +31,46 @@ module.exports = function(client, chan, originalMsg) {
 
 	const link = escapeHeader(links[0]);
 	fetch(link, function(res) {
-		parse(msg, link, res, client);
+		parse(msg, link, res, null, client);
 	});
 };
 
-function parse(msg, url, res, client) {
-	var toggle = msg.toggle = {
+function parse(msg, url, res, res2, client) {
+	let uri = res.uri;
+	let toggle = msg.toggle = {
 		id: msg.id,
 		type: "",
 		head: "",
 		body: "",
 		thumb: "",
-		link: url,
+		link: uri,
 	};
 
 	switch (res.type) {
 	case "text/html":
 		var $ = cheerio.load(res.text);
+		if (res2 === null) {
+			var image =
+				$("meta[property=\"og:image\"]").attr("content")
+				|| $("meta[name=\"twitter:image:src\"]").attr("content")
+				|| "";
+			if (image) {
+				fetch(image, function(response) {
+					parse(msg, url, res, response, client);
+				});
+				return;
+			}
+		}
 		toggle.type = "link";
 		toggle.head = $("title").text();
 		toggle.body =
 			$("meta[name=description]").attr("content")
 			|| $("meta[property=\"og:description\"]").attr("content")
 			|| "No description found.";
-		toggle.thumb =
-			$("meta[property=\"og:image\"]").attr("content")
-			|| $("meta[name=\"twitter:image:src\"]").attr("content")
-			|| "";
-		if (Helper.config.prefetchForceSSL) {
-			toggle.thumb = toggle.thumb.replace(/^http:\/\//, "https://");
+
+		var thumbnail = checkImage(res2);
+		if (thumbnail) {
+			toggle.thumb = thumbnail;
 		}
 		break;
 
@@ -67,11 +78,10 @@ function parse(msg, url, res, client) {
 	case "image/gif":
 	case "image/jpg":
 	case "image/jpeg":
-		if (res.size < (Helper.config.prefetchMaxImageSize * 1024)) {
+		uri = checkImage(res);
+		if (uri) {
 			toggle.type = "image";
-			if (Helper.config.prefetchForceSSL) {
-				toggle.link = toggle.link.replace(/^http:\/\//, "https://");
-			}
+			toggle.link = uri;
 		} else {
 			return;
 		}
@@ -82,6 +92,29 @@ function parse(msg, url, res, client) {
 	}
 
 	client.emit("toggle", toggle);
+}
+
+function checkImage(res) {
+	let uri = false;
+
+	if (res) {
+		switch (res.type) {
+		case "image/png":
+		case "image/gif":
+		case "image/jpg":
+		case "image/jpeg":
+			if (res.size < (Helper.config.prefetchMaxImageSize * 1024)) {
+				if (Helper.config.prefetchForceSSL) {
+					uri = res.uri.replace(/^http:\/\//, "https://");
+				} else {
+					uri = res.uri;
+				}
+			}
+			break;
+		}
+	}
+
+	return uri;
 }
 
 function fetch(url, cb) {
@@ -96,6 +129,7 @@ function fetch(url, cb) {
 			}
 		});
 	} catch (e) {
+		cb(false);
 		return;
 	}
 	var length = 0;
@@ -122,6 +156,7 @@ function fetch(url, cb) {
 			var body;
 			var type;
 			var size = req.response.headers["content-length"];
+			var uri = req.response.request.uri;
 			try {
 				body = JSON.parse(data);
 			} catch (e) {
@@ -133,6 +168,7 @@ function fetch(url, cb) {
 				type = {};
 			}
 			data = {
+				uri: uri.href,
 				text: data,
 				body: body,
 				type: type,

--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -58,6 +58,9 @@ function parse(msg, url, res, client) {
 			$("meta[property=\"og:image\"]").attr("content")
 			|| $("meta[name=\"twitter:image:src\"]").attr("content")
 			|| "";
+		if (Helper.config.prefetchForceSSL) {
+			toggle.thumb = toggle.thumb.replace(/^http:\/\//, "https://");
+		}
 		break;
 
 	case "image/png":
@@ -66,6 +69,9 @@ function parse(msg, url, res, client) {
 	case "image/jpeg":
 		if (res.size < (Helper.config.prefetchMaxImageSize * 1024)) {
 			toggle.type = "image";
+			if (Helper.config.prefetchForceSSL) {
+				toggle.link = toggle.link.replace(/^http:\/\//, "https://");
+			}
 		} else {
 			return;
 		}

--- a/src/server.js
+++ b/src/server.js
@@ -144,7 +144,8 @@ function index(req, res, next) {
 			filename: filename
 		};
 	});
-	res.setHeader("Content-Security-Policy", "default-src *; connect-src 'self' ws: wss:; style-src * 'unsafe-inline'; script-src 'self'; child-src 'self'; object-src 'none'; form-action 'none';");
+	let blockMixed = Helper.config.prefetchForceSSL ? "block-all-mixed-content; img-src https: data:, " : "";
+	res.setHeader("Content-Security-Policy", blockMixed + "default-src *; connect-src 'self' ws: wss:; style-src * 'unsafe-inline'; script-src 'self'; child-src 'self'; object-src 'none'; form-action 'none';");
 	res.setHeader("Referrer-Policy", "no-referrer");
 	res.render("index", data);
 }


### PR DESCRIPTION
This PR:
1. Adds option to rewrite `http://` to `https://` on prefetch to keep `Secure` status
2. Replaces redirects with the final URI
3. Adds thumbnails handling (they haven't even checked for size before)

Also fixes #1180
Conflicts with #1165