### PR TITLE
Make sure channel list close button is really absent when channel is not selected

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -556,7 +556,7 @@ kbd {
 	font-size: 10px;
 	margin-top: 1px;
 	padding: 3px 6px;
-	transition: opacity 0.2s, background-color 0.2s, color 0.2s;
+	transition: background-color 0.2s, color 0.2s;
 }
 
 #sidebar .badge:empty {
@@ -568,17 +568,11 @@ kbd {
 	color: #49505a;
 }
 
-#sidebar .chan.active .badge,
-#sidebar .badge:empty {
-	opacity: 0;
-}
-
 #sidebar .close {
 	border-radius: 3px;
 	width: 18px;
 	height: 18px;
-	visibility: hidden;
-	opacity: 0;
+	display: none;
 	transition: opacity 0.2s, background-color 0.2s;
 }
 
@@ -593,8 +587,8 @@ kbd {
 }
 
 #sidebar .chan.active .close {
-	visibility: visible;
 	opacity: 0.4;
+	display: unset;
 }
 
 #sidebar .chan.active .close:hover {


### PR DESCRIPTION
This removes the ghost close button when a channel with long name is not selected, or when there is a badge for it.

The first part of this bug is already present in v2.4.0 (it is however more noticeable now that font is bigger), but not the second, most likely introduced by https://github.com/thelounge/lounge/pull/1561/commits/4dc3769b18c509ec631cfc312250773ae7570e40.

&nbsp; | When channel is selected (no difference) | When channel is not selected | When badge is shown
--- | --- | --- | ---
Before | <img width="200" alt="screen shot 2017-10-10 at 01 43 43" src="https://user-images.githubusercontent.com/113730/31371059-09c0f0e2-ad5d-11e7-8eda-8dd89752cd23.png"> | <img width="280" alt="screen shot 2017-10-10 at 01 43 53" src="https://user-images.githubusercontent.com/113730/31371064-0fb3e9d2-ad5d-11e7-9487-19457cfebe5e.png"> | <img width="300" alt="screen shot 2017-10-10 at 01 45 12" src="https://user-images.githubusercontent.com/113730/31371106-3be9830e-ad5d-11e7-8413-2f7fc7efaf76.png">
After | <img width="200" alt="screen shot 2017-10-10 at 01 44 04" src="https://user-images.githubusercontent.com/113730/31371112-45890e3e-ad5d-11e7-9371-150f02d31bf2.png"> | <img width="280" alt="screen shot 2017-10-10 at 01 44 13" src="https://user-images.githubusercontent.com/113730/31371113-45a1e882-ad5d-11e7-83d4-061a8e86d13d.png"> | <img width="300" alt="screen shot 2017-10-10 at 01 44 43" src="https://user-images.githubusercontent.com/113730/31371114-45b21ad6-ad5d-11e7-8bcf-852668cd1e2a.png">


