### PR TITLE
Use monospace font in custom CSS textarea

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -83,7 +83,8 @@ button {
 }
 
 code,
-kbd {
+kbd,
+textarea#user-specified-css-input {
 	font-family: Consolas, Menlo, Monaco, "Lucida Console", "DejaVu Sans Mono", "Courier New", monospace;
 }
 

--- a/client/index.html
+++ b/client/index.html
@@ -376,7 +376,7 @@
 								<h2>Custom Stylesheet</h2>
 							</div>
 							<div class="col-sm-12">
-								<textarea class="input" name="userStyles" id="user-specified-css-input" placeholder="You can override any style with CSS here"></textarea>
+								<textarea class="input" name="userStyles" id="user-specified-css-input" placeholder="/* You can override any style with CSS here */"></textarea>
 							</div>
 						</div>
 


### PR DESCRIPTION
This is definitely the best CSS ever (far from it really) but when tackling #1551 this should fall into place. The end result is much nicer than not having this anyway, and not specifying placeholder makes for a weird look when empty.

<img width="330" alt="screen shot 2017-09-21 at 01 59 26" src="https://user-images.githubusercontent.com/113730/30680972-a6e81072-9e70-11e7-8145-b5530d3fae59.png"> <img width="330" alt="screen shot 2017-09-21 at 02 00 01" src="https://user-images.githubusercontent.com/113730/30680973-a6ee3506-9e70-11e7-8f3e-216e499ac96e.png">
