### PR TITLE
Fix link previews not truncating correctly

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -968,6 +968,7 @@ kbd {
 
 #chat .content {
 	flex: 1 1 auto;
+	min-width: 0;
 }
 
 #loading a,


### PR DESCRIPTION
Ref: https://css-tricks.com/flexbox-truncated-text/#article-header-id-3