### PR TITLE
Match emoji in their textual representation as well

### DIFF
--- a/client/js/libs/handlebars/ircmessageparser/findEmoji.js
+++ b/client/js/libs/handlebars/ircmessageparser/findEmoji.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const emojiRegExp = require("emoji-regex")();
+const emojiRegExp = require("emoji-regex/text.js")();
 
 function findEmoji(text) {
 	const result = [];


### PR DESCRIPTION
> To match emoji in their textual representation as well (i.e. emoji that are not Emoji_Presentation symbols and that aren’t forced to render as emoji by a variation selector), require the other regex

Test: ♥