### PR TITLE
Reword link preview settings to better match reality

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -282,18 +282,18 @@
 							</div>
 							{{#if prefetch}}
 							<div class="col-sm-12">
-								<h2>Links and URLs</h2>
+								<h2>Link previews</h2>
 							</div>
 							<div class="col-sm-6">
 								<label class="opt">
 									<input type="checkbox" name="thumbnails">
-									Auto-expand thumbnails
+									Auto-expand images
 								</label>
 							</div>
 							<div class="col-sm-6">
 								<label class="opt">
 									<input type="checkbox" name="links">
-									Auto-expand links
+									Auto-expand websites
 								</label>
 							</div>
 							{{/if}}


### PR DESCRIPTION
- **s/Links and URLs/Link previews/**: From a user perspective, these are the same thing... These options are for the prefetcher, not the URLs themselves
- **s/thumbnails/images/**: What we call thumbnails are for "site" previews, not actual image links
- **s/links/websites/**: Technically, both image and non-image links are links, "websites" carries a tiny bit better the meaning

These are not perfect or ideal for sure, but I feel like these changes reflect better what the settings actually do. Open to suggestions if you feel these are way wrong.