### PR TITLE
Move urijs from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
     "request": "2.81.0",
     "semver": "5.4.1",
     "socket.io": "1.7.4",
-    "spdy": "3.4.7"
+    "spdy": "3.4.7",
+    "urijs": "1.18.10"
   },
   "devDependencies": {
     "babel-core": "6.25.0",
@@ -81,7 +82,6 @@
     "socket.io-client": "1.7.4",
     "stylelint": "8.0.0",
     "stylelint-config-standard": "17.0.0",
-    "urijs": "1.18.10",
     "webpack": "3.4.1"
   }
 }


### PR DESCRIPTION
https://github.com/thelounge/lounge/pull/1276 refactored previews, and in particular [reused our link-in-messages detection](https://github.com/thelounge/lounge/pull/1276/files#diff-4805d608cbc31851a7bee1bf4c7e247eR6) instead of [having a separate logic](https://github.com/thelounge/lounge/pull/1276/files#diff-4805d608cbc31851a7bee1bf4c7e247eL19). 

Unfortunately, this loads a client library, which requires `urijs`. Since these are built at release time, we were not including this package in the production dependencies, and it is now breaking at install time (hey hey, for once it's not me who broke it! 😂).

This might happen again if we add a client dependency in this file and forget it is also loaded by the server. We could in the future either extract this logic into a shared location, or we could move this logic entirely on the server (or maybe many other options), but in the meantime this will fix the issue in `v2.4.0-rc.1`.

Thanks to @dgw for noticing this!!

```
01:33 <dgw> Did $ sudo npm -g install thelounge@next
01:33 <dgw> lounge won't start
01:33 <dgw> "Error: Cannot find module 'urijs'"
01:34 <dgw> seems like that shouldn't happen
01:36 <dgw> Manually doing sudo npm -g install urijs fixed it
01:39 <dgw> Looks like urijs is listed in devDependencies but not in dependencies
```