### PR TITLE
Fix background color contrast on Zenburn previews

### DIFF
--- a/client/themes/zenburn.css
+++ b/client/themes/zenburn.css
@@ -59,7 +59,7 @@ body {
 }
 
 #footer {
-	background: #33332f;
+	background: #333;
 	border-top: 1px solid #000;
 }
 
@@ -237,10 +237,11 @@ body {
 	color: #ccc;
 }
 
-/* Embeds */
+/* Previews */
+
 #chat .toggle-content,
 #chat .toggle-button {
-	background: #93b3a3;
+	background: #333;
 	color: #dcdccc;
 }
 


### PR DESCRIPTION
Again, since we're fixing previews for 2.3.3, here is another one, that fixes an accessibility issue.

Before | After
--- | ---
<img width="1004" alt="screen shot 2017-07-04 at 13 23 35" src="https://user-images.githubusercontent.com/113730/27839327-678b25ee-60be-11e7-9485-da0475ed7a22.png"> | <img width="1004" alt="screen shot 2017-07-04 at 13 22 59" src="https://user-images.githubusercontent.com/113730/27839330-6bad2bb8-60be-11e7-82b5-94223ada5f65.png">
