### PR TITLE
Mark channels as read when receiving self-messages

### DIFF
--- a/client/js/socket-events/msg.js
+++ b/client/js/socket-events/msg.js
@@ -61,6 +61,11 @@ function processReceivedMessage(data) {
 			.appendTo(container);
 	}
 
+	// Clear unread/highlight counter if self-message
+	if (data.msg.self) {
+		sidebar.find("[data-target='" + target + "'] .badge").removeClass("highlight").empty();
+	}
+
 	// Message arrived in a non active channel, trim it to 100 messages
 	if (activeChannelId !== targetId && container.find(".msg").slice(0, -100).remove().length) {
 		channel.find(".show-more").addClass("show");

--- a/src/models/chan.js
+++ b/src/models/chan.js
@@ -72,7 +72,11 @@ Chan.prototype.pushMessage = function(client, msg, increasesUnread) {
 		}
 	}
 
-	if (!msg.self && !isOpen) {
+	if (msg.self) {
+		// reset counters/markers when receiving self-/echo-message
+		this.firstUnread = 0;
+		this.highlight = 0;
+	} else if (!isOpen) {
 		if (!this.firstUnread) {
 			this.firstUnread = msg.id;
 		}


### PR DESCRIPTION
Resets highlight counter and last unread message ID on server, and clears the badge on the active client when the message is rendered.

I've been poking at it for a good half-hour, so hopefully I haven't missed any edge cases. (I also hope I'm understanding the unread-message tracking correctly and not failing to reset some value I missed.)

Resolves #911 (issue mention omitted from commit description for the same reason as my other PR: avoiding spam from force-pushes).

Edit: Glad to see the tests pass on CI, as I was pretty sure they would. Had tests fail locally but seemed to be an environment problem (maybe outdated eslint or something).