### PR TITLE
Use a promise to simplify calling of `sendInitEvent`

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -295,13 +295,15 @@ Client.prototype.connect = function(args) {
 	client.save();
 };
 
-Client.prototype.generateToken = function(callback) {
-	crypto.randomBytes(48, (err, buf) => {
-		if (err) {
-			throw err;
-		}
-
-		callback(buf.toString("hex"));
+Client.prototype.generateToken = function() {
+	return new Promise((resolve, reject) => {
+		crypto.randomBytes(48, (err, buf) => {
+			if (err) {
+				reject(err);
+			} else {
+				resolve(buf.toString("hex"));
+			}
+		});
 	});
 };
 


### PR DESCRIPTION
Extracted from #1465, PR meant to be closed on creation, purely for the sake of archiving (since I removed commit from original PR).