### PR TITLE
Fix previews in actions ("/me") after page reload

### DIFF
--- a/client/js/render.js
+++ b/client/js/render.js
@@ -73,15 +73,13 @@ function buildChatMessage(data) {
 	const msg = $(templates[template](data.msg));
 	const text = msg.find(".text");
 
-	if (data.msg.previews.length) {
-		data.msg.previews.forEach((preview) => {
-			renderPreview(preview, msg);
-		});
-	}
-
 	if (template === "msg_action") {
 		text.html(templates.actions[type](data.msg));
 	}
+
+	data.msg.previews.forEach((preview) => {
+		renderPreview(preview, msg);
+	});
 
 	if ((type === "message" || type === "action") && chan.hasClass("channel")) {
 		const nicks = chan.find(".users").data("nicks");


### PR DESCRIPTION
Fixes #1346 

Took me quite a while to figure this one out!

What happens essentially is that `renderPreview` adds preview templates (toggle button and content) with ``msg.find(`.text a[href="${preview.link}"]`)`` and ``msg.find(`.preview[data-url="${preview.link}"]`)``. At that point, `msg` contained `$(templates["msg_action"](data.msg))` but the content of the potential "actions" templates.

Switching those makes sure that when the previews get added, the content of the generated message is fully loaded before adding the previews.