### PR TITLE
Fix some missing parts from recent font changes/resizing

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -848,10 +848,6 @@ kbd {
 	line-height: 1.4;
 }
 
-#windows #form .input {
-	font-size: 13px;
-}
-
 #windows #chat .header {
 	display: block;
 }
@@ -998,7 +994,7 @@ kbd {
 #chat .time,
 #chat .from,
 #chat .content {
-	padding: 2px 0;
+	padding: 3px 0;
 	flex: 0 0 auto;
 }
 
@@ -1196,9 +1192,9 @@ kbd {
 	border-radius: 2px;
 	display: none;
 	color: #222;
-	font-size: 12px;
 	max-width: 100%;
-	margin: 2px 0;
+	margin: 0;
+	margin-top: 6px;
 	overflow: hidden;
 }
 
@@ -1210,7 +1206,7 @@ kbd {
 
 #chat .toggle-content .thumb {
 	max-width: 48px;
-	max-height: 32px;
+	max-height: 38px;
 }
 
 #chat .toggle-thumbnail {
@@ -1577,9 +1573,9 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 	background: transparent;
 	border: none;
 	font: inherit;
-	min-height: 18px; /* Required when computing input height at char deletion */
-	height: 18px;
-	max-height: 90px;
+	min-height: 19px; /* Required when computing input height at char deletion */
+	height: 19px;
+	max-height: 95px; /* min-height/height x number of lines maximum */
 	line-height: 1.4;
 	outline: none;
 	margin: 5px;
@@ -2015,6 +2011,7 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 	#help .about,
 	#loading,
 	#context-menu,
+	#form #input,
 	.textcomplete-menu,
 	.messages .msg {
 		font-size: 15px;


### PR DESCRIPTION
Following #1540, #1153, #1553, and #1561, some last adjustments were necessary:

- Separate messages by one more pixel: the recent font changes make multiline messages rather hard to differentite from one another. I believe adding 2px looked better, but I knew that would cause riots so I went for a middle ground 😅
- Make previews the same size than messages themselves, and adapt the thumbnail height accordingly
- Make the message input font size same as message size