### PR TITLE
Remove event-stream dependency in favor of plain Buffers

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "cheerio": "0.22.0",
     "colors": "1.1.2",
     "commander": "2.11.0",
-    "event-stream": "3.3.4",
     "express": "4.15.4",
     "express-handlebars": "3.0.0",
     "fs-extra": "4.0.2",

--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -5,7 +5,6 @@ const request = require("request");
 const url = require("url");
 const Helper = require("../../helper");
 const findLinks = require("../../../client/js/libs/handlebars/ircmessageparser/findLinks");
-const es = require("event-stream");
 const storage = require("../storage");
 
 process.setMaxListeners(0);
@@ -155,6 +154,7 @@ function fetch(uri, cb) {
 	} catch (e) {
 		return cb(null);
 	}
+	const buffers = [];
 	var length = 0;
 	var limit = Helper.config.prefetchMaxImageSize * 1024;
 	req
@@ -166,18 +166,15 @@ function fetch(uri, cb) {
 			}
 		})
 		.on("error", function() {})
-		.pipe(es.map(function(data, next) {
+		.on("data", (data) => {
 			length += data.length;
-			if (length > limit) {
-				req.response.req.abort();
-			}
-			next(null, data);
-		}))
-		.pipe(es.wait(function(err, data) {
-			if (err) {
-				return cb(null);
-			}
+			buffers.push(data);
 
+			if (length > limit) {
+				req.abort();
+			}
+		})
+		.on("end", () => {
 			if (req.response.statusCode < 200 || req.response.statusCode > 299) {
 				return cb(null);
 			}
@@ -193,14 +190,12 @@ function fetch(uri, cb) {
 				type = req.response.headers["content-type"].split(/ *; */).shift();
 			}
 
-			data = {
-				data: data,
+			cb({
+				data: Buffer.concat(buffers, length),
 				type: type,
 				size: size
-			};
-
-			cb(data);
-		}));
+			});
+		});
 }
 
 // https://github.com/request/request/issues/2120


### PR DESCRIPTION
We were not making real use of [`event-stream`](https://github.com/dominictarr/event-stream) apart for a minor convenience so might as well not rely on it (and its 7 dependencies).

I am not totally familiar with `Buffer`s so I might not be 100% correct, but it does work just as expected and tests pass. :man_shrugging: 