### PR TITLE
Hide empty preview divs when there are no previews loaded

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1201,6 +1201,12 @@ kbd {
 	display: inline-flex !important;
 }
 
+/* Do not display an empty div when there are no previews. Useful for example in
+part/quit messages where we don't load previews (adds a blank line otherwise) */
+#chat .preview:empty {
+	display: none;
+}
+
 #chat .count {
 	background: #fafafa;
 	height: 48px;


### PR DESCRIPTION
Fixes #1343.

Not the cleanest thing in the world, but getting this as clean as can be is actually a bit of effort (sending the list of links to be previewed as part of the `emit("msg")` instead of at parse time) so until then it will have to do.

Before | After
--- | ---
<img width="646" alt="screen shot 2017-07-18 at 00 38 05" src="https://user-images.githubusercontent.com/113730/28301016-927f4936-6b51-11e7-9536-af79f1b06b74.png"> | <img width="655" alt="screen shot 2017-07-18 at 00 37 52" src="https://user-images.githubusercontent.com/113730/28301018-96042dba-6b51-11e7-8945-b26693cb5544.png">

