### PR TITLE
Fix time placeholder showing on mobile format for condensed messages

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -837,6 +837,10 @@ kbd {
 	display: none;
 }
 
+#chat .condensed .time {
+	visibility: hidden;
+}
+
 #windows .header .topic,
 .messages .msg,
 .sidebar {
@@ -2043,6 +2047,11 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 		padding: 0;
 	}
 
+	#chat .condensed .time,
+	#chat .condensed .from {
+		display: none;
+	}
+
 	#chat .date-marker,
 	#chat .unread-marker {
 		margin: 0;
@@ -2180,8 +2189,4 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 #chat .action .text,
 #chat table.channel-list .topic {
 	white-space: pre-wrap;
-}
-
-.hide-text {
-	color: transparent !important;
 }

--- a/client/views/msg_condensed.tpl
+++ b/client/views/msg_condensed.tpl
@@ -1,5 +1,5 @@
-<div class="msg {{type}} closed" data-time="{{time}}">
-	<span class="time hide-text">{{tz time}}</span>
+<div class="msg condensed closed" data-time="{{time}}">
+	<span class="time">{{tz time}}</span>
 	<span class="from"></span>
 	<span class="content">
 		<span class="condensed-text"></span>


### PR DESCRIPTION
/Cc @MaxLeiter

As an extra, make sure time placeholder cannot be selected anymore, ~and do not do an extra call to `tz` helper when time is not relevant/displayed~.

I tried to entirely remove `time`/`from` blocks, but because of flexbox layout, that broke message alignment...

Before | After
--- | ---
<img width="617" alt="screen shot 2017-08-22 at 20 12 38" src="https://user-images.githubusercontent.com/113730/29593252-43191a60-8777-11e7-9061-be717abd6f5a.png"> | <img width="623" alt="screen shot 2017-08-22 at 20 13 58" src="https://user-images.githubusercontent.com/113730/29593261-505267d6-8777-11e7-90f3-ed43b02c7f35.png">
<img width="613" alt="screen shot 2017-08-22 at 20 13 04" src="https://user-images.githubusercontent.com/113730/29593251-4318f508-8777-11e7-9111-a0f4d4258427.png"> | <img width="630" alt="screen shot 2017-08-22 at 20 13 45" src="https://user-images.githubusercontent.com/113730/29593268-59a778f8-8777-11e7-8df7-1e786ffb08db.png">
<img width="421" alt="screen shot 2017-08-22 at 20 13 15" src="https://user-images.githubusercontent.com/113730/29593253-4319eb2a-8777-11e7-9855-b5a14a03bc2f.png"> | <img width="431" alt="screen shot 2017-08-22 at 20 13 34" src="https://user-images.githubusercontent.com/113730/29593270-5f365348-8777-11e7-9f4c-61a17a67f80c.png">

