### PR TITLE
Toggle user list tooltip shouldn't appear on mobile

### DIFF
--- a/client/views/chat.tpl
+++ b/client/views/chat.tpl
@@ -3,7 +3,7 @@
 	<div class="header">
 		<button class="lt" aria-label="Toggle channel list"></button>
 		{{#equal type "channel"}}
-			<span class="rt-tooltip tooltipped tooltipped-w" aria-label="Toggle user list">
+			<span class="rt-tooltip tooltipped tooltipped-w tooltipped-no-touch" aria-label="Toggle user list">
 				<button class="rt" aria-label="Toggle user list"></button>
 			</span>
 		{{/equal}}


### PR DESCRIPTION
Minor thing, but all other tooltips are suppressed on mobile, and the "Toggle user list" one isn't. I think it should be.