### PR TITLE
Correctly configure client socket transports

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -25,7 +25,7 @@
 	<meta name="theme-color" content="#455164">
 
 	</head>
-	<body class="signed-out {{#if public}}public{{/if}}">
+	<body class="signed-out {{#if public}}public{{/if}}" data-transports="{{tojson transports}}">
 
 	<div id="wrap">
 	<div id="viewport">

--- a/client/js/socket.js
+++ b/client/js/socket.js
@@ -5,6 +5,7 @@ const io = require("socket.io-client");
 const path = window.location.pathname + "socket.io/";
 
 const socket = io({
+	transports: $(document.body).data("transports"),
 	path: path,
 	autoConnect: false,
 	reconnection: false

--- a/src/server.js
+++ b/src/server.js
@@ -32,7 +32,12 @@ module.exports = function() {
 		.use(allRequests)
 		.use(index)
 		.use(express.static("client"))
-		.engine("html", expressHandlebars({extname: ".html"}))
+		.engine("html", expressHandlebars({
+			extname: ".html",
+			helpers: {
+				tojson: c => JSON.stringify(c)
+			}
+		}))
 		.set("view engine", "html")
 		.set("views", path.join(__dirname, "..", "client"));
 


### PR DESCRIPTION
Fixes #848. This will match server/client transport configuration (e.g. websocket only, or polling only, or websocket priorioty over polling).