### PR TITLE
Add connect URL query to skip connect form

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -711,6 +711,7 @@ $(function() {
 			}
 		});
 	});
+
 	if ($("body").hasClass("public")) {
 		$("#connect").one("show", function() {
 			var params = URI(document.location.search);
@@ -733,6 +734,9 @@ $(function() {
 						}
 					}
 				}
+			}
+			if (params.connect) {
+				$(this).find(".btn").click();
 			}
 		});
 	}


### PR DESCRIPTION
If you add ?connect=true to the URL on a public instance the user will be automatically connected.