### PR TITLE
Fix too big line height previews text on Crypto

### DIFF
--- a/client/themes/crypto.css
+++ b/client/themes/crypto.css
@@ -136,3 +136,9 @@ a:hover,
 .tooltipped:after {
 	font-family: Inconsolata-g, monospace;
 }
+
+/* Previews */
+
+#chat .toggle-text {
+	line-height: initial;
+}


### PR DESCRIPTION
Since we're at fixing previews for 2.3.3...

Before | After
--- | ---
<img width="875" alt="screen shot 2017-07-04 at 13 14 31" src="https://user-images.githubusercontent.com/113730/27838856-3a34028a-60bb-11e7-8311-5cf4525d4cc2.png"> | <img width="874" alt="screen shot 2017-07-04 at 13 14 46" src="https://user-images.githubusercontent.com/113730/27838857-3d22193c-60bb-11e7-8f79-0f001402a861.png">
