### PR TITLE
Move link prefetcher button to toggle template and warn on the client when image is too big

### DIFF
--- a/client/js/socket-events/toggle.js
+++ b/client/js/socket-events/toggle.js
@@ -6,8 +6,9 @@ const templates = require("../../views");
 const options = require("../options");
 
 socket.on("toggle", function(data) {
-	const toggle = $("#toggle-" + data.id);
-	toggle.parent().after(templates.toggle({toggle: data}));
+	$(`#msg-${data.id}.toggle .text`).append(templates.toggle({toggle: data}));
+	const toggle = $(`#toggle-${data.id}`);
+
 	switch (data.type) {
 	case "link":
 		if (options.links) {

--- a/client/views/msg.tpl
+++ b/client/views/msg.tpl
@@ -9,9 +9,6 @@
 	</span>
 	{{#equal type "toggle"}}
 		<span class="text">
-			<div class="force-newline">
-				<button id="toggle-{{id}}" class="toggle-button" aria-label="Toggle prefetched media">···</button>
-			</div>
 			{{#if toggle}}
 				{{> toggle}}
 			{{/if}}

--- a/client/views/toggle.tpl
+++ b/client/views/toggle.tpl
@@ -1,19 +1,27 @@
 {{#toggle}}
-<div class="toggle-content toggle-type-{{type}}">
-	{{#equal type "image"}}
-		<a href="{{link}}" target="_blank">
-			<img src="{{link}}">
-		</a>
-	{{else}}
-		<a href="{{link}}" target="_blank">
-			{{#if thumb}}
-				<img src="{{thumb}}" class="thumb">
-			{{/if}}
-			<div class="head">{{head}}</div>
-			<div class="body">
-				{{body}}
-			</div>
-		</a>
-	{{/equal}}
-</div>
+
+{{#if type}}
+	<div class="force-newline">
+		<button id="toggle-{{id}}" class="toggle-button" aria-label="Toggle prefetched media">···</button>
+	</div>
+
+	<div class="toggle-content toggle-type-{{type}}">
+		{{#equal type "image"}}
+			<a href="{{link}}" target="_blank">
+				<img src="{{link}}">
+			</a>
+		{{else}}
+			<a href="{{link}}" target="_blank">
+				{{#if thumb}}
+					<img src="{{thumb}}" class="thumb">
+				{{/if}}
+				<div class="head">{{head}}</div>
+				<div class="body">
+					{{body}}
+				</div>
+			</a>
+		{{/equal}}
+	</div>
+{{/if}}
+
 {{/toggle}}


### PR DESCRIPTION
Before that PR, toggle button would appear instantly even if the link cannot be prefetched. We need to wait that a response comes back to know if it actually can be displayed or not.

Probably worth reviewing with `?w=1` as most of this PR changes are just indentation.