### PR TITLE
Add documentation for LOUNGE_HOME environment variable in the CLI helper

### DIFF
--- a/src/command-line/add.js
+++ b/src/command-line/add.js
@@ -4,10 +4,12 @@ var ClientManager = new require("../clientManager");
 var colors = require("colors/safe");
 var program = require("commander");
 var Helper = require("../helper");
+const Utils = require("./utils");
 
 program
 	.command("add <name>")
 	.description("Add a new user")
+	.on("--help", Utils.extraHelp)
 	.action(function(name) {
 		var manager = new ClientManager();
 		var users = manager.getUsers();

--- a/src/command-line/config.js
+++ b/src/command-line/config.js
@@ -4,10 +4,12 @@ var program = require("commander");
 var child = require("child_process");
 var colors = require("colors/safe");
 var Helper = require("../helper");
+const Utils = require("./utils");
 
 program
 	.command("config")
-	.description(`Edit configuration file located at ${colors.green(Helper.CONFIG_PATH)}. Set the ${colors.green("LOUNGE_HOME")} environment variable to change.`)
+	.description(`Edit configuration file located at ${colors.green(Helper.CONFIG_PATH)}.`)
+	.on("--help", Utils.extraHelp)
 	.action(function() {
 		var child_spawn = child.spawn(
 			process.env.EDITOR || "vi",

--- a/src/command-line/edit.js
+++ b/src/command-line/edit.js
@@ -5,10 +5,12 @@ var program = require("commander");
 var child = require("child_process");
 var colors = require("colors/safe");
 var Helper = require("../helper");
+const Utils = require("./utils");
 
 program
 	.command("edit <name>")
 	.description(`Edit user file located at ${colors.green(Helper.getUserConfigPath("<name>"))}.`)
+	.on("--help", Utils.extraHelp)
 	.action(function(name) {
 		var users = new ClientManager().getUsers();
 		if (users.indexOf(name) === -1) {

--- a/src/command-line/index.js
+++ b/src/command-line/index.js
@@ -8,9 +8,11 @@ var fs = require("fs");
 var fsextra = require("fs-extra");
 var path = require("path");
 var Helper = require("../helper");
+const Utils = require("./utils");
 
 program.version(Helper.getVersion(), "-v, --version")
 	.option("--home <path>", `${colors.bold("[DEPRECATED]")} Use the ${colors.green("LOUNGE_HOME")} environment variable instead.`)
+	.on("--help", Utils.extraHelp)
 	.parseOptions(process.argv);
 
 if (program.home) {

--- a/src/command-line/index.js
+++ b/src/command-line/index.js
@@ -23,14 +23,7 @@ if (program.home) {
 let home = program.home || process.env.LOUNGE_HOME;
 
 if (!home) {
-	const distConfig = path.resolve(path.join(
-		__dirname,
-		"..",
-		"..",
-		".lounge_home"
-	));
-
-	home = fs.readFileSync(distConfig, "utf-8").trim();
+	home = Utils.defaultLoungeHome();
 }
 
 Helper.setHome(home);

--- a/src/command-line/list.js
+++ b/src/command-line/list.js
@@ -3,10 +3,12 @@
 var ClientManager = new require("../clientManager");
 var program = require("commander");
 var colors = require("colors/safe");
+const Utils = require("./utils");
 
 program
 	.command("list")
 	.description("List all users")
+	.on("--help", Utils.extraHelp)
 	.action(function() {
 		var users = new ClientManager().getUsers();
 		if (!users.length) {

--- a/src/command-line/remove.js
+++ b/src/command-line/remove.js
@@ -3,10 +3,12 @@
 var ClientManager = new require("../clientManager");
 var program = require("commander");
 var colors = require("colors/safe");
+const Utils = require("./utils");
 
 program
 	.command("remove <name>")
 	.description("Remove an existing user")
+	.on("--help", Utils.extraHelp)
 	.action(function(name) {
 		var manager = new ClientManager();
 		if (manager.removeUser(name)) {

--- a/src/command-line/reset.js
+++ b/src/command-line/reset.js
@@ -5,10 +5,12 @@ var fs = require("fs");
 var program = require("commander");
 var colors = require("colors/safe");
 var Helper = require("../helper");
+const Utils = require("./utils");
 
 program
 	.command("reset <name>")
 	.description("Reset user password")
+	.on("--help", Utils.extraHelp)
 	.action(function(name) {
 		var users = new ClientManager().getUsers();
 		if (users.indexOf(name) === -1) {

--- a/src/command-line/start.js
+++ b/src/command-line/start.js
@@ -5,6 +5,7 @@ var program = require("commander");
 var colors = require("colors/safe");
 var server = require("../server");
 var Helper = require("../helper");
+const Utils = require("./utils");
 
 program
 	.command("start")
@@ -14,6 +15,7 @@ program
 	.option("    --public", "start in public mode")
 	.option("    --private", "start in private mode")
 	.description("Start the server")
+	.on("--help", Utils.extraHelp)
 	.action(function(options) {
 		var users = new ClientManager().getUsers();
 

--- a/src/command-line/utils.js
+++ b/src/command-line/utils.js
@@ -1,0 +1,18 @@
+"use strict";
+
+const colors = require("colors/safe");
+
+class Utils {
+	static extraHelp() {
+		[
+			"",
+			"",
+			"  Environment variable:",
+			"",
+			`    LOUNGE_HOME   Path for all configuration files and folders. Defaults to ${colors.green("~/.lounge")}.`,
+			"",
+		].forEach((e) => console.log(e));
+	}
+}
+
+module.exports = Utils;

--- a/src/command-line/utils.js
+++ b/src/command-line/utils.js
@@ -1,6 +1,10 @@
 "use strict";
 
 const colors = require("colors/safe");
+const fs = require("fs");
+const path = require("path");
+
+let loungeHome;
 
 class Utils {
 	static extraHelp() {
@@ -9,9 +13,25 @@ class Utils {
 			"",
 			"  Environment variable:",
 			"",
-			`    LOUNGE_HOME   Path for all configuration files and folders. Defaults to ${colors.green("~/.lounge")}.`,
+			`    LOUNGE_HOME   Path for all configuration files and folders. Defaults to ${colors.green(Utils.defaultLoungeHome())}.`,
 			"",
 		].forEach((e) => console.log(e));
+	}
+
+	static defaultLoungeHome() {
+		if (loungeHome) {
+			return loungeHome;
+		}
+		const distConfig = path.resolve(path.join(
+			__dirname,
+			"..",
+			"..",
+			".lounge_home"
+		));
+
+		loungeHome = fs.readFileSync(distConfig, "utf-8").trim();
+
+		return loungeHome;
 	}
 }
 


### PR DESCRIPTION
Couldn't do this in a nicer way, see https://github.com/tj/commander.js/issues/682.

<img width="400" alt="screen shot 2017-08-21 at 01 48 29" src="https://user-images.githubusercontent.com/113730/29505228-0877a382-8613-11e7-94f8-3699b6469fe2.png">

(`~` in default not expanded on purpose)