### PR TITLE
Handle browser history when opening/closing image preview

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -336,8 +336,6 @@ $(function() {
 			state.clickTarget = `#footer button[data-target="${target}"]`;
 		}
 
-		state.clickTarget += ", #image-viewer";
-
 		if (history && history.pushState) {
 			if (data && data.replaceHistory && history.replaceState) {
 				history.replaceState(state, null, null);
@@ -809,8 +807,23 @@ $(function() {
 			return;
 		}
 
-		const {clickTarget} = state;
+		let {clickTarget} = state;
+
 		if (clickTarget) {
+			// This will be true when click target corresponds to opening a thumbnail,
+			// browsing to the previous/next thumbnail, or closing the image viewer.
+			const imageViewerRelated =
+				clickTarget === "#image-viewer" ||
+				clickTarget.includes(".toggle-thumbnail");
+
+			// If the click target is not related to the image viewer but the viewer
+			// is currently opened, we need to close it.
+			if (!imageViewerRelated && $("#image-viewer").hasClass("opened")) {
+				clickTarget += ", #image-viewer";
+			}
+
+			// Emit the click to the target, while making sure it is not going to be
+			// added to the state again.
 			$(clickTarget).trigger("click", {
 				pushState: false
 			});

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -336,6 +336,8 @@ $(function() {
 			state.clickTarget = `#footer button[data-target="${target}"]`;
 		}
 
+		state.clickTarget += ", #image-viewer";
+
 		if (history && history.pushState) {
 			if (data && data.replaceHistory && history.replaceState) {
 				history.replaceState(state, null, null);

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -331,7 +331,7 @@ $(function() {
 		const state = {};
 
 		if (self.hasClass("chan")) {
-			state.clickTarget = `.chan[data-id="${self.data("id")}"]`;
+			state.clickTarget = `#sidebar .chan[data-id="${self.data("id")}"]`;
 		} else {
 			state.clickTarget = `#footer button[data-target="${target}"]`;
 		}
@@ -812,9 +812,7 @@ $(function() {
 		if (clickTarget) {
 			// This will be true when click target corresponds to opening a thumbnail,
 			// browsing to the previous/next thumbnail, or closing the image viewer.
-			const imageViewerRelated =
-				clickTarget === "#image-viewer" ||
-				clickTarget.includes(".toggle-thumbnail");
+			const imageViewerRelated = clickTarget.includes(".toggle-thumbnail");
 
 			// If the click target is not related to the image viewer but the viewer
 			// is currently opened, we need to close it.

--- a/client/js/renderPreview.js
+++ b/client/js/renderPreview.js
@@ -92,10 +92,12 @@ function handleImageInPreview(content, container) {
 
 const imageViewer = $("#image-viewer");
 
-$("#chat").on("click", ".toggle-thumbnail", function(event, data) {
+$("#chat").on("click", ".toggle-thumbnail", function(event, data = {}) {
 	const link = $(this);
 
-	openImageViewer(link, {pushState: !data || data.pushState !== false});
+	// Passing `data`, specifically `data.pushState`, to not add the action to the
+	// history state if back or forward buttons were pressed.
+	openImageViewer(link, data);
 
 	// Prevent the link to open a new page since we're opening the image viewer,
 	// but keep it a link to allow for Ctrl/Cmd+click.
@@ -103,8 +105,10 @@ $("#chat").on("click", ".toggle-thumbnail", function(event, data) {
 	return false;
 });
 
-imageViewer.on("click", function(event, data) {
-	closeImageViewer({pushState: !data || data.pushState !== false});
+imageViewer.on("click", function(event, data = {}) {
+	// Passing `data`, specifically `data.pushState`, to not add the action to the
+	// history state if back or forward buttons were pressed.
+	closeImageViewer(data);
 });
 
 $(document).keydown(function(e) {
@@ -125,7 +129,7 @@ $(document).keydown(function(e) {
 	}
 });
 
-function openImageViewer(link, {pushState = true}) {
+function openImageViewer(link, {pushState = true} = {}) {
 	$(".previous-image").removeClass("previous-image");
 	$(".next-image").removeClass("next-image");
 
@@ -171,9 +175,9 @@ function openImageViewer(link, {pushState = true}) {
 	if (pushState) {
 		const clickTarget =
 			`#${link.closest(".msg").attr("id")} ` +
-			`a[href="${link.attr("href")}"] ` +
+			`a.toggle-thumbnail[href="${link.attr("href")}"] ` +
 			"img";
-		history.pushState({clickTarget: clickTarget}, null, null);
+		history.pushState({clickTarget}, null, null);
 	}
 }
 
@@ -187,7 +191,7 @@ imageViewer.on("click", ".next-image-btn", function() {
 	return false;
 });
 
-function closeImageViewer({pushState = true}) {
+function closeImageViewer({pushState = true} = {}) {
 	imageViewer
 		.removeClass("opened")
 		.one("transitionend", function() {

--- a/client/js/renderPreview.js
+++ b/client/js/renderPreview.js
@@ -92,10 +92,10 @@ function handleImageInPreview(content, container) {
 
 const imageViewer = $("#image-viewer");
 
-$("#chat").on("click", ".toggle-thumbnail", function() {
+$("#chat").on("click", ".toggle-thumbnail", function(event, data) {
 	const link = $(this);
 
-	openImageViewer(link);
+	openImageViewer(link, {pushState: !data || data.pushState !== false});
 
 	// Prevent the link to open a new page since we're opening the image viewer,
 	// but keep it a link to allow for Ctrl/Cmd+click.
@@ -103,8 +103,8 @@ $("#chat").on("click", ".toggle-thumbnail", function() {
 	return false;
 });
 
-imageViewer.on("click", function() {
-	closeImageViewer();
+imageViewer.on("click", function(event, data) {
+	closeImageViewer({pushState: !data || data.pushState !== false});
 });
 
 $(document).keydown(function(e) {
@@ -125,7 +125,7 @@ $(document).keydown(function(e) {
 	}
 });
 
-function openImageViewer(link) {
+function openImageViewer(link, {pushState = true}) {
 	$(".previous-image").removeClass("previous-image");
 	$(".next-image").removeClass("next-image");
 
@@ -166,6 +166,15 @@ function openImageViewer(link) {
 	imageViewer
 		.off("transitionend")
 		.addClass("opened");
+
+	// History management
+	if (pushState) {
+		const clickTarget =
+			`#${link.closest(".msg").attr("id")} ` +
+			`a[href="${link.attr("href")}"] ` +
+			"img";
+		history.pushState({clickTarget: clickTarget}, null, null);
+	}
 }
 
 imageViewer.on("click", ".previous-image-btn", function() {
@@ -178,7 +187,7 @@ imageViewer.on("click", ".next-image-btn", function() {
 	return false;
 });
 
-function closeImageViewer() {
+function closeImageViewer({pushState = true}) {
 	imageViewer
 		.removeClass("opened")
 		.one("transitionend", function() {
@@ -186,4 +195,9 @@ function closeImageViewer() {
 		});
 
 	input.focus();
+
+	// History management
+	if (pushState) {
+		history.pushState({clickTarget: "#image-viewer"}, null, null);
+	}
 }

--- a/client/js/renderPreview.js
+++ b/client/js/renderPreview.js
@@ -202,6 +202,9 @@ function closeImageViewer({pushState = true} = {}) {
 
 	// History management
 	if (pushState) {
-		history.pushState({clickTarget: "#image-viewer"}, null, null);
+		const clickTarget =
+			"#sidebar " +
+			`.chan[data-id="${$("#sidebar .chan.active").data("id")}"]`;
+		history.pushState({clickTarget}, null, null);
 	}
 }


### PR DESCRIPTION
Fixes #1497.

~This doesn't work too great, and I'm not sure why. This code itself seems to work fine, but when interacting with other history-aware elements, or when reaching initially-loaded page, things go wrong.
Any suggestions?~
All fixed.