### PR TITLE
Fix image viewer cycling when some previews are hidden

### DIFF
--- a/client/js/renderPreview.js
+++ b/client/js/renderPreview.js
@@ -124,21 +124,21 @@ function openImageViewer(link) {
 	// Only expanded thumbnails are being cycled through.
 
 	// Previous image
-	let previousCandidates = link.closest(".preview").prev(".preview");
-	if (!previousCandidates.length) {
-		previousCandidates = link.closest(".msg").prevAll();
-	}
-	const previousImage = previousCandidates
+	let previousImage = link.closest(".preview").prev(".preview")
 		.find(".toggle-content.show .toggle-thumbnail").last();
+	if (!previousImage.length) {
+		previousImage = link.closest(".msg").prevAll()
+			.find(".toggle-content.show .toggle-thumbnail").last();
+	}
 	previousImage.addClass("previous-image");
 
 	// Next image
-	let nextCandidates = link.closest(".preview").next(".preview");
-	if (!nextCandidates.length) {
-		nextCandidates = link.closest(".msg").nextAll();
-	}
-	const nextImage = nextCandidates
+	let nextImage = link.closest(".preview").next(".preview")
 		.find(".toggle-content.show .toggle-thumbnail").first();
+	if (!nextImage.length) {
+		nextImage = link.closest(".msg").nextAll()
+			.find(".toggle-content.show .toggle-thumbnail").first();
+	}
 	nextImage.addClass("next-image");
 
 	$("#image-viewer").html(templates.image_viewer({


### PR DESCRIPTION
To reproduce the bug, on `master`:

1. Send a first message with 1 link
2. Send a second message with 2 links
3. Collapse the second preview (i.e. the first preview of the second message)
4. Click on the last thumbnail (i.e. the second preview of the second message)

➡️ The <kbd>&lt;</kbd> (Previous image) button does not show up.

Same applies for <kbd>&gt;</kbd> (Next image), obviously.

Issue was that the first check (the one for previews on the same message) was only checking for existing previews, not if they were being expanded. So in the scenario above, first check would detect one preview, but the class was never added (as it gets added only when preview is shown), so the cycling button is not shown.