### PR TITLE
Use `thelounge` instead of `lounge` when it comes to external packages

### DIFF
--- a/src/command-line/install.js
+++ b/src/command-line/install.js
@@ -24,7 +24,7 @@ program
 		packageJson(packageName, {
 			fullMetadata: true
 		}).then((json) => {
-			if (!("lounge" in json)) {
+			if (!("thelounge" in json)) {
 				log.error(`${colors.red(packageName)} does not have The Lounge metadata.`);
 
 				process.exit(1);

--- a/src/plugins/themes.js
+++ b/src/plugins/themes.js
@@ -62,11 +62,11 @@ function getModuleInfo(packageName) {
 		log.warn(`Specified theme ${colors.yellow(packageName)} is not installed in packages directory`);
 		return;
 	}
-	if (!module.lounge) {
+	if (!module.thelounge) {
 		log.warn(`Specified theme ${colors.yellow(packageName)} doesn't have required information.`);
 		return;
 	}
-	return module.lounge;
+	return module.thelounge;
 }
 
 function makePackageThemeObject(moduleName) {


### PR DESCRIPTION
We keep having confusions between `lounge`  and `thelounge` everywhere (sorry.....).

When v3 shows up, we should be able to get rid of the inconsistency entirely. In the meantime, new stuff, especially external packages that will rely on fairly stable contracts, should honor that to make the transition easier. Apart from those, nothing should be problematic.