### PR TITLE
fix gap between #sidebar and #footer

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -431,7 +431,7 @@ kbd {
 }
 
 #sidebar {
-	bottom: 48px;
+	bottom: 45px;
 	left: 0;
 	overflow: auto;
 	overflow-x: hidden;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5107843/32559036-e090f5a0-c4ae-11e7-894b-69fbe9f65b59.png)

Currently #sidebar has `bottom: 48px` and the #footer has `height: 45px`. This should fix the gap.