### PR TITLE
Remove "in" transition on autocomplete items to fix a visual glitch on value refresh

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1553,6 +1553,7 @@ kbd {
 .textcomplete-item:hover,
 .textcomplete-menu .active {
 	background-color: #f6f6f6;
+	transition: none;
 }
 
 .context-menu-item:before,


### PR DESCRIPTION
@xPaw noticed the refresh is gross when typing further characters.

I disabled only the transition when it shows up, not when it disappears (btw I'm not sure I understand why "in" transitions are disabled when setting them to `none` on `:hover` in CSS...).
@xPaw, can you try this and tell me what you think? Alternative is to simply disable them, but I figured I should give it a try like this first.