### PR TITLE
Enable `no-console` and `no-alert` ESLint rules 

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -9,54 +9,54 @@ env:
   node: true
 
 rules:
-  arrow-body-style: 2
-  arrow-parens: [2, always]
-  arrow-spacing: 2
-  block-scoped-var: 2
-  block-spacing: [2, always]
-  brace-style: [2, 1tbs]
-  comma-dangle: 0
-  curly: [2, all]
-  dot-location: [2, property]
-  dot-notation: 2
-  eol-last: 2
-  eqeqeq: 2
-  handle-callback-err: 2
-  indent: [2, tab]
-  key-spacing: [2, {beforeColon: false, afterColon: true}]
-  keyword-spacing: [2, {before: true, after: true}]
-  linebreak-style: [2, unix]
-  no-alert: 2
-  no-catch-shadow: 2
-  no-confusing-arrow: 2
-  no-control-regex: 0
-  no-duplicate-imports: 2
-  no-else-return: 2
-  no-implicit-globals: 2
-  no-multi-spaces: 2
-  no-multiple-empty-lines: [2, { "max": 1 }]
-  no-shadow: 2
-  no-template-curly-in-string: 2
-  no-trailing-spaces: 2
-  no-unsafe-negation: 2
-  no-useless-computed-key: 2
-  no-useless-return: 2
-  object-curly-spacing: [2, never]
-  padded-blocks: [2, never]
-  prefer-const: 2
-  quote-props: [2, as-needed]
-  quotes: [2, double, avoid-escape]
-  semi-spacing: 2
-  semi-style: [2, last]
-  semi: [2, always]
-  space-before-blocks: 2
-  space-before-function-paren: [2, never]
-  space-in-parens: [2, never]
-  space-infix-ops: 2
-  spaced-comment: [2, always]
-  strict: 2
-  template-curly-spacing: 2
-  yoda: 2
+  arrow-body-style: error
+  arrow-parens: [error, always]
+  arrow-spacing: error
+  block-scoped-var: error
+  block-spacing: [error, always]
+  brace-style: [error, 1tbs]
+  comma-dangle: off
+  curly: [error, all]
+  dot-location: [error, property]
+  dot-notation: error
+  eol-last: error
+  eqeqeq: error
+  handle-callback-err: error
+  indent: [error, tab]
+  key-spacing: [error, {beforeColon: false, afterColon: true}]
+  keyword-spacing: [error, {before: true, after: true}]
+  linebreak-style: [error, unix]
+  no-alert: error
+  no-catch-shadow: error
+  no-confusing-arrow: error
+  no-control-regex: off
+  no-duplicate-imports: error
+  no-else-return: error
+  no-implicit-globals: error
+  no-multi-spaces: error
+  no-multiple-empty-lines: [error, { "max": 1 }]
+  no-shadow: error
+  no-template-curly-in-string: error
+  no-trailing-spaces: error
+  no-unsafe-negation: error
+  no-useless-computed-key: error
+  no-useless-return: error
+  object-curly-spacing: [error, never]
+  padded-blocks: [error, never]
+  prefer-const: error
+  quote-props: [error, as-needed]
+  quotes: [error, double, avoid-escape]
+  semi-spacing: error
+  semi-style: [error, last]
+  semi: [error, always]
+  space-before-blocks: error
+  space-before-function-paren: [error, never]
+  space-in-parens: [error, never]
+  space-infix-ops: error
+  spaced-comment: [error, always]
+  strict: error
+  template-curly-spacing: error
+  yoda: error
 
 globals:
   log: false

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -26,6 +26,7 @@ rules:
   key-spacing: [2, {beforeColon: false, afterColon: true}]
   keyword-spacing: [2, {before: true, after: true}]
   linebreak-style: [2, unix]
+  no-alert: 2
   no-catch-shadow: 2
   no-confusing-arrow: 2
   no-control-regex: 0

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -28,7 +28,6 @@ rules:
   linebreak-style: [2, unix]
   no-catch-shadow: 2
   no-confusing-arrow: 2
-  no-console: 0
   no-control-regex: 0
   no-duplicate-imports: 2
   no-else-return: 2

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -418,7 +418,7 @@ $(function() {
 		if (chan.hasClass("lobby")) {
 			cmd = "/quit";
 			var server = chan.find(".name").html();
-			if (!confirm("Disconnect from " + server + "?")) {
+			if (!confirm("Disconnect from " + server + "?")) { // eslint-disable-line no-alert
 				return false;
 			}
 		}

--- a/client/js/socket.js
+++ b/client/js/socket.js
@@ -35,8 +35,6 @@ const socket = io({
 		});
 		// Hides the "Send Message" button
 		$("#submit").remove();
-
-		console.error(data);
 	});
 });
 

--- a/index.js
+++ b/index.js
@@ -8,9 +8,11 @@ process.chdir(__dirname);
 // Doing this check as soon as possible allows us to avoid ES6 parser errors or other issues
 var pkg = require("./package.json");
 if (!require("semver").satisfies(process.version, pkg.engines.node)) {
+	/* eslint-disable no-console */
 	console.error("=== WARNING!");
 	console.error("=== The oldest supported Node.js version is", pkg.engines.node);
 	console.error("=== We strongly encourage you to upgrade, see https://nodejs.org/en/download/package-manager/ for more details\n");
+	/* eslint-enable no-console */
 }
 
 require("./src/command-line");

--- a/scripts/build-fontawesome.js
+++ b/scripts/build-fontawesome.js
@@ -1,26 +1,27 @@
-/* eslint-disable no-console */
 "use strict";
 
-var fs = require("fs-extra");
+const colors = require("colors/safe");
+const fs = require("fs-extra");
+const log = require("../src/log");
 
-var srcDir = "./node_modules/font-awesome/fonts/";
-var destDir = "./client/fonts/";
-var fonts = [
+const srcDir = "./node_modules/font-awesome/fonts/";
+const destDir = "./client/fonts/";
+const fonts = [
 	"fontawesome-webfont.woff",
 	"fontawesome-webfont.woff2"
 ];
 
-fs.ensureDir(destDir, function(dirErr) {
+fs.ensureDir(destDir, (dirErr) => {
 	if (dirErr) {
-		console.error(dirErr);
+		log.error(dirErr);
 	}
 
-	fonts.forEach(function(font) {
-		fs.copy(srcDir + font, destDir + font, function(err) {
+	fonts.forEach((font) => {
+		fs.copy(srcDir + font, destDir + font, (err) => {
 			if (err) {
-				console.error(err);
+				log.error(err);
 			} else {
-				console.log(font + " successfully installed.");
+				log.info(colors.bold(font) + " successfully installed.");
 			}
 		});
 	});

--- a/scripts/build-fontawesome.js
+++ b/scripts/build-fontawesome.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 "use strict";
 
 var fs = require("fs-extra");

--- a/src/command-line/utils.js
+++ b/src/command-line/utils.js
@@ -15,7 +15,7 @@ class Utils {
 			"",
 			`    LOUNGE_HOME   Path for all configuration files and folders. Defaults to ${colors.green(Utils.defaultLoungeHome())}.`,
 			"",
-		].forEach((e) => console.log(e));
+		].forEach((e) => console.log(e)); // eslint-disable-line no-console
 	}
 
 	static defaultLoungeHome() {

--- a/src/log.js
+++ b/src/log.js
@@ -16,6 +16,7 @@ function timestamp(type, messageArgs) {
 	return messageArgs;
 }
 
+/* eslint-disable no-console */
 exports.error = function() {
 	console.error.apply(console, timestamp(colors.red("[ERROR]"), arguments));
 };
@@ -31,6 +32,7 @@ exports.info = function() {
 exports.debug = function() {
 	console.log.apply(console, timestamp(colors.green("[DEBUG]"), arguments));
 };
+/* eslint-enable no-console */
 
 exports.prompt = (options, callback) => {
 	options.prompt = timestamp(colors.cyan("[PROMPT]"), [options.text]).join(" ");

--- a/test/fixtures/env.js
+++ b/test/fixtures/env.js
@@ -1,7 +1,7 @@
 "use strict";
 
 global.log = {
-	error: () => console.error.apply(console, arguments),
+	error: () => console.error.apply(console, arguments), // eslint-disable-line no-console
 	warn: () => {},
 	info: () => {},
 	debug: () => {},

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -79,8 +79,6 @@ if (process.env.NODE_ENV === "production") {
 		sourceMap: true,
 		comments: false
 	}));
-} else {
-	console.log("Building in development mode, bundles will not be minified.");
 }
 
 module.exports = config;


### PR DESCRIPTION
We almost slipped in a few `console.log` statements so this should make it safer. Outside of the current occurrences we have, we shouldn't need any more in the code, or at least not without explicitly acknowledging them.