### PR TITLE
Do not store unnecessary information in user objects

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -417,7 +417,7 @@ $(function() {
 		nicks = [];
 
 		for (i in data.users) {
-			nicks.push(data.users[i].name);
+			nicks.push(data.users[i].nick);
 		}
 
 		nicks = nicks.sort(function(a, b) {

--- a/client/views/user.tpl
+++ b/client/views/user.tpl
@@ -6,6 +6,6 @@
 	{{/unless}}
 	<div class="user-mode {{modes mode}}">
 	{{/diff}}
-	<span role="button" class="user {{colorClass name}}" data-name="{{name}}">{{mode}}{{name}}</span>
+	<span role="button" class="user {{colorClass nick}}" data-name="{{nick}}">{{mode}}{{nick}}</span>
 {{/each}}
 </div>

--- a/src/models/chan.js
+++ b/src/models/chan.js
@@ -77,7 +77,7 @@ Chan.prototype.sortUsers = function(irc) {
 
 	this.users = this.users.sort(function(a, b) {
 		if (a.mode === b.mode) {
-			return a.name.toLowerCase() < b.name.toLowerCase() ? -1 : 1;
+			return a.nick.toLowerCase() < b.nick.toLowerCase() ? -1 : 1;
 		}
 
 		return userModeSortPriority[a.mode] - userModeSortPriority[b.mode];
@@ -85,7 +85,7 @@ Chan.prototype.sortUsers = function(irc) {
 };
 
 Chan.prototype.getMode = function(name) {
-	var user = _.find(this.users, {name: name});
+	var user = _.find(this.users, {nick: name});
 	if (user) {
 		return user.mode;
 	}

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -7,13 +7,21 @@ module.exports = User;
 function User(attr, prefixLookup) {
 	_.defaults(this, attr, {
 		modes: [],
+		mode: "",
 		nick: ""
 	});
 
 	// irc-framework sets character mode, but lounge works with symbols
 	this.modes = this.modes.map(mode => prefixLookup[mode]);
 
-	// TODO: Remove this
-	this.name = this.nick;
-	this.mode = (this.modes && this.modes[0]) || "";
+	if (this.modes[0]) {
+		this.mode = this.modes[0];
+	}
 }
+
+User.prototype.toJSON = function() {
+	return {
+		nick: this.nick,
+		mode: this.mode,
+	};
+};

--- a/src/plugins/irc-events/kick.js
+++ b/src/plugins/irc-events/kick.js
@@ -14,7 +14,7 @@ module.exports = function(irc, network) {
 		if (data.kicked === irc.user.nick) {
 			chan.users = [];
 		} else {
-			chan.users = _.without(chan.users, _.find(chan.users, {name: data.kicked}));
+			chan.users = _.without(chan.users, _.find(chan.users, {nick: data.kicked}));
 		}
 
 		client.emit("users", {

--- a/src/plugins/irc-events/mode.js
+++ b/src/plugins/irc-events/mode.js
@@ -81,7 +81,7 @@ module.exports = function(irc, network) {
 				return;
 			}
 
-			const user = _.find(targetChan.users, {name: mode.param});
+			const user = _.find(targetChan.users, {nick: mode.param});
 			if (!user) {
 				return;
 			}

--- a/src/plugins/irc-events/names.js
+++ b/src/plugins/irc-events/names.js
@@ -10,7 +10,12 @@ module.exports = function(irc, network) {
 			return;
 		}
 
-		chan.users = data.users.map(u => new User(u, network.prefixLookup));
+		chan.users = data.users.map(user => {
+			return new User({
+				nick: user.nick,
+				modes: user.modes,
+			}, network.prefixLookup);
+		});
 
 		chan.sortUsers(irc);
 

--- a/src/plugins/irc-events/nick.js
+++ b/src/plugins/irc-events/nick.js
@@ -25,11 +25,11 @@ module.exports = function(irc, network) {
 		}
 
 		network.channels.forEach(chan => {
-			var user = _.find(chan.users, {name: data.nick});
+			var user = _.find(chan.users, {nick: data.nick});
 			if (typeof user === "undefined") {
 				return;
 			}
-			user.name = data.new_nick;
+			user.nick = data.new_nick;
 			chan.sortUsers(irc);
 			client.emit("users", {
 				chan: chan.id

--- a/src/plugins/irc-events/part.js
+++ b/src/plugins/irc-events/part.js
@@ -18,7 +18,7 @@ module.exports = function(irc, network) {
 				chan: chan.id
 			});
 		} else {
-			var user = _.find(chan.users, {name: from});
+			var user = _.find(chan.users, {nick: from});
 			chan.users = _.without(chan.users, user);
 			client.emit("users", {
 				chan: chan.id

--- a/src/plugins/irc-events/quit.js
+++ b/src/plugins/irc-events/quit.js
@@ -8,7 +8,7 @@ module.exports = function(irc, network) {
 	irc.on("quit", function(data) {
 		network.channels.forEach(chan => {
 			var from = data.nick;
-			var user = _.find(chan.users, {name: from});
+			var user = _.find(chan.users, {nick: from});
 			if (typeof user === "undefined") {
 				return;
 			}

--- a/test/models/chan.js
+++ b/test/models/chan.js
@@ -32,9 +32,7 @@ describe("Chan", function() {
 		};
 
 		var getUserNames = function(chan) {
-			return chan.users.map(function(u) {
-				return u.name;
-			});
+			return chan.users.map(u => u.nick);
 		};
 
 		it("should sort a simple user list", function() {


### PR DESCRIPTION
This PR would will reduce memory and bandwidth use. I also found inconsistent `name`/`nick` references that could cause insignificant bugs.

