### PR TITLE
Fix possible race condition when attaching clients

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -236,6 +236,8 @@ function index(req, res, next) {
 function initializeClient(socket, client, token, lastMessage) {
 	socket.emit("authorized");
 
+	client.clientAttach(socket.id, token);
+
 	socket.on("disconnect", function() {
 		client.clientDetach(socket.id);
 	});
@@ -430,8 +432,6 @@ function initializeClient(socket, client, token, lastMessage) {
 	socket.join(client.id);
 
 	const sendInitEvent = (tokenToSend) => {
-		client.clientAttach(socket.id, token);
-
 		let networks = client.networks;
 
 		if (lastMessage > -1) {
@@ -456,7 +456,7 @@ function initializeClient(socket, client, token, lastMessage) {
 
 	if (!Helper.config.public && token === null) {
 		client.generateToken((newToken) => {
-			token = newToken;
+			client.attachedClients[socket.id].token = token = newToken;
 
 			client.updateSession(token, getClientIp(socket), socket.request);
 


### PR DESCRIPTION
Socket events were bound before attaching client, so technically an event could be trigger before there is an attached client and crash. I believe this fixes the issue.

```
        this.attachedClients[socketId].openChannel = target.chan.id;
                                                   ^
 
TypeError: Cannot set property 'openChannel' of undefined
    at Client.open (/home/irc/root/lounge/src/client.js:438:45)
    at Socket.<anonymous> (/home/irc/root/lounge/src/server.js:318:11)
    at emitOne (events.js:115:13)
    at Socket.emit (events.js:210:7)
    at /home/irc/root/lounge/node_modules/socket.io/lib/socket.js:503:12
    at _combinedTickCallback (internal/process/next_tick.js:131:7)
    at process._tickCallback (internal/process/next_tick.js:180:9)
```