### PR TITLE
Include all available whois info

### DIFF
--- a/client/views/actions/whois.tpl
+++ b/client/views/actions/whois.tpl
@@ -1,12 +1,60 @@
 <div>
 	{{> ../user_name nick=whois.nick}}
-	<i class="hostmask">({{whois.user}}@{{whois.host}})</i>:
-	<b>{{{parse whois.real_name}}}</b>
+	<i class="hostmask">({{whois.user}}@{{whois.host}})</i>
 </div>
+{{#if whois.actuallhost}}
+<div>
+	Actual host
+	{{> ../user_name nick=whois.nick}}
+	<i class="hostmask">({{whois.user}}@{{whois.actuallhost}})</i>
+</div>
+{{/if}}
+{{#if whois.real_name}}
+<div>
+	{{> ../user_name nick=whois.nick}}'s real name is:
+	<b>{{parse whois.real_name}}</b>
+</div>
+{{/if}}
 {{#if whois.account}}
 <div>
 	{{> ../user_name nick=whois.nick}}
 	is logged in as <b>{{whois.account}}</b>
+</div>
+{{/if}}
+{{#if whois.registered_nick}}
+<div>
+	{{> ../user_name nick=whois.nick}}
+	{{whois.registered_nick}}
+</div>
+{{/if}}
+{{#if whois.modes}}
+<div>
+	{{> ../user_name nick=whois.nick}}
+	{{whois.modes}}
+</div>
+{{/if}}
+{{#if whois.special}}
+<div>
+	{{> ../user_name nick=whois.nick}}
+	{{whois.special}}
+</div>
+{{/if}}
+{{#if whois.operator}}
+<div>
+	{{> ../user_name nick=whois.nick}}
+	{{whois.operator}}
+</div>
+{{/if}}
+{{#if whois.helpop}}
+<div>
+	{{> ../user_name nick=whois.nick}}
+	is available for help
+</div>
+{{/if}}
+{{#if whois.bot}}
+<div>
+	{{> ../user_name nick=whois.nick}}
+	is a bot
 </div>
 {{/if}}
 {{#if whois.channels}}
@@ -33,9 +81,15 @@
 	is away <i>({{whois.away}})</i>
 </div>
 {{/if}}
+{{#if whois.logonTime}}
+<div>
+	{{> ../user_name nick=whois.nick}}
+	connected at {{localetime whois.logonTime}}
+</div>
+{{/if}}
 {{#if whois.idle}}
 <div>
 	{{> ../user_name nick=whois.nick}}
-	has been idle since {{localetime whois.idleTime}}.
+	has been idle since {{localetime whois.idleTime}}
 </div>
 {{/if}}

--- a/src/plugins/irc-events/whois.js
+++ b/src/plugins/irc-events/whois.js
@@ -30,7 +30,8 @@ module.exports = function(irc, network) {
 		} else {
 			// Absolute datetime in milliseconds since nick is idle
 			data.idleTime = Date.now() - data.idle * 1000;
-
+			// Absolute datetime in milliseconds when nick logged on.
+			data.logonTime = data.logon * 1000;
 			msg = new Msg({
 				type: Msg.Type.WHOIS,
 				whois: data,


### PR DESCRIPTION
This fixes #560 by including all the information [irc-framework provides](https://github.com/kiwiirc/irc-framework/blob/16728e3165d04afce5502ec6c8cd848638b2c4b7/docs/events.md). 

Specifically it adds the following information when available: 

- actual host (used in cases of webirc)
- registered nick
- modes
- operator
- helpop
- bot 
- logon time

