### PR TITLE
Take into account wordboundaries for custom highlighting

### DIFF
--- a/client/js/options.js
+++ b/client/js/options.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const $ = require("jquery");
+const escapeRegExp = require("lodash/escapeRegExp");
 const settings = $("#settings");
 const userStyles = $("#user-specified-css");
 const storage = require("./localStorage");
@@ -98,6 +99,15 @@ settings.on("change", "input, select, textarea", function() {
 			// otherwise, users get notifications for everything
 			return h !== "";
 		});
+		// Construct regex with wordboundary for every highlight item
+		const highlightsTokens = options.highlights.map(function(h) {
+			return escapeRegExp(h);
+		});
+		if (highlightsTokens && highlightsTokens.length) {
+			module.exports.highlightsRE = new RegExp("\\b(?:" + highlightsTokens.join("|") + ")\\b", "i");
+		} else {
+			module.exports.highlightsRE = null;
+		}
 	} else if (name === "showSeconds") {
 		chat.find(".msg > .time").each(function() {
 			$(this).text(tz($(this).parent().data("time")));

--- a/client/js/render.js
+++ b/client/js/render.js
@@ -65,9 +65,11 @@ function buildChatMessage(data) {
 	const chan = chat.find(target);
 	let template = "msg";
 
-	if (!data.msg.highlight && !data.msg.self && (type === "message" || type === "notice") && options.highlights.some(function(h) {
-		return data.msg.text.toLocaleLowerCase().indexOf(h.toLocaleLowerCase()) > -1;
-	})) {
+	// See if any of the custom highlight regexes match
+	if (!data.msg.highlight && !data.msg.self
+		&& options.highlightsRE
+		&& (type === "message" || type === "notice")
+		&& options.highlightsRE.exec(data.msg.text)) {
 		data.msg.highlight = true;
 	}
 


### PR DESCRIPTION
Fixes #719

When you have `apple` as a keyword is *does* highlight: 
```
Take a look at this magnificent apple!
I wouldn't call that an "apple"
Apple>Microsoft
```
But it *doesn't* highlight:
```
apples applepie grappler
```
Or if it's `sq` in my case it does highlight:
```
Hey sq!
```
But it doesn't highlight:
```
That guy is rather grotesque
```
