### PR TITLE
Fix general spelling errors

### DIFF
--- a/client/js/libs/handlebars/ircmessageparser/findLinks.js
+++ b/client/js/libs/handlebars/ircmessageparser/findLinks.js
@@ -29,7 +29,7 @@ function findLinks(text) {
 			// Extract the scheme of the URL detected, if there is one
 			parsedScheme = URI(url).scheme().toLowerCase();
 		} catch (e) {
-			// URI may throw an exception for malfored urls,
+			// URI may throw an exception for malformed urls,
 			// as to why withinString finds these in the first place is a mystery
 			return;
 		}

--- a/client/js/socket-events/more.js
+++ b/client/js/socket-events/more.js
@@ -46,7 +46,7 @@ socket.on("more", function(data) {
 	}
 
 	// Date change detect
-	// Have to use data instaid of the documentFragment because it's being weird
+	// Have to use data instead of the documentFragment because it's being weird
 	let lastDate;
 	$(data.messages).each(function() {
 		const msgData = this;

--- a/client/js/socket-events/msg.js
+++ b/client/js/socket-events/msg.js
@@ -65,7 +65,7 @@ socket.on("msg", function(data) {
 	if (activeChannelId !== targetId && container.find(".msg").slice(0, -100).remove().length) {
 		channel.find(".show-more").addClass("show");
 
-		// Remove date-seperators that would otherwise
+		// Remove date-separators that would otherwise
 		// be "stuck" at the top of the channel
 		channel.find(".date-marker-container").each(function() {
 			if ($(this).next().hasClass("date-marker-container")) {

--- a/src/userLog.js
+++ b/src/userLog.js
@@ -11,7 +11,7 @@ module.exports.write = function(user, network, chan, msg) {
 	try {
 		fsextra.ensureDirSync(path);
 	} catch (e) {
-		log.error("Unabled to create logs directory", e);
+		log.error("Unable to create logs directory", e);
 		return;
 	}
 

--- a/test/client/js/libs/handlebars/ircmessageparser/findChannels.js
+++ b/test/client/js/libs/handlebars/ircmessageparser/findChannels.js
@@ -69,7 +69,7 @@ describe("findChannels", () => {
 		expect(actual).to.deep.equal(expected);
 	});
 
-	it("should work with whois reponses", () => {
+	it("should work with whois responses", () => {
 		const input = "@#a";
 		const expected = [{
 			channel: "#a",

--- a/test/client/js/libs/handlebars/ircmessageparser/parseStyle.js
+++ b/test/client/js/libs/handlebars/ircmessageparser/parseStyle.js
@@ -201,7 +201,7 @@ describe("parseStyle", () => {
 		expect(actual).to.deep.equal(expected);
 	});
 
-	it("should carry state corretly forward", () => {
+	it("should carry state correctly forward", () => {
 		const input = "\x02bold\x038yellow\x02nonBold\x03default";
 		const expected = [{
 			bold: true,

--- a/test/client/js/libs/handlebars/parse.js
+++ b/test/client/js/libs/handlebars/parse.js
@@ -285,7 +285,7 @@ describe("parse Handlebars helper", () => {
 		expect(actual).to.deep.equal(expected);
 	});
 
-	it("should trim commom protocols", () => {
+	it("should trim common protocols", () => {
 		const testCases = [{
 			input: "like..http://example.com",
 			expected:

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -62,7 +62,7 @@ const config = {
 	plugins: [
 		// socket.io uses debug, we don't need it
 		new webpack.NormalModuleReplacementPlugin(/debug/, path.resolve(__dirname, "scripts/noop.js")),
-		// automatically split all vendor dependancies into a separate bundle
+		// automatically split all vendor dependencies into a separate bundle
 		new webpack.optimize.CommonsChunkPlugin({
 			name: "js/bundle.vendor.js",
 			minChunks: (module) => module.context && module.context.indexOf("node_modules") !== -1


### PR DESCRIPTION
@Raqbit noticed this morning that in the webpack config 'dependencies' was misspelt, and @xPaw had the idea to run a spellchecker on the code... so I did. 

I doubt I found all of them, but I'm sure I found most.

:innocent: 