### PR TITLE
Remove the "Stay signed in" checkbox at login

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1353,17 +1353,6 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 	margin-top: 10px;
 }
 
-#sign-in .remember {
-	float: left;
-	font-size: 14px;
-	margin-top: 12px;
-}
-
-#sign-in .remember input {
-	float: left;
-	margin: 3px 10px 0 0;
-}
-
 #sign-in .btn {
 	margin-top: 25px;
 }

--- a/client/index.html
+++ b/client/index.html
@@ -97,12 +97,6 @@
 								<input class="input" type="password" name="password">
 								</label>
 							</div>
-							<div class="col-xs-12">
-								<label class="remember">
-									<input type="checkbox" name="remember" value="on" id="sign-in-remember" checked>
-									Stay signed in
-								</label>
-							</div>
 							<div class="col-xs-12 error" style="display: none;">
 								Authentication failed.
 							</div>

--- a/client/themes/crypto.css
+++ b/client/themes/crypto.css
@@ -78,11 +78,6 @@ a:hover,
 	font-size: 12px;
 }
 
-#sign-in .remember {
-	font-size: 12px;
-	line-height: 30px;
-}
-
 #sidebar .chan:first-child {
 	color: #00ff0e;
 }

--- a/src/server.js
+++ b/src/server.js
@@ -203,7 +203,7 @@ function index(req, res, next) {
 	res.render("index", data);
 }
 
-function initializeClient(socket, client, generateToken, token) {
+function initializeClient(socket, client, token) {
 	socket.emit("authorized");
 
 	socket.on("disconnect", function() {
@@ -376,7 +376,7 @@ function initializeClient(socket, client, generateToken, token) {
 		});
 	};
 
-	if (generateToken) {
+	if (!Helper.config.public && token === null) {
 		client.generateToken((newToken) => {
 			token = newToken;
 
@@ -457,7 +457,7 @@ function performAuthentication(data) {
 	const socket = this;
 	let client;
 
-	const finalInit = () => initializeClient(socket, client, !!data.remember, data.token || null);
+	const finalInit = () => initializeClient(socket, client, data.token || null);
 
 	const initClient = () => {
 		client.ip = getClientIp(socket.request);


### PR DESCRIPTION
This option is less and less the norm on modern webapps, it is fair to assume this is the default behavior. In fact, we were making it the default.

But more importantly, coming soon is the ability of remotely logging out of your other sessions, which is well handled through token deletion. That means we need to know about said tokens, which are not sent in no-"Stay signed in" version.