### PR TITLE
EPERM: operation not permitted on chmod

### DIFF
--- a/src/command-line/index.js
+++ b/src/command-line/index.js
@@ -17,7 +17,11 @@ Helper.setHome(program.home || process.env.LOUNGE_HOME);
 
 if (!fs.existsSync(Helper.CONFIG_PATH)) {
 	fsextra.ensureDirSync(Helper.HOME);
-	fs.chmodSync(Helper.HOME, "0700");
+	try {
+		fs.chmodSync(Helper.HOME, "0700");
+	} catch (e) {
+		log.warn(`Error when changing permissions on ${Helper.HOME} to 0700: ${e}`);
+	}
 	fsextra.copySync(path.resolve(path.join(
 		__dirname,
 		"..",


### PR DESCRIPTION
Fixed a small issue when running thelounge on [OpenShift](https://www.openshift.com/) where an uncaught `EPERM` error is thrown on `chmod`ing `Helper.HOME` on initial startup.  This probably affects thelounge running in Kubernetes also. Error below:

```
fs.js:1168
  return binding.chmod(pathModule._makeLong(path), modeNum(mode));
                 ^
Error: EPERM: operation not permitted, chmod '/home/lounge/data'
    at Error (native)
    at Object.fs.chmodSync (fs.js:1168:18)
    at Object.<anonymous> (/usr/local/lib/node_modules/thelounge/src/command-line/index.js:20:5)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
```

To fix, I've added a try/catch on chmod'ing the HOME folder, and logged a warning.