### PR TITLE
Fix #1692 when kicker is server

### DIFF
--- a/src/models/chan.js
+++ b/src/models/chan.js
@@ -2,6 +2,7 @@
 
 var _ = require("lodash");
 var Helper = require("../helper");
+const User = require("./user");
 const userLog = require("../userLog");
 const storage = require("../plugins/storage");
 
@@ -119,6 +120,10 @@ Chan.prototype.findMessage = function(msgId) {
 
 Chan.prototype.findUser = function(nick) {
 	return _.find(this.users, {nick: nick});
+};
+
+Chan.prototype.getUser = function(nick) {
+	return this.findUser(nick) || new User({nick: nick});
 };
 
 Chan.prototype.getMode = function(name) {

--- a/src/plugins/irc-events/kick.js
+++ b/src/plugins/irc-events/kick.js
@@ -11,8 +11,8 @@ module.exports = function(irc, network) {
 			return;
 		}
 
-		const kicker = chan.findUser(data.nick);
-		const target = chan.findUser(data.kicked);
+		const kicker = chan.getUser(data.nick);
+		const target = chan.getUser(data.kicked);
 
 		if (data.kicked === irc.user.nick) {
 			chan.users = [];


### PR DESCRIPTION
I want to make use of `getUser` in other instances where we send nick+mode separately in some events (like mode, part, etc).