### PR TITLE
Fix wrongly positioned menu when opening it and switching to landscape

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -353,26 +353,6 @@ kbd {
 	overflow: hidden;
 }
 
-#viewport {
-	height: 100%;
-	transition: transform 160ms, -webkit-transform 160ms;
-	-webkit-transform: translateZ(0);
-	transform: translateZ(0);
-}
-
-#viewport.menu-open {
-	-webkit-transform: translate3d(220px, 0, 0);
-	transform: translate3d(220px, 0, 0);
-}
-
-#viewport.menu-dragging {
-	transition: none !important;
-}
-
-#viewport.menu-open .messages {
-	pointer-events: none;
-}
-
 #chat button,
 #form button,
 #chat .user {
@@ -2013,6 +1993,26 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 	.textcomplete-menu,
 	.messages .msg {
 		font-size: 15px;
+	}
+
+	#viewport {
+		height: 100%;
+		transition: transform 160ms, -webkit-transform 160ms;
+		-webkit-transform: translateZ(0);
+		transform: translateZ(0);
+	}
+
+	#viewport.menu-open {
+		-webkit-transform: translate3d(220px, 0, 0);
+		transform: translate3d(220px, 0, 0);
+	}
+
+	#viewport.menu-dragging {
+		transition: none !important;
+	}
+
+	#viewport.menu-open .messages {
+		pointer-events: none;
 	}
 
 	#sidebar,


### PR DESCRIPTION
Fixes #1564.

This could be reproduced on tablet or large phone (as long as portrait mode shows a collapsible menu and landscape mode shows normal menu) or when resizing the browser on desktop.

I simply moved the definition of those collapsible-menu-related attributes only where it behaves that way. This also has the advantage of not animating the menu anymore when changing orientation for example.