### PR TITLE
Automatic client reconnection

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1483,6 +1483,15 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 }
 
 #connection-error {
+	font-size: 12px;
+	line-height: 36px;
+	font-weight: bold;
+	letter-spacing: 1px;
+	word-spacing: 3px;
+	text-transform: uppercase;
+	background: #e74c3c;
+	color: #fff;
+	text-align: center;
 	display: none;
 }
 

--- a/client/index.html
+++ b/client/index.html
@@ -63,7 +63,7 @@
 				</div>
 				<div id="chat-container" class="window">
 					<div id="chat"></div>
-					<button id="connection-error" class="btn btn-reconnect">Client connection lost &mdash; Click here to reconnect</button>
+					<div id="connection-error"></div>
 					<form id="form" method="post" action="">
 						<div class="input">
 							<span id="nick">

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -588,9 +588,6 @@ $(function() {
 	}
 	setTimeout(updateDateMarkers, msUntilNextDay());
 
-	// Only start opening socket.io connection after all events have been registered
-	socket.open();
-
 	window.addEventListener("popstate", (e) => {
 		const {state} = e;
 		if (!state) {
@@ -604,4 +601,7 @@ $(function() {
 			});
 		}
 	});
+
+	// Only start opening socket.io connection after all events have been registered
+	socket.open();
 });

--- a/client/js/render.js
+++ b/client/js/render.js
@@ -35,6 +35,10 @@ function buildChannelMessages(chanId, chanType, messages) {
 }
 
 function appendMessage(container, chanId, chanType, msg) {
+	if (utils.lastMessageId < msg.id) {
+		utils.lastMessageId = msg.id;
+	}
+
 	let lastChild = container.children(".msg, .date-marker-container").last();
 	const renderedMessage = buildChatMessage(msg);
 

--- a/client/js/render.js
+++ b/client/js/render.js
@@ -8,6 +8,7 @@ const utils = require("./utils");
 const sorting = require("./sorting");
 const constants = require("./constants");
 const condensed = require("./condensed");
+const helpers_parse = require("./libs/handlebars/parse");
 
 const chat = $("#chat");
 const sidebar = $("#sidebar");
@@ -27,11 +28,11 @@ module.exports = {
 	renderNetworks,
 };
 
-function buildChannelMessages(chanId, chanType, messages) {
+function buildChannelMessages(container, chanId, chanType, messages) {
 	return messages.reduce((docFragment, message) => {
 		appendMessage(docFragment, chanId, chanType, message);
 		return docFragment;
-	}, $(document.createDocumentFragment()));
+	}, container);
 }
 
 function appendMessage(container, chanId, chanType, msg) {
@@ -121,7 +122,7 @@ function renderChannel(data) {
 }
 
 function renderChannelMessages(data) {
-	const documentFragment = buildChannelMessages(data.id, data.type, data.messages);
+	const documentFragment = buildChannelMessages($(document.createDocumentFragment()), data.id, data.type, data.messages);
 	const channel = chat.find("#chan-" + data.id + " .messages").append(documentFragment);
 
 	const template = $(templates.unread_marker());
@@ -168,7 +169,7 @@ function renderChannelUsers(data) {
 	}
 }
 
-function renderNetworks(data) {
+function renderNetworks(data, singleNetwork) {
 	sidebar.find(".empty").hide();
 	sidebar.find(".networks").append(
 		templates.network({
@@ -176,15 +177,51 @@ function renderNetworks(data) {
 		})
 	);
 
+	let newChannels;
 	const channels = $.map(data.networks, function(n) {
 		return n.channels;
 	});
+
+	if (!singleNetwork && utils.lastMessageId > -1) {
+		newChannels = [];
+
+		channels.forEach((channel) => {
+			const chan = $("#chan-" + channel.id);
+
+			if (chan.length > 0) {
+				if (chan.data("type") === "channel") {
+					chan
+						.data("needsNamesRefresh", true)
+						.find(".header .topic")
+						.html(helpers_parse(channel.topic))
+						.attr("title", channel.topic);
+				}
+
+				if (channel.messages.length > 0) {
+					const container = chan.find(".messages");
+					buildChannelMessages(container, channel.id, channel.type, channel.messages);
+
+					if (container.find(".msg").length >= 100) {
+						container.find(".show-more").addClass("show");
+					}
+
+					container.trigger("keepToBottom");
+				}
+			} else {
+				newChannels.push(channel);
+			}
+		});
+	} else {
+		newChannels = channels;
+	}
+
 	chat.append(
 		templates.chat({
 			channels: channels
 		})
 	);
-	channels.forEach((channel) => {
+
+	newChannels.forEach((channel) => {
 		renderChannel(channel);
 
 		if (channel.type === "channel") {

--- a/client/js/socket-events/auth.js
+++ b/client/js/socket-events/auth.js
@@ -3,8 +3,19 @@
 const $ = require("jquery");
 const socket = require("../socket");
 const storage = require("../localStorage");
+const utils = require("../utils");
 
 socket.on("auth", function(data) {
+	// If we reconnected and serverHash differents, that means the server restarted
+	// And we will reload the page to grab the latest version
+	if (utils.serverHash > -1 && data.serverHash > -1 && data.serverHash !== utils.serverHash) {
+		socket.disconnect();
+		location.reload(true);
+		return;
+	}
+
+	utils.serverHash = data.serverHash;
+
 	const login = $("#sign-in");
 	let token;
 	const user = storage.get("user");
@@ -12,6 +23,13 @@ socket.on("auth", function(data) {
 	login.find(".btn").prop("disabled", false);
 
 	if (!data.success) {
+		if (login.length === 0) {
+			socket.disconnect();
+			$("#connection-error").text("Authentication failed, reloading…");
+			location.reload();
+			return;
+		}
+
 		storage.remove("token");
 
 		const error = login.find(".error");
@@ -20,9 +38,15 @@ socket.on("auth", function(data) {
 		});
 	} else if (user) {
 		token = storage.get("token");
+
 		if (token) {
 			$("#loading-page-message").text("Authorizing…");
-			socket.emit("auth", {user: user, token: token});
+
+			socket.emit("auth", {
+				user: user,
+				token: token,
+				lastMessage: utils.lastMessageId,
+			});
 		}
 	}
 

--- a/client/js/socket-events/auth.js
+++ b/client/js/socket-events/auth.js
@@ -6,7 +6,7 @@ const storage = require("../localStorage");
 const utils = require("../utils");
 
 socket.on("auth", function(data) {
-	// If we reconnected and serverHash differents, that means the server restarted
+	// If we reconnected and serverHash differs, that means the server restarted
 	// And we will reload the page to grab the latest version
 	if (utils.serverHash > -1 && data.serverHash > -1 && data.serverHash !== utils.serverHash) {
 		socket.disconnect();

--- a/client/js/socket-events/auth.js
+++ b/client/js/socket-events/auth.js
@@ -10,6 +10,7 @@ socket.on("auth", function(data) {
 	// And we will reload the page to grab the latest version
 	if (utils.serverHash > -1 && data.serverHash > -1 && data.serverHash !== utils.serverHash) {
 		socket.disconnect();
+		$("#connection-error").text("Server restarted, reloading…");
 		location.reload(true);
 		return;
 	}
@@ -40,7 +41,7 @@ socket.on("auth", function(data) {
 		token = storage.get("token");
 
 		if (token) {
-			$("#loading-page-message").text("Authorizing…");
+			$("#loading-page-message, #connection-error").text("Authorizing…");
 
 			socket.emit("auth", {
 				user: user,

--- a/client/js/socket-events/more.js
+++ b/client/js/socket-events/more.js
@@ -33,7 +33,7 @@ socket.on("more", function(data) {
 	}
 
 	// Add the older messages
-	const documentFragment = render.buildChannelMessages(data.chan, type, data.messages);
+	const documentFragment = render.buildChannelMessages($(document.createDocumentFragment()), data.chan, type, data.messages);
 	chan.prepend(documentFragment);
 
 	// Move unread marker to correct spot if needed

--- a/client/js/socket-events/network.js
+++ b/client/js/socket-events/network.js
@@ -6,7 +6,7 @@ const render = require("../render");
 const sidebar = $("#sidebar");
 
 socket.on("network", function(data) {
-	render.renderNetworks(data);
+	render.renderNetworks(data, true);
 
 	sidebar.find(".chan")
 		.last()
@@ -20,4 +20,3 @@ socket.on("network", function(data) {
 socket.on("network_changed", function(data) {
 	sidebar.find("#network-" + data.network).data("options", data.serverOptions);
 });
-

--- a/client/js/socket.js
+++ b/client/js/socket.js
@@ -2,6 +2,7 @@
 
 const $ = require("jquery");
 const io = require("socket.io-client");
+const utils = require("./utils");
 const path = window.location.pathname + "socket.io/";
 const status = $("#loading-page-message, #connection-error");
 
@@ -43,6 +44,12 @@ function handleDisconnect(data) {
 	status.text(`Waiting to reconnect… (${message})`).addClass("shown");
 	$(".show-more-button, #input").prop("disabled", true);
 	$("#submit").hide();
+
+	// If the server shuts down, socket.io skips reconnection
+	// and we have to manually call connect to start the process
+	if (socket.io.skipReconnect) {
+		utils.requestIdleCallback(() => socket.connect(), 2000);
+	}
 }
 
 module.exports = socket;

--- a/client/js/socket.js
+++ b/client/js/socket.js
@@ -8,8 +8,10 @@ const socket = io({
 	transports: $(document.body).data("transports"),
 	path: path,
 	autoConnect: false,
-	reconnection: false
+	reconnection: !$(document.body).hasClass("public")
 });
+
+window.lounge_socket = socket; // TODO: Remove later, this is for debugging
 
 [
 	"connect_error",
@@ -34,7 +36,7 @@ const socket = io({
 			}
 		});
 		// Hides the "Send Message" button
-		$("#submit").remove();
+		$("#submit").hide();
 	});
 });
 
@@ -43,11 +45,16 @@ socket.on("connecting", function() {
 });
 
 socket.on("connect", function() {
-	$("#loading-page-message").text("Finalizing connection…");
+	// Clear send buffer when reconnecting, socket.io would emit these
+	// immediately upon connection and it will have no effect, so we ensure
+	// nothing is sent to the server that might have happened.
+	socket.sendBuffer = [];
+
+	status.text("Finalizing connection…");
 });
 
 socket.on("authorized", function() {
-	$("#loading-page-message").text("Authorized, loading messages…");
+	$("#loading-page-message").text("Loading messages…");
 });
 
 module.exports = socket;

--- a/client/js/socket.js
+++ b/client/js/socket.js
@@ -3,6 +3,7 @@
 const $ = require("jquery");
 const io = require("socket.io-client");
 const path = window.location.pathname + "socket.io/";
+const status = $("#loading-page-message, #connection-error");
 
 const socket = io({
 	transports: $(document.body).data("transports"),
@@ -11,37 +12,16 @@ const socket = io({
 	reconnection: !$(document.body).hasClass("public")
 });
 
-window.lounge_socket = socket; // TODO: Remove later, this is for debugging
+socket.on("disconnect", handleDisconnect);
+socket.on("connect_error", handleDisconnect);
+socket.on("error", handleDisconnect);
 
-[
-	"connect_error",
-	"connect_failed",
-	"disconnect",
-	"error",
-].forEach(function(e) {
-	socket.on(e, function(data) {
-		$("#loading-page-message").text("Connection failed: " + data);
-		$("#connection-error").addClass("shown").one("click", function() {
-			window.onbeforeunload = null;
-			window.location.reload();
-		});
-
-		// Disables sending a message by pressing Enter. `off` is necessary to
-		// cancel `inputhistory`, which overrides hitting Enter. `on` is then
-		// necessary to avoid creating new lines when hitting Enter without Shift.
-		// This is fairly hacky but this solution is not permanent.
-		$("#input").off("keydown").on("keydown", function(event) {
-			if (event.which === 13 && !event.shiftKey) {
-				event.preventDefault();
-			}
-		});
-		// Hides the "Send Message" button
-		$("#submit").hide();
-	});
+socket.on("reconnecting", function(attempt) {
+	status.text(`Reconnecting… (attempt ${attempt})`);
 });
 
 socket.on("connecting", function() {
-	$("#loading-page-message").text("Connecting…");
+	status.text("Connecting…");
 });
 
 socket.on("connect", function() {
@@ -54,7 +34,15 @@ socket.on("connect", function() {
 });
 
 socket.on("authorized", function() {
-	$("#loading-page-message").text("Loading messages…");
+	status.text("Loading messages…");
 });
+
+function handleDisconnect(data) {
+	const message = data.message || data;
+
+	status.text(`Waiting to reconnect… (${message})`).addClass("shown");
+	$(".show-more-button, #input").prop("disabled", true);
+	$("#submit").hide();
+}
 
 module.exports = socket;

--- a/client/js/utils.js
+++ b/client/js/utils.js
@@ -3,7 +3,12 @@
 const $ = require("jquery");
 const input = $("#input");
 
+var serverHash = -1;
+var lastMessageId = -1;
+
 module.exports = {
+	serverHash,
+	lastMessageId,
 	confirmExit,
 	forceFocus,
 	move,

--- a/client/themes/crypto.css
+++ b/client/themes/crypto.css
@@ -65,12 +65,8 @@ a:hover,
 	background: #00ff0e;
 }
 
-.btn-reconnect {
+#connection-error {
 	background: #f00;
-	color: #fff;
-	border: 0;
-	border-radius: 0;
-	margin: 0;
 }
 
 #settings .opt {

--- a/client/themes/example.css
+++ b/client/themes/example.css
@@ -46,14 +46,6 @@ body {
 	border-radius: 2px;
 }
 
-.btn-reconnect {
-	background: #e74c3c;
-	color: #fff;
-	border: 0;
-	border-radius: 0;
-	margin: 0;
-}
-
 @media (max-width: 768px) {
 	#sidebar {
 		left: -220px;

--- a/client/themes/morning.css
+++ b/client/themes/morning.css
@@ -205,14 +205,6 @@ body {
 	color: #99a2b4;
 }
 
-.btn-reconnect {
-	background: #e74c3c;
-	color: #fff;
-	border: 0;
-	border-radius: 0;
-	margin: 0;
-}
-
 /* Form elements */
 
 #chat-container ::-moz-placeholder {

--- a/client/themes/zenburn.css
+++ b/client/themes/zenburn.css
@@ -232,14 +232,6 @@ body {
 	color: #d2d39b;
 }
 
-.btn-reconnect {
-	background: #e74c3c;
-	color: #fff;
-	border: 0;
-	border-radius: 0;
-	margin: 0;
-}
-
 /* Form elements */
 
 #chat-container ::-moz-placeholder {

--- a/src/server.js
+++ b/src/server.js
@@ -23,6 +23,9 @@ const authPlugins = [
 	require("./plugins/auth/local"),
 ];
 
+// A random number that will force clients to reload the page if it differs
+const serverHash = Math.floor(Date.now() * Math.random());
+
 var manager = null;
 
 module.exports = function() {
@@ -135,7 +138,10 @@ module.exports = function() {
 			if (config.public) {
 				performAuthentication.call(socket, {});
 			} else {
-				socket.emit("auth", {success: true});
+				socket.emit("auth", {
+					serverHash: serverHash,
+					success: true,
+				});
 				socket.on("auth", performAuthentication);
 			}
 		});


### PR DESCRIPTION
Instead of simply redrawing all channel windows, it only draws new ones, and for existing ones it updates the topic and only new messages (on auth, client tells the server latest message id it has seen).

Client will force reload the client page if server restarted between connections (server generates a random number on start), this is to help with buffer problems (e.g. last message id going backwards) and Lounge updates.

The red disconnected bar also reports all the status changes.

- [x] Disable input bar correctly.
- [x] Test removing user and reconnecting (should refresh into sign in page).
- [x] Cleanup error message handling