### PR TITLE
Display correct kick modes

### DIFF
--- a/client/views/actions/kick.tpl
+++ b/client/views/actions/kick.tpl
@@ -1,6 +1,6 @@
-{{> ../user_name nick=from}}
+{{> ../user_name nick=from.nick mode=from.mode}}
 has kicked
-{{> ../user_name nick=target mode=""}}
+{{> ../user_name nick=target.nick mode=target.mode}}
 {{#if text}}
 	<i class="part-reason">({{{parse text}}})</i>
 {{/if}}

--- a/src/plugins/irc-events/kick.js
+++ b/src/plugins/irc-events/kick.js
@@ -11,12 +11,13 @@ module.exports = function(irc, network) {
 			return;
 		}
 
-		const user = chan.findUser(data.kicked);
+		const kicker = chan.findUser(data.nick);
+		const target = chan.findUser(data.kicked);
 
 		if (data.kicked === irc.user.nick) {
 			chan.users = [];
 		} else {
-			chan.users = _.without(chan.users, user);
+			chan.users = _.without(chan.users, target);
 		}
 
 		client.emit("users", {
@@ -26,9 +27,8 @@ module.exports = function(irc, network) {
 		var msg = new Msg({
 			type: Msg.Type.KICK,
 			time: data.time,
-			mode: user.mode,
-			from: data.nick,
-			target: data.kicked,
+			from: kicker,
+			target: target,
 			text: data.message || "",
 			highlight: data.kicked === irc.user.nick,
 			self: data.nick === irc.user.nick


### PR DESCRIPTION
As far as I'm aware, passing User objects incurs no particular overhead because objects are passed by reference. (Correct me if I'm wrong on that…)

Finding and saving the users before any code modifies `chan.users` is essential to this working as expected.

Closes #1523
Closes #1525
Fixes #1522
Fixes #1351