### PR TITLE
Make emoji bigger

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -941,6 +941,14 @@ kbd {
 	padding: 0 10px;
 }
 
+.inline-emoji {
+	display: inline-block;
+	font-size: 1.4em;
+	position: relative;
+	top: .15em;
+	margin-top: -.4em;
+}
+
 .inline-channel {
 	cursor: pointer;
 }

--- a/client/js/libs/handlebars/ircmessageparser/findEmoji.js
+++ b/client/js/libs/handlebars/ircmessageparser/findEmoji.js
@@ -1,0 +1,27 @@
+"use strict";
+
+function findEmoji(text) {
+	const result = [];
+	let match;
+
+	// RegExp to identify emoji
+	const emojiPattern = "(?:[\u2700-\u27bf]|(?:\ud83c[\udde6-\uddff]){2}|[\ud800-\udbff][\udc00-\udfff]|[\u0023-\u0039]\ufe0f?\u20e3|\u3299|\u3297|\u303d|\u3030|\u24c2|\ud83c[\udd70-\udd71]|\ud83c[\udd7e-\udd7f]|\ud83c\udd8e|\ud83c[\udd91-\udd9a]|\ud83c[\udde6-\uddff]|\ud83c[\ude01-\ude02]|\ud83c\ude1a|\ud83c\ude2f|\ud83c[\ude32-\ude3a]|\ud83c[\ude50-\ude51]|\u203c|\u2049|[\u25aa-\u25ab]|\u25b6|\u25c0|[\u25fb-\u25fe]|\u00a9|\u00ae|\u2122|\u2139|\ud83c\udc04|[\u2600-\u26FF]|\u2b05|\u2b06|\u2b07|\u2b1b|\u2b1c|\u2b50|\u2b55|\u231a|\u231b|\u2328|\u23cf|[\u23e9-\u23f3]|[\u23f8-\u23fa]|\ud83c\udccf|\u2934|\u2935|[\u2190-\u21ff])";
+	const emojiRegExp = new RegExp(emojiPattern, "g");
+
+	do {
+		// With global ("g") regexes, calling `exec` multiple times will find
+		// successive matches in the same string.
+		match = emojiRegExp.exec(text);
+		if (match) {
+			result.push({
+				start: match.index,
+				end: match.index + match[0].length,
+				emoji: match[0]
+			});
+		}
+	} while (match);
+
+	return result;
+}
+
+module.exports = findEmoji;

--- a/client/js/libs/handlebars/parse.js
+++ b/client/js/libs/handlebars/parse.js
@@ -4,6 +4,7 @@ const Handlebars = require("handlebars/runtime");
 const parseStyle = require("./ircmessageparser/parseStyle");
 const findChannels = require("./ircmessageparser/findChannels");
 const findLinks = require("./ircmessageparser/findLinks");
+const findEmoji = require("./ircmessageparser/findEmoji");
 const merge = require("./ircmessageparser/merge");
 
 // Create an HTML `span` with styling information for a given fragment
@@ -59,10 +60,12 @@ module.exports = function parse(text) {
 	const userModes = ["!", "@", "%", "+"]; // TODO User modes should be RPL_ISUPPORT.PREFIX
 	const channelParts = findChannels(cleanText, channelPrefixes, userModes);
 	const linkParts = findLinks(cleanText);
+	const emojiParts = findEmoji(cleanText);
 
 	// Sort all parts identified based on their position in the original text
 	const parts = channelParts
 		.concat(linkParts)
+		.concat(emojiParts)
 		.sort((a, b) => a.start - b.start);
 
 	// Merge the styling information with the channels / URLs / text objects and
@@ -78,6 +81,8 @@ module.exports = function parse(text) {
 		} else if (textPart.channel) {
 			const escapedChannel = Handlebars.Utils.escapeExpression(textPart.channel);
 			return `<span class="inline-channel" role="button" tabindex="0" data-chan="${escapedChannel}">${fragments}</span>`;
+		} else if (textPart.emoji) {
+			return `<span class="inline-emoji">${fragments}</span>`;
 		}
 
 		return fragments;


### PR DESCRIPTION
Increases the size of emoji by 40% without displacing the surrounding text. Discord, Slack, and Telegram provide a similar functionality to make emoji a bit more legible.

Before: ![Before preview](http://i.imgur.com/xqXIsuf.png)

After: ![After preview](http://i.imgur.com/EAkGT1x.png)

(Note: black text is not a bug, just happened because I took the screenshot from different simultaneously running clients.)

This is my first time contributing to The Lounge so I expect I'll have some fixes to make.