### PR TITLE
Escape channel names in slugify helper correctly

### DIFF
--- a/client/js/libs/handlebars/slugify.js
+++ b/client/js/libs/handlebars/slugify.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const escape = require("css.escape");
+
 module.exports = function(orig) {
-	return orig.toLowerCase().replace(/[^a-z0-9]/, "-");
+	return escape(orig.toLowerCase());
 };

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "babel-loader": "7.1.2",
     "babel-preset-env": "1.6.0",
     "chai": "4.1.1",
+    "css.escape": "1.5.1",
     "emoji-regex": "6.5.1",
     "eslint": "4.5.0",
     "font-awesome": "4.7.0",


### PR DESCRIPTION
Fixes #1172.

`css.escape` uses browser's `CSS.escape` otherwise polyfills it.

Breaking change: first invalid character (e.g. `#`) is no longer replaced with `-`. Channels that previously were `chan--test` are now `chan-\#test`.