### PR TITLE
Get rid of `/clear` command and keybind

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -405,15 +405,6 @@
 
 						<div class="help-item">
 							<div class="subject">
-								<kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>L</kbd>
-							</div>
-							<div class="description">
-								<p>Clear the current screen</p>
-							</div>
-						</div>
-
-						<div class="help-item">
-							<div class="subject">
 								<kbd>Ctrl</kbd> + <kbd>K</kbd>
 							</div>
 							<div class="description">
@@ -476,15 +467,6 @@
 							</div>
 							<div class="description">
 								<p>Switch to the previous/next window in the channel list</p>
-							</div>
-						</div>
-
-						<div class="help-item">
-							<div class="subject">
-								<kbd>⇧</kbd> + <kbd>⌘</kbd> + <kbd>L</kbd>
-							</div>
-							<div class="description">
-								<p>Clear the current screen</p>
 							</div>
 						</div>
 
@@ -580,15 +562,6 @@
 							</div>
 							<div class="description">
 								<p>Load the banlist for the current channel.</p>
-							</div>
-						</div>
-
-						<div class="help-item">
-							<div class="subject">
-								<code>/clear</code>
-							</div>
-							<div class="description">
-								<p>Clear the current screen.</p>
 							</div>
 						</div>
 

--- a/client/js/keybinds.js
+++ b/client/js/keybinds.js
@@ -2,7 +2,6 @@
 
 const $ = require("jquery");
 const Mousetrap = require("mousetrap");
-const utils = require("./utils");
 const input = $("#input");
 const sidebar = $("#sidebar");
 const windows = $("#windows");
@@ -59,16 +58,6 @@ Mousetrap.bind([
 	}
 
 	channels.eq(target).click();
-});
-
-Mousetrap.bind([
-	"command+shift+l",
-	"ctrl+shift+l"
-], function(e) {
-	if (e.target === input[0]) {
-		utils.clear();
-		e.preventDefault();
-	}
 });
 
 Mousetrap.bind([

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -180,11 +180,6 @@ $(function() {
 		input.val("");
 		resetInputHeight(input.get(0));
 
-		if (text.indexOf("/clear") === 0) {
-			utils.clear();
-			return;
-		}
-
 		if (text.indexOf("/collapse") === 0) {
 			$(".chan.active .toggle-preview.opened").click();
 			return;

--- a/client/js/utils.js
+++ b/client/js/utils.js
@@ -1,11 +1,9 @@
 "use strict";
 
 const $ = require("jquery");
-const chat = $("#chat");
 const input = $("#input");
 
 module.exports = {
-	clear,
 	confirmExit,
 	forceFocus,
 	move,
@@ -24,12 +22,6 @@ function resetHeight(element) {
 // This can only be called from another interactive event (e.g. button click)
 function forceFocus() {
 	input.trigger("click").focus();
-}
-
-function clear() {
-	chat.find(".active")
-		.find(".show-more").addClass("show").end()
-		.find(".messages .msg, .date-marker-container").remove();
 }
 
 function toggleNickEditor(toggle) {


### PR DESCRIPTION
Since the introduction of infinite scrolling (https://github.com/thelounge/lounge/pull/1318), `/clear` is now broken. As far as I can tell, there is no way to reproduce something decent (and working!) without drastically changing its behavior from "hide the messages in current channel" to "permanently destroy all messages in memory in the current channel", which is not a great change to introduce sneakily 😂. This was discussed in #1519.

The code for this was very trivial, so removing it now until there is a better way to do so, if this is ever possible.

Also, `/clear` was not even autocompleted, sooo...