### PR TITLE
Correctly show whitespace and newlines in messages

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -2085,3 +2085,19 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 #image-viewer .open-btn {
 	margin: 0 auto 10px;
 }
+
+/* Correctly handle multiple successive whitespace characters.
+   For example: user has quit ( ===> L   O   L <=== )  */
+
+#windows .header .topic,
+#chat .message .text,
+#chat .motd .text,
+#chat .notice .text,
+#chat .ctcp-message,
+#chat .part-reason,
+#chat .quit-reason,
+#chat .new-topic,
+#chat .action-text,
+#chat table.channel-list .topic {
+	white-space: pre-wrap;
+}

--- a/client/views/actions/ctcp.tpl
+++ b/client/views/actions/ctcp.tpl
@@ -1,2 +1,2 @@
 {{> ../user_name nick=from}}
-<b>{{ctcpType}}</b> {{{parse ctcpMessage}}}
+<b>{{ctcpType}}</b> <span class="ctcp-message">{{{parse ctcpMessage}}}</span>


### PR DESCRIPTION
Screwed up last PR so here's a clean one. Fix for https://github.com/thelounge/lounge/issues/1229

Extension of https://github.com/thelounge/lounge/pull/1237