### PR TITLE
Add a transition when toggling the user list

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -790,6 +790,7 @@ kbd {
 
 #chat .channel .chat {
 	right: 180px;
+	transition: right .4s;
 }
 
 #chat .special {


### PR DESCRIPTION
I remember looking at this some time ago, and because of the `transform` mechanism we were using, it wasn't possible. Now, it's doable with a single line of change 🎉 

It removes jump on markers (date, new message) and text/preview overflow.

Before | After
--- | ---
![transition_before](https://user-images.githubusercontent.com/113730/27839905-ec5c94b6-60c2-11e7-8223-10abf867f99d.gif) | ![transition_after](https://user-images.githubusercontent.com/113730/27839906-ed85a0da-60c2-11e7-8f13-ef233685a450.gif)
