### PR TITLE
Fix the copying of multiple lines having too many linebreaks

### DIFF
--- a/client/js/clipboard.js
+++ b/client/js/clipboard.js
@@ -1,0 +1,28 @@
+"use strict";
+
+function addLink() {
+	// Get the selected text
+	const selection = window.getSelection(),
+		newdiv = document.createElement("div");
+
+	let copytext = selection;
+
+	copytext = copytext.toString();
+	copytext = copytext.replace(/\n(\d{2}:\d{2}(:\d{2})?)/g, "<br>$1"); // Replace first newlines on each message with <br>
+	copytext = copytext.replace(/\n/g, " "); // Remove all other newlines
+
+	// hide the newly created container
+	newdiv.style.position = "absolute";
+	newdiv.style.left = "-99999px";
+
+	// insert the container, fill it with the text
+	document.body.appendChild(newdiv);
+	newdiv.innerHTML = copytext;
+	selection.selectAllChildren(newdiv);
+
+	window.setTimeout(function() {
+		document.body.removeChild(newdiv);
+	}, 100);
+}
+
+document.addEventListener("copy", addLink);

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -14,6 +14,7 @@ const emojiMap = require("./libs/simplemap.json");
 require("./libs/jquery/inputhistory");
 require("./libs/jquery/stickyscroll");
 require("./libs/jquery/tabcomplete");
+require("./clipboard");
 const helpers_parse = require("./libs/handlebars/parse");
 const helpers_roundBadgeNumber = require("./libs/handlebars/roundBadgeNumber");
 const slideoutMenu = require("./libs/slideout");


### PR DESCRIPTION
Fixes #1146 

I apologise profusely for this, and if someone else can think of a better way (no, removing flexbox is not better) then feel free to deny this. But this works.

Also, this will make it incredibly easy to add in "<" and ">" around usernames once this is in (but that's for a different PR).