### PR TITLE
Remove content borders on mobile to maximise use of space

### DIFF
--- a/client/themes/example.css
+++ b/client/themes/example.css
@@ -57,6 +57,17 @@ body {
 	}
 
 	#main {
-		left: 5px;
+		left: 0;
+		bottom: 0;
+		right: 0;
+		top: 0;
+	}
+
+	#windows .window::before {
+		display: none;
+	}
+
+	#windows .window {
+		border-radius: 0;
 	}
 }


### PR DESCRIPTION
This only impacts the Example theme.

Before | After
---- | ----
![screenshot_20171001-094613](https://user-images.githubusercontent.com/602850/31053139-4c137dbe-a68e-11e7-8ac8-844f5bcbc4e6.png) | ![screenshot_20171001-094407](https://user-images.githubusercontent.com/602850/31053138-4c0ed84a-a68e-11e7-8057-7241de3c1188.png)

