### PR TITLE
Fix references to undefined `this`

### DIFF
--- a/src/models/chan.js
+++ b/src/models/chan.js
@@ -59,7 +59,7 @@ Chan.prototype.pushMessage = function(client, msg, increasesUnread) {
 	this.messages.push(msg);
 
 	if (client.config.log === true) {
-		writeUserLog(client, msg);
+		writeUserLog.call(this, client, msg);
 	}
 
 	if (Helper.config.maxHistory >= 0 && this.messages.length > Helper.config.maxHistory) {


### PR DESCRIPTION
https://github.com/thelounge/lounge/commit/79eb83d82ff48a58aac7bc1bd6a44ece5ef85dcc introduces a couple uses of `this` in a function that doesn't know about the channel.

I preferred to pass the channel instead of making this part of the prototype (and therefore exporting it) but I can switch to that otherwise.