### PR TITLE
Fix history not loading if first message is condensed

### DIFF
--- a/client/js/socket-events/more.js
+++ b/client/js/socket-events/more.js
@@ -79,11 +79,11 @@ socket.on("more", function(data) {
 
 chat.on("click", ".show-more-button", function() {
 	const self = $(this);
-	const lastMessage = self.closest(".chat").find(".msg").first();
+	const lastMessage = self.closest(".chat").find(".msg:not(.condensed)").first();
 	let lastMessageId = -1;
 
 	if (lastMessage.length > 0) {
-		lastMessageId = parseInt(lastMessage[0].id.replace("msg-", ""), 10);
+		lastMessageId = parseInt(lastMessage.attr("id").replace("msg-", ""), 10);
 	}
 
 	self


### PR DESCRIPTION
I broke this in 14cac93e10ce1978a65786a60221f7dc7043e090 as I forgot that `.condensed` also has `.msg`.