### PR TITLE
Automatically load history when scrolling upwards

### DIFF
--- a/client/js/render.js
+++ b/client/js/render.js
@@ -12,6 +12,8 @@ const condensed = require("./condensed");
 const chat = $("#chat");
 const sidebar = $("#sidebar");
 
+require("intersection-observer");
+
 const historyObserver = window.IntersectionObserver ?
 	new window.IntersectionObserver(loadMoreHistory, {
 		root: chat.get(0)

--- a/client/js/render.js
+++ b/client/js/render.js
@@ -12,6 +12,11 @@ const condensed = require("./condensed");
 const chat = $("#chat");
 const sidebar = $("#sidebar");
 
+const historyObserver = window.IntersectionObserver ?
+	new window.IntersectionObserver(loadMoreHistory, {
+		root: chat.get(0)
+	}) : null;
+
 module.exports = {
 	appendMessage,
 	buildChannelMessages,
@@ -145,6 +150,10 @@ function renderChannel(data) {
 	if (data.type === "channel") {
 		renderChannelUsers(data);
 	}
+
+	if (historyObserver) {
+		historyObserver.observe(chat.find("#chan-" + data.id + " .show-more").get(0));
+	}
 }
 
 function renderChannelMessages(data) {
@@ -219,4 +228,20 @@ function renderNetworks(data) {
 	if (sidebar.find(".highlight").length) {
 		utils.toggleNotificationMarkers(true);
 	}
+}
+
+function loadMoreHistory(entries) {
+	entries.forEach((entry) => {
+		if (!entry.isIntersecting) {
+			return;
+		}
+
+		var target = $(entry.target).find(".show-more-button");
+
+		if (target.attr("disabled")) {
+			return;
+		}
+
+		target.click();
+	});
 }

--- a/client/js/socket-events/more.js
+++ b/client/js/socket-events/more.js
@@ -38,7 +38,13 @@ socket.on("more", function(data) {
 
 	// restore scroll position
 	const position = chan.height() - heightOld;
-	scrollable.scrollTop(position);
+	scrollable.finish().scrollTop(position);
+
+	// We have to do this hack due to smooth scrolling in browsers,
+	// as scrollTop does not apply correctly
+	if (window.requestAnimationFrame) {
+		window.requestAnimationFrame(() => scrollable.scrollTop(position));
+	}
 
 	if (data.messages.length !== 100) {
 		scrollable.find(".show-more").removeClass("show");

--- a/client/js/socket-events/more.js
+++ b/client/js/socket-events/more.js
@@ -12,7 +12,7 @@ socket.on("more", function(data) {
 
 	// get the scrollable wrapper around messages
 	const scrollable = chan.closest(".chat");
-	const heightOld = chan.height();
+	const heightOld = chan.height() - scrollable.scrollTop();
 
 	// If there are no more messages to show, just hide the button and do nothing else
 	if (!data.messages.length) {

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "fuzzy": "0.1.3",
     "handlebars": "4.0.10",
     "handlebars-loader": "1.6.0",
+    "intersection-observer": "0.4.2",
     "jquery": "3.2.1",
     "jquery-textcomplete": "1.8.4",
     "jquery-ui": "1.12.1",


### PR DESCRIPTION
This is a different implementation compared to #1148. This uses `IntersectionObserver` to do the heavy lifting without requiring us to deal with scroll positions and counting the messages in DOM.

Technically we can use this approach to lazily load messages on initial page load, as the callback would be callback for empty channel when you switch to it.

Chrome, Opera, Edge, and Firefox support it. Other browsers supported with polyfill.


Fixes #207.