### PR TITLE
Fix expanded status messages not taking up full line width

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -814,6 +814,11 @@ kbd {
 	flex: 1;
 }
 
+/* Ensures expanded status messages always take up the full width */
+#chat .condensed .msg {
+	flex-basis: 100%;
+}
+
 #chat .condensed-text {
 	cursor: pointer;
 	transition: opacity .2s;


### PR DESCRIPTION
Fixes #1414
/Cc @Raqbit

I accidentally removed this [here](https://github.com/thelounge/lounge/pull/759/commits/853e64667090d41406eadd21cd0cd42f9b7c565a#diff-97db1f70168fb5f12457b238ff6052b5L830), probably as a side-effect of the entire commit. It turns out, the issue did not appear on my 13" screen because condense messages were long enough to trigger status messages to start on the next line :man_shrugging: 

Before | After
--- | ---
<img width="867" alt="screen shot 2017-08-15 at 20 03 09" src="https://user-images.githubusercontent.com/113730/29341880-3d4b049a-81f5-11e7-8c58-a4777344c598.png"> | <img width="594" alt="screen shot 2017-08-15 at 20 03 23" src="https://user-images.githubusercontent.com/113730/29341881-3f6c472a-81f5-11e7-85fb-6d693b4883e2.png">

