### PR TITLE
Fix flickering on link hovering, and inconsistencies between chat links and UI links

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -31,6 +31,12 @@ body {
 	overflow-y: hidden;
 }
 
+a,
+a:hover,
+a:focus {
+	color: #50a656;
+}
+
 a {
 	transition: opacity 0.2s;
 }
@@ -1011,10 +1017,6 @@ kbd {
 #chat .special .time,
 #chat .special .from {
 	display: none;
-}
-
-#chat a {
-	color: #50a656;
 }
 
 /* Nicknames */


### PR DESCRIPTION
I noticed that 2 transitions were conflicting, blue to dark blue with no timed transitions, and full opacity to light opacity with a 0.2s transition. The first one is actually set by Bootstrap, the second one is ours.

As I was fixing that, I switched the (default Bootstrap) blue links into the green ones we use in the chat window (fixes https://github.com/thelounge/lounge/issues/510).