### PR TITLE
Remove devDependencies badge on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![Travis CI Build Status](https://img.shields.io/travis/thelounge/lounge/master.svg?label=linux+build)](https://travis-ci.org/thelounge/lounge)
 [![AppVeyor Build Status](https://img.shields.io/appveyor/ci/astorije/lounge/master.svg?label=windows+build)](https://ci.appveyor.com/project/astorije/lounge/branch/master)
 [![Dependencies Status](https://img.shields.io/david/thelounge/lounge.svg)](https://david-dm.org/thelounge/lounge)
-[![Developer Dependencies Status](https://img.shields.io/david/dev/thelounge/lounge.svg)](https://david-dm.org/thelounge/lounge?type=dev)
 
 The Lounge is a modern web IRC client designed for self-hosting.
 


### PR DESCRIPTION
Now that Greenkeeper is taking care of our dependencies, it makes less sense to keep this one.

This also create some room for a potential future extra badge if we need it, without taking up a new line.

I would however definitely keep the production dependencies badge because it informs users on the status of what they install. It also leaves an access to David's devDependencies report if interested.