### PR TITLE
Fix invalid prefetch thumbnail url getting pushed to client

### DIFF
--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -51,13 +51,17 @@ function parse(msg, url, res, client) {
 		toggle.type = "link";
 		toggle.head = $("title").text();
 		toggle.body =
-			$("meta[name=description]").attr("content")
-			|| $("meta[property=\"og:description\"]").attr("content")
-			|| "No description found.";
+				$("meta[name=description]").attr("content")
+				|| $("meta[property=\"og:description\"]").attr("content")
+				|| "No description found.";
 		toggle.thumb =
-			$("meta[property=\"og:image\"]").attr("content")
-			|| $("meta[name=\"twitter:image:src\"]").attr("content")
-			|| "";
+				$("meta[property=\"og:image\"]").attr("content")
+				|| $("meta[name=\"twitter:image:src\"]").attr("content");
+		fetch(toggle.thumb, function(prefetchRes) {
+			if (prefetchRes.error) {
+				toggle.thumb = "";
+			}
+		});
 		break;
 
 	case "image/png":
@@ -90,6 +94,7 @@ function fetch(url, cb) {
 			}
 		});
 	} catch (e) {
+		cb({error: e});
 		return;
 	}
 	var length = 0;


### PR DESCRIPTION
Fixes #1180

When prefetching a page, thelounge will first fetch the actual image before pushing the (possibly invalid) url to the client. When it comes across any type of error it'll simply omit the thumbnail.