### PR TITLE
Store preview images on disk for privacy, security and caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ package-lock.json
 
 .nyc_output/
 coverage/
+test/fixtures/.lounge/storage/
 
 # Built assets created at npm install/prepublish time
 # See https://docs.npmjs.com/misc/scripts

--- a/client/views/msg_preview.tpl
+++ b/client/views/msg_preview.tpl
@@ -2,7 +2,7 @@
 <div class="toggle-content toggle-type-{{type}}{{#if shown}} show{{/if}}">
 	{{#equal type "image"}}
 		<a class="toggle-thumbnail" href="{{link}}" target="_blank" rel="noopener">
-			<img src="{{link}}">
+			<img src="{{thumb}}">
 		</a>
 	{{else}}
 		{{#if thumb}}

--- a/defaults/config.js
+++ b/defaults/config.js
@@ -67,6 +67,23 @@ module.exports = {
 	prefetch: false,
 
 	//
+	// Store and proxy prefetched images and thumbnails.
+	// This improves security and privacy by not exposing client IP address,
+	// and always loading images from The Lounge instance and making all assets secure,
+	// which in result fixes mixed content warnings.
+	//
+	// If storage is enabled, The Lounge will fetch and store images and thumbnails
+	// in ~/.lounge/storage folder, or %HOME%/storage if --home is used.
+	//
+	// Images are deleted when they are no longer referenced by any message (controlled by maxHistory),
+	// and the folder is cleaned up on every The Lounge restart.
+	//
+	// @type     boolean
+	// @default  false
+	//
+	prefetchStorage: false,
+
+	//
 	// Prefetch URLs Image Preview size limit
 	//
 	// If prefetch is enabled, The Lounge will only display content under the maximum size.

--- a/src/helper.js
+++ b/src/helper.js
@@ -12,6 +12,7 @@ const colors = require("colors/safe");
 var Helper = {
 	config: null,
 	expandHome: expandHome,
+	getStoragePath: getStoragePath,
 	getUserConfigPath: getUserConfigPath,
 	getUserLogsPath: getUserLogsPath,
 	setHome: setHome,
@@ -88,6 +89,10 @@ function getUserConfigPath(name) {
 
 function getUserLogsPath(name, network) {
 	return path.join(this.HOME, "logs", name, network);
+}
+
+function getStoragePath() {
+	return path.join(this.HOME, "storage");
 }
 
 function ip2hex(address) {

--- a/src/models/chan.js
+++ b/src/models/chan.js
@@ -2,6 +2,7 @@
 
 var _ = require("lodash");
 var Helper = require("../helper");
+const storage = require("../plugins/storage");
 
 module.exports = Chan;
 
@@ -53,7 +54,15 @@ Chan.prototype.pushMessage = function(client, msg, increasesUnread) {
 	this.messages.push(msg);
 
 	if (Helper.config.maxHistory >= 0 && this.messages.length > Helper.config.maxHistory) {
-		this.messages.splice(0, this.messages.length - Helper.config.maxHistory);
+		const deleted = this.messages.splice(0, this.messages.length - Helper.config.maxHistory);
+
+		if (Helper.config.prefetch && Helper.config.prefetchStorage) {
+			deleted.forEach((deletedMessage) => {
+				if (deletedMessage.preview && deletedMessage.preview.thumb) {
+					storage.dereference(deletedMessage.preview.thumb);
+				}
+			});
+		}
 	}
 
 	if (!msg.self && !isOpen) {

--- a/src/plugins/storage.js
+++ b/src/plugins/storage.js
@@ -1,0 +1,81 @@
+"use strict";
+
+const fs = require("fs");
+const fsextra = require("fs-extra");
+const path = require("path");
+const crypto = require("crypto");
+const helper = require("../helper");
+
+class Storage {
+	constructor() {
+		this.references = new Map();
+
+		// Ensures that a directory is empty.
+		// Deletes directory contents if the directory is not empty.
+		// If the directory does not exist, it is created.
+		fsextra.emptyDirSync(helper.getStoragePath());
+	}
+
+	dereference(url) {
+		// If maxHistory is 0, image would be dereferenced before client had a chance to retrieve it,
+		// so for now, just don't implement dereferencing for this edge case.
+		if (helper.maxHistory === 0) {
+			return;
+		}
+
+		const references = (this.references.get(url) || 0) - 1;
+
+		if (references < 0) {
+			return log.warn("Tried to dereference a file that has no references", url);
+		}
+
+		if (references > 0) {
+			return this.references.set(url, references);
+		}
+
+		this.references.delete(url);
+
+		// Drop "storage/" from url and join it with full storage path
+		const filePath = path.join(helper.getStoragePath(), url.substring(8));
+
+		fs.unlink(filePath, (err) => {
+			if (err) {
+				log.error("Failed to delete stored file", err);
+			}
+		});
+	}
+
+	store(data, extension, callback) {
+		const hash = crypto.createHash("sha256").update(data).digest("hex");
+		const a = hash.substring(0, 2);
+		const b = hash.substring(2, 4);
+		const folder = path.join(helper.getStoragePath(), a, b);
+		const filePath = path.join(folder, `${hash.substring(4)}.${extension}`);
+		const url = `storage/${a}/${b}/${hash.substring(4)}.${extension}`;
+
+		this.references.set(url, 1 + (this.references.get(url) || 0));
+
+		// If file with this name already exists, we don't need to write it again
+		if (fs.existsSync(filePath)) {
+			return callback(url);
+		}
+
+		fsextra.ensureDir(folder).then(() => {
+			fs.writeFile(filePath, data, (err) => {
+				if (err) {
+					log.error("Failed to store a file", err);
+
+					return callback("");
+				}
+
+				callback(url);
+			});
+		}).catch((err) => {
+			log.error("Failed to create storage folder", err);
+
+			return callback("");
+		});
+	}
+}
+
+module.exports = new Storage();

--- a/test/plugins/storage.js
+++ b/test/plugins/storage.js
@@ -1,0 +1,68 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const crypto = require("crypto");
+const expect = require("chai").expect;
+const util = require("../util");
+const Helper = require("../../src/helper");
+const link = require("../../src/plugins/irc-events/link.js");
+
+describe("Image storage", function() {
+	const testImagePath = path.resolve(__dirname, "../../client/img/apple-touch-icon-120x120.png");
+	const correctImageHash = crypto.createHash("sha256").update(fs.readFileSync(testImagePath)).digest("hex");
+	const correctImageURL = `storage/${correctImageHash.substring(0, 2)}/${correctImageHash.substring(2, 4)}/${correctImageHash.substring(4)}.png`;
+
+	before(function(done) {
+		this.app = util.createWebserver();
+		this.app.get("/real-test-image.png", function(req, res) {
+			res.sendFile(testImagePath);
+		});
+		this.connection = this.app.listen(9003, done);
+	});
+
+	after(function(done) {
+		this.connection.close(done);
+	});
+
+	beforeEach(function() {
+		this.irc = util.createClient();
+		this.network = util.createNetwork();
+
+		Helper.config.prefetchStorage = true;
+	});
+
+	it("should store the thumbnail", function(done) {
+		const message = this.irc.createMessage({
+			text: "http://localhost:9003/thumb"
+		});
+
+		link(this.irc, this.network.channels[0], message);
+
+		this.app.get("/thumb", function(req, res) {
+			res.send("<title>Google</title><meta property='og:image' content='http://localhost:9003/real-test-image.png'>");
+		});
+
+		this.irc.once("msg:preview", function(data) {
+			expect(data.preview.head).to.equal("Google");
+			expect(data.preview.link).to.equal("http://localhost:9003/thumb");
+			expect(data.preview.thumb).to.equal(correctImageURL);
+			done();
+		});
+	});
+
+	it("should store the image", function(done) {
+		const message = this.irc.createMessage({
+			text: "http://localhost:9003/real-test-image.png"
+		});
+
+		link(this.irc, this.network.channels[0], message);
+
+		this.irc.once("msg:preview", function(data) {
+			expect(data.preview.type).to.equal("image");
+			expect(data.preview.link).to.equal("http://localhost:9003/real-test-image.png");
+			expect(data.preview.thumb).to.equal(correctImageURL);
+			done();
+		});
+	});
+});


### PR DESCRIPTION
- [x] Add `block-all-mixed-content; img-src 'self'` to our CSP.
- [x] Filenames are SHA256 of the file, split into 2 subfolders.
- [x] Fix tests
- [x] Allow disabling this in the config
- [x] Empty storage on startup
- [x] Delete images when they are no longer referenced in message history