### PR TITLE
Improve output of WebPush error

### DIFF
--- a/src/plugins/webpush.js
+++ b/src/plugins/webpush.js
@@ -65,7 +65,7 @@ class WebPush {
 					return;
 				}
 
-				log.error("WebPush Error", error);
+				log.error(`WebPush Error (${error})`);
 			});
 	}
 }


### PR DESCRIPTION
Without this, the error displayed contains a lot of superfluous information, repeated.

Before:

<img width="806" alt="screen shot 2017-08-26 at 11 46 03" src="https://user-images.githubusercontent.com/113730/29742842-657f50c6-8a54-11e7-81a3-c6697a85b6df.png">

The after should just be something like:

```
2017-08-26 06:15:45 [ERROR] WebPush Error (getaddrinfo ENOTFOUND fcm.googleapis.com fcm.googleapis.com:443)
```

This is similar to [that](https://github.com/thelounge/lounge/commit/ed68ff4a34ce7c4d6d3b931420df65495d420979#diff-d2b968c6b04880a9a797066220f71e00R100) and makes for a more digestible output.