### PR TITLE
Ignore all dotfiles in npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,19 +2,11 @@
 # npm-debug.log and node_modules/ are ignored by default.
 # See https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package
 
+.*
 client/js/bundle.vendor.js.map
 client/views/
 coverage/
 scripts/
 test/
-.editorconfig
-.eslintignore
-.eslintrc.yml
-.gitattributes
-.gitignore
-.nycrc
-.npmignore
-.stylelintrc
-.travis.yml
 appveyor.yml
 webpack.config.js


### PR DESCRIPTION
Last release shipped `.stylelintrc.yml` as the filename changed.