### PR TITLE
Don't send messages on init

### DIFF
--- a/client/views/chat.tpl
+++ b/client/views/chat.tpl
@@ -12,7 +12,7 @@
 		<span title="{{topic}}" class="topic">{{{parse topic}}}</span>
 	</div>
 	<div class="chat">
-		<div class="show-more {{#equal messages.length 100}}show{{/equal}}">
+		<div class="show-more{{#if messages.length}} show{{/if}}">
 			<button class="show-more-button" data-id="{{id}}">Show older messages</button>
 		</div>
 		<div class="messages"></div>

--- a/src/models/chan.js
+++ b/src/models/chan.js
@@ -139,7 +139,7 @@ Chan.prototype.removeUser = function(user) {
 Chan.prototype.toJSON = function() {
 	var clone = _.clone(this);
 	clone.users = []; // Do not send user list, the client will explicitly request it when needed
-	clone.messages = clone.messages.slice(-100);
+	clone.messages = clone.messages.slice(-1);
 	return clone;
 };
 


### PR DESCRIPTION
I don't know what problems can arise from doing this, but this fixes a major problem where loading the client may take a lot of time due to huge amount of channels.

This might screw `lastMessageId` on reconnects.