### PR TITLE
Add title attributes to previews

### DIFF
--- a/client/views/msg_preview.tpl
+++ b/client/views/msg_preview.tpl
@@ -10,10 +10,8 @@
 			<img src="{{thumb}}" class="thumb">
 		{{/if}}
 		<div class="toggle-text">
-			<div class="head">{{head}}</div>
-			<div class="body">
-				{{body}}
-			</div>
+			<div class="head" title="{{head}}">{{head}}</div>
+			<div class="body" title="{{body}}">{{body}}</div>
 		</div>
 	{{/equal}}
 </a>


### PR DESCRIPTION
This is useful on long preview titles/descriptions that truncate. We currently do the same for topics.

<img width="631" alt="screen shot 2017-07-03 at 02 39 00" src="https://user-images.githubusercontent.com/113730/27780785-f656f932-5f98-11e7-8c92-76f45806b3eb.png">
