### PR TITLE
Process chat messages in requestIdleCallback if available

### DIFF
--- a/client/js/socket-events/msg.js
+++ b/client/js/socket-events/msg.js
@@ -7,6 +7,17 @@ const chat = $("#chat");
 const templates = require("../../views");
 
 socket.on("msg", function(data) {
+	if (window.requestIdleCallback) {
+		// During an idle period the user agent will run idle callbacks in FIFO order
+		// until either the idle period ends or there are no more idle callbacks eligible to be run.
+		// We set a maximum timeout of 2 seconds so that messages don't take too long to appear.
+		window.requestIdleCallback(() => processReceivedMessage(data), {timeout: 2000});
+	} else {
+		processReceivedMessage(data);
+	}
+});
+
+function processReceivedMessage(data) {
 	const msg = render.buildChatMessage(data);
 	const targetId = data.chan;
 	const target = "#chan-" + targetId;
@@ -73,4 +84,4 @@ socket.on("msg", function(data) {
 			}
 		});
 	}
-});
+}


### PR DESCRIPTION
Takes a simpler approach to the queue processing PR. This still helps a lot with performance when connecting to ZNC and buffer playback happens.

Browser support: https://caniuse.com/#feat=requestidlecallback
We don't lose anything by not polyfilling it.