### PR TITLE
Remove --progress from webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "start-dev": "npm-run-all --parallel watch start",
     "build": "npm-run-all build:*",
     "build:font-awesome": "node scripts/build-fontawesome.js",
-    "build:webpack": "webpack --progress",
+    "build:webpack": "webpack",
     "watch": "webpack --watch",
     "test": "npm-run-all -c test:* lint",
     "test:mocha": "mocha",


### PR DESCRIPTION
Webpack does not detect if it's run in CI and it's rather spammy to see in all the builds. It probably slows down the builds too.