### PR TITLE
Allow themes from npm

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -264,8 +264,8 @@
 								<label for="theme-select" class="sr-only">Theme</label>
 								<select id="theme-select" name="theme" class="input">
 									{{#each themes}}
-										<option value="{{filename}}">
-											{{name}}
+										<option value="{{name}}">
+											{{displayName}}
 										</option>
 									{{/each}}
 								</select>

--- a/defaults/config.js
+++ b/defaults/config.js
@@ -51,11 +51,12 @@ module.exports = {
 
 	//
 	// Set the default theme.
+	// Find out how to add new themes at https://thelounge.github.io/docs/packages/themes
 	//
 	// @type     string
-	// @default  "themes/example.css"
+	// @default  "example"
 	//
-	theme: "themes/example.css",
+	theme: "example",
 
 	//
 	// Prefetch URLs

--- a/src/helper.js
+++ b/src/helper.js
@@ -12,6 +12,8 @@ const colors = require("colors/safe");
 var Helper = {
 	config: null,
 	expandHome: expandHome,
+	getPackagesPath: getPackagesPath,
+	getPackageModulePath: getPackageModulePath,
 	getStoragePath: getStoragePath,
 	getUserConfigPath: getUserConfigPath,
 	getUserLogsPath: getUserLogsPath,
@@ -94,6 +96,14 @@ function getUserLogsPath(name, network) {
 
 function getStoragePath() {
 	return path.join(this.HOME, "storage");
+}
+
+function getPackagesPath() {
+	return path.join(this.HOME, "packages", "node_modules");
+}
+
+function getPackageModulePath(packageName) {
+	return path.join(Helper.getPackagesPath(), packageName);
 }
 
 function ip2hex(address) {

--- a/src/plugins/themes.js
+++ b/src/plugins/themes.js
@@ -1,0 +1,85 @@
+"use strict";
+
+const fs = require("fs");
+const Helper = require("../helper");
+const colors = require("colors/safe");
+const path = require("path");
+const _ = require("lodash");
+const themes = new Map();
+
+module.exports = {
+	getAll: getAll,
+	getFilename: getFilename
+};
+
+fs.readdir("client/themes/", (err, builtInThemes) => {
+	if (err) {
+		return;
+	}
+	builtInThemes
+		.filter((theme) => theme.endsWith(".css"))
+		.map(makeLocalThemeObject)
+		.forEach((theme) => themes.set(theme.name, theme));
+});
+
+fs.readdir(Helper.getPackagesPath(), (err, packages) => {
+	if (err) {
+		return;
+	}
+	packages
+		.map(makePackageThemeObject)
+		.forEach((theme) => {
+			if (theme) {
+				themes.set(theme.name, theme);
+			}
+		});
+});
+
+function getAll() {
+	return _.sortBy(Array.from(themes.values()), "displayName");
+}
+
+function getFilename(module) {
+	if (themes.has(module)) {
+		return themes.get(module).filename;
+	}
+}
+
+function makeLocalThemeObject(css) {
+	const themeName = css.slice(0, -4);
+	return {
+		displayName: themeName.charAt(0).toUpperCase() + themeName.slice(1),
+		filename: path.join(__dirname, "..", "client", "themes", `${themeName}.css`),
+		name: themeName
+	};
+}
+
+function getModuleInfo(packageName) {
+	let module;
+	try {
+		module = require(Helper.getPackageModulePath(packageName));
+	} catch (e) {
+		log.warn(`Specified theme ${colors.yellow(packageName)} is not installed in packages directory`);
+		return;
+	}
+	if (!module.lounge) {
+		log.warn(`Specified theme ${colors.yellow(packageName)} doesn't have required information.`);
+		return;
+	}
+	return module.lounge;
+}
+
+function makePackageThemeObject(moduleName) {
+	const module = getModuleInfo(moduleName);
+	if (!module || module.type !== "theme") {
+		return;
+	}
+	const modulePath = Helper.getPackageModulePath(moduleName);
+	const displayName = module.name || moduleName;
+	const filename = path.join(modulePath, module.css);
+	return {
+		displayName: displayName,
+		filename: filename,
+		name: moduleName
+	};
+}


### PR DESCRIPTION
This has a bit of work left to do, but it works. Woop.

- [x] Clean up code
- [x] Documentation on how to create a theme for the lounge
- [x] Figure out how I can get rid of the multiple names...
- [x] Get packages from `$LOUNGE_HOME/packages` instead of globally/locally
- [x] rename "plugins"/"themes" to "packages" (except where being a theme is useful info)

![screenshot from 2017-06-24 16-20-02](https://user-images.githubusercontent.com/2162657/27509660-d2228f86-58f9-11e7-870a-f161e2e25d34.png)
