### PR TITLE
Show notices and errors inline

### DIFF
--- a/src/plugins/irc-events/error.js
+++ b/src/plugins/irc-events/error.js
@@ -16,6 +16,7 @@ module.exports = function(irc, network) {
 		const msg = new Msg({
 			type: Msg.Type.ERROR,
 			text: text,
+			showInActive: true,
 		});
 		lobby.pushMessage(client, msg, true);
 	});
@@ -25,6 +26,7 @@ module.exports = function(irc, network) {
 		const msg = new Msg({
 			type: Msg.Type.ERROR,
 			text: data.nick + ": " + (data.reason || "Nickname is already in use."),
+			showInActive: true,
 		});
 		lobby.pushMessage(client, msg, true);
 
@@ -44,6 +46,7 @@ module.exports = function(irc, network) {
 		const msg = new Msg({
 			type: Msg.Type.ERROR,
 			text: data.nick + ": " + (data.reason || "Nickname is invalid."),
+			showInActive: true,
 		});
 		lobby.pushMessage(client, msg, true);
 


### PR DESCRIPTION
Fixes #114.

Display received notices and errors in currently active channel, if the actual target is the network lobby. Reloading the page will put them back into the lobby window.