### PR TITLE
Keep original <title> name when changing the title

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -26,6 +26,8 @@ $(function() {
 	var sidebar = $("#sidebar, #footer");
 	var chat = $("#chat");
 
+	$(document.body).data("app-name", document.title);
+
 	var ignoreSortSync = false;
 
 	var pop;
@@ -1012,7 +1014,7 @@ $(function() {
 			.addClass("active")
 			.trigger("show");
 
-		var title = "The Lounge";
+		let title = $(document.body).data("app-name");
 		if (chan.data("title")) {
 			title = chan.data("title") + " — " + title;
 		}


### PR DESCRIPTION
Changing `title` in `index.html` will no longer require modifying and recompiling the javascript.