### PR TITLE
Fix MOTD underline in Safari

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -56,6 +56,18 @@ a:hover {
 	opacity: .8;
 }
 
+/**
+ * From Normalize. See https://github.com/thelounge/lounge/pull/1217
+ * 1. Remove the bottom border in Chrome 57- and Firefox 39-.
+ * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
+ */
+
+abbr[title] {
+	border-bottom: none; /* 1 */
+	text-decoration: underline; /* 2 */
+	text-decoration: underline dotted; /* 2 */
+}
+
 h1,
 h2,
 h3 {


### PR DESCRIPTION
before: ![before](https://sr.ht/mdPx.png)

after: ![after](https://sr.ht/h45R.png)

Basically, safari's user agent CSS applies an underline to <abbr> tags, which bootstrap already does as well (but bootstrap doesn't use text-decoration so it's not overriden).