### PR TITLE
Check og:description before description

### DIFF
--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -51,8 +51,8 @@ function parse(msg, url, res, client) {
 		toggle.type = "link";
 		toggle.head = $("title").text();
 		toggle.body =
-			$("meta[name=description]").attr("content")
-			|| $("meta[property=\"og:description\"]").attr("content")
+			$("meta[property=\"og:description\"]").attr("content")
+			|| $("meta[name=\"description\"]").attr("content")
 			|| "No description found.";
 		toggle.thumb =
 			$("meta[property=\"og:image\"]").attr("content")


### PR DESCRIPTION
This should give more info for links like GitHub commits.

```html
<meta property="og:description" content="Fixes #1239. Fixes #1180.">
<meta name="description" content="lounge - 💬 The Lounge — Self-hosted web IRC client">
```