### PR TITLE
Add touch-action to Messages, Sidebar and User list

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -493,6 +493,7 @@ kbd {
 #sidebar .network,
 #sidebar .network-placeholder {
 	margin-bottom: 30px;
+	touch-action: pan-y;
 }
 
 #sidebar .empty {
@@ -935,6 +936,7 @@ kbd {
 
 #chat .messages {
 	padding: 10px 0;
+	touch-action: pan-y;
 }
 
 #chat .msg {
@@ -1296,6 +1298,7 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 	position: absolute;
 	top: 48px;
 	width: 100%;
+	touch-action: pan-y;
 }
 
 #chat .names-filtered {

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -44,6 +44,7 @@ body {
 	-ms-user-select: none;
 	user-select: none;
 	cursor: default;
+	touch-action: none;
 
 	/**
 	  * Disable pull-to-refresh on mobile that conflicts with scrolling the message list.
@@ -159,6 +160,7 @@ kbd {
 .container {
 	margin: 80px auto;
 	max-width: 480px;
+	touch-action: pan-y;
 }
 
 ::-moz-placeholder {
@@ -484,6 +486,7 @@ kbd {
 
 #sidebar .networks {
 	padding: 20px 30px 0;
+	touch-action: pan-y;
 }
 
 #sidebar .networks:empty {
@@ -908,6 +911,7 @@ kbd {
 	right: 0;
 	width: 180px;
 	transition: right 0.4s;
+	touch-action: pan-y;
 }
 
 #chat .show-more {
@@ -1574,6 +1578,7 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 	-webkit-flex: 1 0 auto;
 	flex: 1 0 auto;
 	align-self: center;
+	touch-action: pan-y;
 }
 
 #form #submit {


### PR DESCRIPTION
This commit fixes #1035 

On the issue, there is a reference to passive events for JS addEventListeners. I've checked all touchend-touchstart events on Master and passive events are already there. So, I only added touch-action css on some parts that have scroll.

