### PR TITLE
Give chat timestamp a fix width to fix message alignment issues

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1005,6 +1005,11 @@ kbd {
 #chat .time {
 	color: #ddd;
 	padding-left: 10px;
+	width: 55px;
+}
+
+#chat.show-seconds .time {
+	width: 75px;
 }
 
 #chat .from {

--- a/client/js/options.js
+++ b/client/js/options.js
@@ -113,6 +113,7 @@ settings.on("change", "input, select, textarea", function() {
 		chat.find(".msg > .time").each(function() {
 			$(this).text(tz($(this).parent().data("time")));
 		});
+		chat.toggleClass("show-seconds", self.prop("checked"));
 	} else if (name === "autocomplete") {
 		if (self.prop("checked")) {
 			$("#input").trigger("autocomplete:on");


### PR DESCRIPTION
Fixes https://github.com/thelounge/lounge/issues/1581.

I gave 5px headroom to the timestamp width I get on my laptop. Tested with/without seconds, on Chrome/Safari/Firefox on Mac, Chrome on Android. Would be nice if someone on Windows and/or Linux could test, just to be sure.

Before | After
--- | ---
<img width="264" alt="screen shot 2017-10-01 at 01 12 41" src="https://user-images.githubusercontent.com/113730/31051991-b3d8274a-a645-11e7-85c2-8f54c1e0ed5a.png"> | <img width="299" alt="screen shot 2017-10-01 at 01 12 22" src="https://user-images.githubusercontent.com/113730/31051992-b3d88d2a-a645-11e7-9f29-18409210dac3.png">
