### PR TITLE
Remove user link color override on dark theme

### DIFF
--- a/client/themes/morning.css
+++ b/client/themes/morning.css
@@ -64,10 +64,6 @@ body {
 	color: #b0bacf;
 }
 
-#chat .user:hover {
-	color: #fefefe;
-}
-
 #chat.colored-nicks .user.color-1 { color: #f7adf7; }
 #chat.colored-nicks .user.color-2 { color: #abf99f; }
 #chat.colored-nicks .user.color-3 { color: #86efdc; }

--- a/client/themes/zenburn.css
+++ b/client/themes/zenburn.css
@@ -90,10 +90,6 @@ body {
 	color: #bc8cbc;
 }
 
-#chat .user:hover {
-	color: #dcdccc;
-}
-
 #chat.colored-nicks .user.color-1 { color: #f7adf7; }
 #chat.colored-nicks .user.color-2 { color: #abf99f; }
 #chat.colored-nicks .user.color-3 { color: #86efdc; }


### PR DESCRIPTION
*You see, that's precisely why I question every new setting: I will always forget to test one of the many combinations we have 😅*

Fixes https://github.com/thelounge/lounge/issues/1372, thanks to @Jay2k1 for noticing this!

This fixes a UI glitch on hover when colored nicknames are disabled on Morning and Zenburn. The UI on colored nicknames actually does not respect this color override anyway, as it just shows the colored nickname with reduced opacity.
The issue here was that the color was changed right away on those themes when colored nicknames are disabled, then transitioned to the opacity.
My fix simply gets rid of those, so the hover effect is theme-specified color + reduced opacity (in which case, transition set in base CSS works fine).