### PR TITLE
Remove user key from user config 

### DIFF
--- a/src/clientManager.js
+++ b/src/clientManager.js
@@ -114,7 +114,6 @@ ClientManager.prototype.addUser = function(name, password, enableLog) {
 		}
 
 		var user = {
-			user: name,
 			password: password || "",
 			log: enableLog,
 			awayMessage: "",


### PR DESCRIPTION
It is completely unnecessary and confusing. It's never used, changing it does not change the actual username.