### PR TITLE
Remove mode from user_name displayed for kick

### DIFF
--- a/client/views/actions/kick.tpl
+++ b/client/views/actions/kick.tpl
@@ -1,4 +1,4 @@
-{{> ../user_name nick=from}}
+{{> ../user_name nick=from mode=""}}
 has kicked
 {{> ../user_name nick=target mode=""}}
 {{#if text}}


### PR DESCRIPTION
Quick bodge over #1522 until the proper mode can be displayed. Better to show nothing than wrong data.