### PR TITLE
Reduced padding around page titles

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -66,10 +66,6 @@ h3 {
 	margin: 0;
 }
 
-h1.title {
-	margin-bottom: 10px;
-}
-
 input {
 	outline: 0;
 }
@@ -2076,7 +2072,7 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 
 @media (max-width: 479px) {
 	.container {
-		margin: 40px 0 !important;
+		margin: 10px 0 !important;
 	}
 
 	#connect .tls {


### PR DESCRIPTION
Removed excess padding around page titles as per issue #1621.
**Before**
![image](https://user-images.githubusercontent.com/4456346/31587370-a7450a0e-b1d8-11e7-8b08-7fd22ce140df.png)


**After**
![image](https://user-images.githubusercontent.com/4456346/31587358-6a6b679a-b1d8-11e7-9439-ea23e1641249.png)
