### PR TITLE
Fix requesting last messages when no message id is known

### DIFF
--- a/client/js/socket-events/more.js
+++ b/client/js/socket-events/more.js
@@ -56,12 +56,13 @@ socket.on("more", function(data) {
 });
 
 chat.on("click", ".show-more-button", function() {
-	var self = $(this);
-	var lastMessage = self.parent().next(".messages").children(".msg").first();
-	if (lastMessage.is(".condensed")) {
-		lastMessage = lastMessage.children(".msg").first();
+	const self = $(this);
+	const lastMessage = self.closest(".chat").find(".msg").first();
+	let lastMessageId = -1;
+
+	if (lastMessage.length > 0) {
+		lastMessageId = parseInt(lastMessage[0].id.replace("msg-", ""), 10);
 	}
-	var lastMessageId = parseInt(lastMessage[0].id.replace("msg-", ""), 10);
 
 	self
 		.text("Loading older messages…")

--- a/src/client.js
+++ b/src/client.js
@@ -412,10 +412,20 @@ Client.prototype.more = function(data) {
 	}
 
 	const chan = target.chan;
-	const index = chan.messages.findIndex((val) => val.id === data.lastId);
+	let messages = [];
+	let index = 0;
 
-	// If we don't find the requested message, send an empty array
-	const messages = index > 0 ? chan.messages.slice(Math.max(0, index - 100), index) : [];
+	// If client requests -1, send last 100 messages
+	if (data.lastId < 0) {
+		index = chan.messages.length;
+	} else {
+		index = chan.messages.findIndex((val) => val.id === data.lastId);
+	}
+
+	// If requested id is not found, an empty array will be sent
+	if (index > 0) {
+		messages = chan.messages.slice(Math.max(0, index - 100), index);
+	}
 
 	client.emit("more", {
 		chan: chan.id,


### PR DESCRIPTION
Fixes #1460.

However there's another bug. When doing `/clear`, the show more button jumps into view, thus IntersectionObserver calls observe on the button, and it loads last history again.