### PR TITLE
Add info message before calling `packageJson`

### DIFF
--- a/src/command-line/install.js
+++ b/src/command-line/install.js
@@ -21,6 +21,8 @@ program
 			return;
 		}
 
+		log.info("Retrieving information about the package...");
+
 		packageJson(packageName, {
 			fullMetadata: true
 		}).then((json) => {


### PR DESCRIPTION
I had some network hiccup, so the CLI seemingly didn't do anything until the packageJson callback got called and the message that package is installing displayed.