### PR TITLE
Remove mention in CHANGELOG that The Lounge uses Semantic Versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Change Log
 
 All notable changes to this project will be documented in this file.
-This project adheres to [Semantic Versioning](http://semver.org/).
 
 <!--
 Use the following template for each new release, built on recommendations from http://keepachangelog.com/.


### PR DESCRIPTION
Not that we don't use something as close as possible, but as an end-user project, it is not entirely meaningful to say we are Semver-compliant, since there is no real breaking changes we introduce. Semver is however very good for libraries.

This PR is up for debate obviously. I think all @thelounge/maintainers agree to this, but I just want to make sure we are on the same page. Whether we keep it or not, I think we've all agreed in the past _de facto_, this is just giving ourselves a label or not IMO.