### PR TITLE
Bump express and socket.io to their latest patch versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "colors": "1.1.2",
     "commander": "2.11.0",
     "event-stream": "3.3.4",
-    "express": "4.15.2",
+    "express": "4.15.3",
     "express-handlebars": "3.0.0",
     "fs-extra": "3.0.1",
     "irc-framework": "2.8.1",
@@ -55,7 +55,7 @@
     "read": "1.0.7",
     "request": "2.81.0",
     "semver": "5.3.0",
-    "socket.io": "1.7.3",
+    "socket.io": "1.7.4",
     "spdy": "3.4.7"
   },
   "devDependencies": {
@@ -75,7 +75,7 @@
     "mousetrap": "1.6.1",
     "npm-run-all": "4.0.2",
     "nyc": "11.0.3",
-    "socket.io-client": "1.7.3",
+    "socket.io-client": "1.7.4",
     "stylelint": "7.12.0",
     "stylelint-config-standard": "16.0.0",
     "urijs": "1.18.10",


### PR DESCRIPTION
Greenkeeper missed express because of their odd RC releases, and we are still stuck trying to bump socket.io to their v2 (see https://github.com/socketio/socket.io/issues/2982).

Tested locally.