### PR TITLE
Increase font size on desktops and mobiles

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -855,8 +855,12 @@ kbd {
 #windows .header .topic,
 .messages .msg,
 .sidebar {
-	font-size: 13px;
+	font-size: 14px;
 	line-height: 1.4;
+}
+
+#windows #form .input {
+	font-size: 13px;
 }
 
 #windows #chat .header {
@@ -1525,7 +1529,7 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 	background: #f6f6f6;
 	color: #666;
 	font: inherit;
-	font-size: 11px;
+	font-size: 13px;
 	margin: 4px;
 	line-height: 22px;
 	height: 24px;
@@ -2000,6 +2004,10 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 		margin-top: 60px !important;
 	}
 
+	.messages .msg {
+		font-size: 16px;
+	}
+
 	#sidebar,
 	#footer {
 		left: -220px;
@@ -2040,14 +2048,6 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 
 	#chat .title::before {
 		display: none;
-	}
-}
-
-@media (min-width: 1610px) {
-	#windows .header .topic,
-	.messages .msg,
-	.sidebar {
-		font-size: 14px;
 	}
 }
 


### PR DESCRIPTION
Fixes #841.

This increases fonts that use to be monospace before #1540 and ended up being smaller as a side effect.

- Increase by a little bit on message window (except on message input, unfortunately, but that was adding a scrollbar to the input, then fixing this would misalign borders, etc. not for this PR).
- Increase a bit more on tablets and phones. The result is really great there, finally not tiny texts anymore, and this + native font stack really makes it look like a native chat app.
- Remove the font size for extra large screens now that message window size is bigger.