### PR TITLE
Fix loading app with autocomplete disabled

### DIFF
--- a/client/js/options.js
+++ b/client/js/options.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const $ = require("jquery");
+require("jquery-textcomplete");
 const escapeRegExp = require("lodash/escapeRegExp");
 const settings = $("#settings");
 const userStyles = $("#user-specified-css");


### PR DESCRIPTION
Adds a client-side require() that was missing from 1e2d35f. Fixes #1647.

Bare `require()` because it's a `jquery` plugin that doesn't need to be referenced directly, but if there should be a `const` on there for some other reason, let me know.