### PR TITLE
Hide link time element on small devices

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1925,6 +1925,10 @@ kbd {
 		padding: 0;
 	}
 
+	#chat .msg.toggle .time {
+		display: none;
+	}
+
 	#chat .date-marker,
 	#chat .unread-marker {
 		margin: 0;


### PR DESCRIPTION
It's visibility is hidden so it looks like an empty line on mobile devices.