### PR TITLE
Do not truncate link previews if viewport can fit more text

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1129,15 +1129,20 @@ kbd {
 }
 
 #chat .toggle-content .thumb {
-	float: left;
 	margin-right: 6px;
 	max-width: 48px;
 	max-height: 32px;
 }
 
+#chat .toggle-text {
+	min-width: 0;
+	display: flex;
+	flex-direction: column;
+	white-space: nowrap;
+}
+
 #chat .toggle-content .head,
 #chat .toggle-content .body {
-	white-space: nowrap;
 	text-overflow: ellipsis;
 	overflow: hidden;
 }
@@ -1151,7 +1156,7 @@ kbd {
 }
 
 #chat .toggle-content.show {
-	display: inline-block !important;
+	display: inline-flex !important;
 }
 
 #chat .count {

--- a/client/views/msg_preview.tpl
+++ b/client/views/msg_preview.tpl
@@ -9,9 +9,11 @@
 		{{#if thumb}}
 			<img src="{{thumb}}" class="thumb">
 		{{/if}}
-		<div class="head">{{head}}</div>
-		<div class="body">
-			{{body}}
+		<div class="toggle-text">
+			<div class="head">{{head}}</div>
+			<div class="body">
+				{{body}}
+			</div>
 		</div>
 	{{/equal}}
 </a>


### PR DESCRIPTION
Fixes #1084. `float: left` on the thumbnail image pushed text, but did not increase container width.

Before:
![03-114187307](https://user-images.githubusercontent.com/613331/27791502-06730a30-5ffe-11e7-887d-b14f5ce3aa33.png)

After:
![03-114120932](https://user-images.githubusercontent.com/613331/27791507-08caf2e8-5ffe-11e7-8a21-14a0a7c4ea40.png)
