### PR TITLE
Fix nick change on Safari for Mac and iOS

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1498,6 +1498,14 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 	outline: none;
 }
 
+[contenteditable="true"] {
+	-webkit-user-select: text;
+	-moz-user-select: text;
+	-ms-user-select: text;
+	user-select: text;
+	cursor: text;
+}
+
 /* Nick editor */
 
 #form #nick {


### PR DESCRIPTION
It is currently impossible to edit the nick text after pressing the edit button on Safari for iOS and Mac because user-select is set to None on Safari by default. This fixes that issue. Tested that it is not editable when it shouldn't be and that it doesn't break anything on Chrome or Firefox.