### PR TITLE
Refactor how user object is sent to the client

### DIFF
--- a/client/views/actions/action.tpl
+++ b/client/views/actions/action.tpl
@@ -1,4 +1,4 @@
-{{> ../user_name nick=from}}
+{{> ../user_name from}}
 <span class="text">{{{parse text}}}</span>
 
 {{#each previews}}

--- a/client/views/actions/away.tpl
+++ b/client/views/actions/away.tpl
@@ -1,3 +1,3 @@
-{{> ../user_name nick=from}}
+{{> ../user_name from}}
 is away
 <i class="away-message">({{{parse text}}})</i>

--- a/client/views/actions/back.tpl
+++ b/client/views/actions/back.tpl
@@ -1,2 +1,2 @@
-{{> ../user_name nick=from}}
+{{> ../user_name from}}
 is back

--- a/client/views/actions/ctcp.tpl
+++ b/client/views/actions/ctcp.tpl
@@ -1,2 +1,2 @@
-{{> ../user_name nick=from}}
+{{> ../user_name from}}
 <b>{{ctcpType}}</b> <span class="ctcp-message">{{{parse ctcpMessage}}}</span>

--- a/client/views/actions/invite.tpl
+++ b/client/views/actions/invite.tpl
@@ -1,9 +1,9 @@
-{{> ../user_name nick=from}}
+{{> ../user_name from}}
 invited
 {{#if invitedYou}}
 	you
 {{else}}
-	{{> ../user_name nick=invited}}
+	{{> ../user_name invited}}
 {{/if}}
 to
 {{{parse channel}}}

--- a/client/views/actions/join.tpl
+++ b/client/views/actions/join.tpl
@@ -1,3 +1,3 @@
-{{> ../user_name nick=from}}
+{{> ../user_name from}}
 <i class="hostmask">({{hostmask}})</i>
 has joined the channel

--- a/client/views/actions/kick.tpl
+++ b/client/views/actions/kick.tpl
@@ -1,6 +1,6 @@
-{{> ../user_name nick=from.nick mode=from.mode}}
+{{> ../user_name from}}
 has kicked
-{{> ../user_name nick=target.nick mode=target.mode}}
+{{> ../user_name target}}
 {{#if text}}
 	<i class="part-reason">({{{parse text}}})</i>
 {{/if}}

--- a/client/views/actions/mode.tpl
+++ b/client/views/actions/mode.tpl
@@ -1,3 +1,3 @@
-{{> ../user_name nick=from}}
+{{> ../user_name from}}
 sets mode
 {{{parse text}}}

--- a/client/views/actions/nick.tpl
+++ b/client/views/actions/nick.tpl
@@ -1,3 +1,3 @@
-{{> ../user_name nick=from}}
+{{> ../user_name from}}
 is now known as
-{{> ../user_name nick=new_nick}}
+{{> ../user_name nick=new_nick mode=from.mode}}

--- a/client/views/actions/part.tpl
+++ b/client/views/actions/part.tpl
@@ -1,4 +1,4 @@
-{{> ../user_name nick=from}}
+{{> ../user_name from}}
 <i class="hostmask">({{hostmask}})</i>
 has left the channel
 {{#if text}}

--- a/client/views/actions/quit.tpl
+++ b/client/views/actions/quit.tpl
@@ -1,4 +1,4 @@
-{{> ../user_name nick=from}}
+{{> ../user_name from}}
 <i class="hostmask">({{hostmask}})</i>
 has quit
 {{#if text}}

--- a/client/views/actions/topic.tpl
+++ b/client/views/actions/topic.tpl
@@ -1,5 +1,5 @@
 {{#if from}}
-	{{> ../user_name nick=from}}
+	{{> ../user_name from}}
 	has changed the topic to:
 {{else}}
 	The topic is:

--- a/client/views/actions/topic_set_by.tpl
+++ b/client/views/actions/topic_set_by.tpl
@@ -1,3 +1,3 @@
 Topic set by
-{{> ../user_name}}
+{{> ../user_name from}}
 on {{localetime when}}

--- a/client/views/msg.tpl
+++ b/client/views/msg.tpl
@@ -4,7 +4,7 @@
 	</span>
 	<span class="from">
 		{{#if from}}
-			{{> user_name nick=from}}
+			{{> user_name from}}
 		{{/if}}
 	</span>
 	<span class="content">

--- a/src/models/chan.js
+++ b/src/models/chan.js
@@ -126,15 +126,6 @@ Chan.prototype.getUser = function(nick) {
 	return this.findUser(nick) || new User({nick: nick});
 };
 
-Chan.prototype.getMode = function(name) {
-	var user = this.findUser(name);
-	if (user) {
-		return user.mode;
-	}
-
-	return "";
-};
-
 Chan.prototype.toJSON = function() {
 	var clone = _.clone(this);
 	clone.users = []; // Do not send user list, the client will explicitly request it when needed

--- a/src/plugins/irc-events/away.js
+++ b/src/plugins/irc-events/away.js
@@ -19,8 +19,7 @@ module.exports = function(irc, network) {
 				type: away ? Msg.Type.AWAY : Msg.Type.BACK,
 				text: away || "",
 				time: data.time,
-				from: data.nick,
-				mode: user.mode,
+				from: user,
 			});
 
 			chan.pushMessage(client, msg);

--- a/src/plugins/irc-events/connection.js
+++ b/src/plugins/irc-events/connection.js
@@ -1,12 +1,12 @@
 "use strict";
 
-var _ = require("lodash");
-var Msg = require("../../models/msg");
-var Chan = require("../../models/chan");
-var Helper = require("../../helper");
+const _ = require("lodash");
+const Msg = require("../../models/msg");
+const Chan = require("../../models/chan");
+const Helper = require("../../helper");
 
 module.exports = function(irc, network) {
-	var client = this;
+	const client = this;
 
 	network.channels[0].pushMessage(client, new Msg({
 		text: "Network created, connecting to " + network.host + ":" + network.port + "...",
@@ -27,10 +27,10 @@ module.exports = function(irc, network) {
 			irc.raw("AWAY", client.awayMessage);
 		}
 
-		var delay = 1000;
-		var commands = network.commands;
-		if (Array.isArray(commands)) {
-			commands.forEach((cmd) => {
+		let delay = 1000;
+
+		if (Array.isArray(network.commands)) {
+			network.commands.forEach((cmd) => {
 				setTimeout(function() {
 					client.input({
 						target: network.channels[0].id,

--- a/src/plugins/irc-events/ctcp.js
+++ b/src/plugins/irc-events/ctcp.js
@@ -7,6 +7,7 @@ module.exports = function(irc, network) {
 
 	irc.on("ctcp response", function(data) {
 		let chan = network.getChannel(data.nick);
+
 		if (typeof chan === "undefined") {
 			chan = network.channels[0];
 		}
@@ -14,7 +15,7 @@ module.exports = function(irc, network) {
 		const msg = new Msg({
 			type: Msg.Type.CTCP,
 			time: data.time,
-			from: data.nick,
+			from: chan.getUser(data.nick),
 			ctcpType: data.type,
 			ctcpMessage: data.message,
 		});

--- a/src/plugins/irc-events/error.js
+++ b/src/plugins/irc-events/error.js
@@ -1,17 +1,19 @@
 "use strict";
 
-var Msg = require("../../models/msg");
+const Msg = require("../../models/msg");
 
 module.exports = function(irc, network) {
-	var client = this;
+	const client = this;
 
 	irc.on("irc error", function(data) {
-		var text = data.error;
+		let text = data.error;
+
 		if (data.reason) {
 			text = data.reason + " (" + text + ")";
 		}
-		var lobby = network.channels[0];
-		var msg = new Msg({
+
+		const lobby = network.channels[0];
+		const msg = new Msg({
 			type: Msg.Type.ERROR,
 			text: text,
 		});
@@ -19,15 +21,15 @@ module.exports = function(irc, network) {
 	});
 
 	irc.on("nick in use", function(data) {
-		var lobby = network.channels[0];
-		var msg = new Msg({
+		const lobby = network.channels[0];
+		const msg = new Msg({
 			type: Msg.Type.ERROR,
 			text: data.nick + ": " + (data.reason || "Nickname is already in use."),
 		});
 		lobby.pushMessage(client, msg, true);
 
 		if (irc.connection.registered === false) {
-			var random = (data.nick || irc.user.nick) + Math.floor(10 + (Math.random() * 89));
+			const random = (data.nick || irc.user.nick) + Math.floor(10 + (Math.random() * 89));
 			irc.changeNick(random);
 		}
 
@@ -38,15 +40,15 @@ module.exports = function(irc, network) {
 	});
 
 	irc.on("nick invalid", function(data) {
-		var lobby = network.channels[0];
-		var msg = new Msg({
+		const lobby = network.channels[0];
+		const msg = new Msg({
 			type: Msg.Type.ERROR,
 			text: data.nick + ": " + (data.reason || "Nickname is invalid."),
 		});
 		lobby.pushMessage(client, msg, true);
 
 		if (irc.connection.registered === false) {
-			var random = "i" + Math.random().toString(36).substr(2, 10); // 'i' so it never begins with a number
+			const random = "i" + Math.random().toString(36).substr(2, 10); // 'i' so it never begins with a number
 			irc.changeNick(random);
 		}
 

--- a/src/plugins/irc-events/invite.js
+++ b/src/plugins/irc-events/invite.js
@@ -1,20 +1,22 @@
 "use strict";
 
-var Msg = require("../../models/msg");
+const Msg = require("../../models/msg");
 
 module.exports = function(irc, network) {
-	var client = this;
+	const client = this;
+
 	irc.on("invite", function(data) {
-		var chan = network.getChannel(data.channel);
+		let chan = network.getChannel(data.channel);
+
 		if (typeof chan === "undefined") {
 			chan = network.channels[0];
 		}
 
-		var msg = new Msg({
+		const msg = new Msg({
 			type: Msg.Type.INVITE,
 			time: data.time,
-			from: data.nick,
-			invited: data.invited,
+			from: chan.getUser(data.nick),
+			invited: chan.getUser(data.invited),
 			channel: data.channel,
 			highlight: true,
 			invitedYou: data.invited === irc.user.nick,

--- a/src/plugins/irc-events/join.js
+++ b/src/plugins/irc-events/join.js
@@ -1,13 +1,15 @@
 "use strict";
 
-var Chan = require("../../models/chan");
-var Msg = require("../../models/msg");
-var User = require("../../models/user");
+const Chan = require("../../models/chan");
+const Msg = require("../../models/msg");
+const User = require("../../models/user");
 
 module.exports = function(irc, network) {
-	var client = this;
+	const client = this;
+
 	irc.on("join", function(data) {
-		var chan = network.getChannel(data.channel);
+		let chan = network.getChannel(data.channel);
+
 		if (typeof chan === "undefined") {
 			chan = new Chan({
 				name: data.channel,
@@ -22,18 +24,21 @@ module.exports = function(irc, network) {
 			// Request channels' modes
 			network.irc.raw("MODE", chan.name);
 		}
-		chan.users.push(new User({nick: data.nick}));
-		chan.sortUsers(irc);
-		client.emit("users", {
-			chan: chan.id,
-		});
-		var msg = new Msg({
+
+		const user = new User({nick: data.nick});
+		const msg = new Msg({
 			time: data.time,
-			from: data.nick,
+			from: user,
 			hostmask: data.ident + "@" + data.hostname,
 			type: Msg.Type.JOIN,
 			self: data.nick === irc.user.nick,
 		});
 		chan.pushMessage(client, msg);
+
+		chan.users.push(user);
+		chan.sortUsers(irc);
+		client.emit("users", {
+			chan: chan.id,
+		});
 	});
 };

--- a/src/plugins/irc-events/kick.js
+++ b/src/plugins/irc-events/kick.js
@@ -1,38 +1,37 @@
 "use strict";
 
-var _ = require("lodash");
-var Msg = require("../../models/msg");
+const _ = require("lodash");
+const Msg = require("../../models/msg");
 
 module.exports = function(irc, network) {
-	var client = this;
+	const client = this;
+
 	irc.on("kick", function(data) {
-		var chan = network.getChannel(data.channel);
+		const chan = network.getChannel(data.channel);
+
 		if (typeof chan === "undefined") {
 			return;
 		}
 
-		const kicker = chan.getUser(data.nick);
-		const target = chan.getUser(data.kicked);
-
-		if (data.kicked === irc.user.nick) {
-			chan.users = [];
-		} else {
-			chan.users = _.without(chan.users, target);
-		}
-
-		client.emit("users", {
-			chan: chan.id,
-		});
-
-		var msg = new Msg({
+		const msg = new Msg({
 			type: Msg.Type.KICK,
 			time: data.time,
-			from: kicker,
-			target: target,
+			from: chan.getUser(data.nick),
+			target: chan.getUser(data.kicked),
 			text: data.message || "",
 			highlight: data.kicked === irc.user.nick,
 			self: data.nick === irc.user.nick,
 		});
 		chan.pushMessage(client, msg);
+
+		if (data.kicked === irc.user.nick) {
+			chan.users = [];
+		} else {
+			chan.users = _.without(chan.users, msg.target);
+		}
+
+		client.emit("users", {
+			chan: chan.id,
+		});
 	});
 };

--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -154,9 +154,11 @@ function fetch(uri, cb) {
 	} catch (e) {
 		return cb(null);
 	}
+
 	const buffers = [];
-	var length = 0;
-	var limit = Helper.config.prefetchMaxImageSize * 1024;
+	let length = 0;
+	let limit = Helper.config.prefetchMaxImageSize * 1024;
+
 	req
 		.on("response", function(res) {
 			if (/^image\/.+/.test(res.headers["content-type"])) {

--- a/src/plugins/irc-events/list.js
+++ b/src/plugins/irc-events/list.js
@@ -1,11 +1,11 @@
 "use strict";
 
-var Chan = require("../../models/chan");
-var Msg = require("../../models/msg");
+const Chan = require("../../models/chan");
+const Msg = require("../../models/msg");
 
 module.exports = function(irc, network) {
-	var client = this;
-	var MAX_CHANS = 500;
+	const client = this;
+	const MAX_CHANS = 500;
 
 	irc.on("channel list start", function() {
 		network.chanCache = [];
@@ -39,7 +39,8 @@ module.exports = function(irc, network) {
 	});
 
 	function updateListStatus(msg) {
-		var chan = network.getChannel("Channel List");
+		let chan = network.getChannel("Channel List");
+
 		if (typeof chan === "undefined") {
 			chan = new Chan({
 				type: Chan.Type.SPECIAL,

--- a/src/plugins/irc-events/message.js
+++ b/src/plugins/irc-events/message.js
@@ -6,7 +6,7 @@ const LinkPrefetch = require("./link");
 const Helper = require("../../helper");
 
 module.exports = function(irc, network) {
-	var client = this;
+	const client = this;
 
 	irc.on("notice", function(data) {
 		// Some servers send notices without any nickname
@@ -37,14 +37,16 @@ module.exports = function(irc, network) {
 
 	function handleMessage(data) {
 		let chan;
+		let user;
 		let highlight = false;
 		const self = data.nick === irc.user.nick;
 
 		// Server messages go to server window, no questions asked
 		if (data.from_server) {
 			chan = network.channels[0];
+			user = chan.getUser(data.nick);
 		} else {
-			var target = data.target;
+			let target = data.target;
 
 			// If the message is targeted at us, use sender as target instead
 			if (target.toLowerCase() === irc.user.nick.toLowerCase()) {
@@ -52,6 +54,7 @@ module.exports = function(irc, network) {
 			}
 
 			chan = network.getChannel(target);
+
 			if (typeof chan === "undefined") {
 				// Send notices that are not targeted at us into the server window
 				if (data.type === Msg.Type.NOTICE) {
@@ -69,15 +72,13 @@ module.exports = function(irc, network) {
 				}
 			}
 
+			user = chan.getUser(data.nick);
+
 			// Query messages (unless self) always highlight
 			if (chan.type === Chan.Type.QUERY) {
 				highlight = !self;
 			} else if (chan.type === Chan.Type.CHANNEL) {
-				const user = chan.findUser(data.nick);
-
-				if (user) {
-					user.lastMessage = data.time || Date.now();
-				}
+				user.lastMessage = data.time || Date.now();
 			}
 		}
 
@@ -87,11 +88,10 @@ module.exports = function(irc, network) {
 			highlight = network.highlightRegex.test(data.message);
 		}
 
-		var msg = new Msg({
+		const msg = new Msg({
 			type: data.type,
 			time: data.time,
-			mode: chan.getMode(data.nick),
-			from: data.nick,
+			from: user,
 			text: data.message,
 			self: self,
 			highlight: highlight,

--- a/src/plugins/irc-events/mode.js
+++ b/src/plugins/irc-events/mode.js
@@ -1,7 +1,6 @@
 "use strict";
 
 const _ = require("lodash");
-const Chan = require("../../models/chan");
 const Msg = require("../../models/msg");
 
 module.exports = function(irc, network) {
@@ -70,8 +69,7 @@ module.exports = function(irc, network) {
 			const msg = new Msg({
 				time: data.time,
 				type: Msg.Type.MODE,
-				mode: (targetChan.type !== Chan.Type.LOBBY && targetChan.getMode(data.nick)) || "",
-				from: data.nick,
+				from: targetChan.getUser(data.nick),
 				text: text,
 				self: data.nick === irc.user.nick,
 			});

--- a/src/plugins/irc-events/motd.js
+++ b/src/plugins/irc-events/motd.js
@@ -1,15 +1,16 @@
 "use strict";
 
-var Msg = require("../../models/msg");
+const Msg = require("../../models/msg");
 
 module.exports = function(irc, network) {
-	var client = this;
+	const client = this;
+
 	irc.on("motd", function(data) {
-		var lobby = network.channels[0];
+		const lobby = network.channels[0];
 
 		if (data.motd) {
 			data.motd.split("\n").forEach((text) => {
-				var msg = new Msg({
+				const msg = new Msg({
 					type: Msg.Type.MOTD,
 					text: text,
 				});
@@ -18,7 +19,7 @@ module.exports = function(irc, network) {
 		}
 
 		if (data.error) {
-			var msg = new Msg({
+			const msg = new Msg({
 				type: Msg.Type.MOTD,
 				text: data.error,
 			});

--- a/src/plugins/irc-events/nick.js
+++ b/src/plugins/irc-events/nick.js
@@ -1,21 +1,23 @@
 "use strict";
 
-var Msg = require("../../models/msg");
+const Msg = require("../../models/msg");
 
 module.exports = function(irc, network) {
-	var client = this;
+	const client = this;
+
 	irc.on("nick", function(data) {
 		let msg;
-		var self = false;
-		if (data.nick === irc.user.nick) {
+		const self = data.nick === irc.user.nick;
+
+		if (self) {
 			network.setNick(data.new_nick);
 
-			var lobby = network.channels[0];
+			const lobby = network.channels[0];
 			msg = new Msg({
-				text: "You're now known as " + data.new_nick,
+				text: `You're now known as ${data.new_nick}`,
 			});
 			lobby.pushMessage(client, msg, true);
-			self = true;
+
 			client.save();
 			client.emit("nick", {
 				network: network.id,
@@ -25,23 +27,26 @@ module.exports = function(irc, network) {
 
 		network.channels.forEach((chan) => {
 			const user = chan.findUser(data.nick);
+
 			if (typeof user === "undefined") {
 				return;
 			}
-			user.nick = data.new_nick;
-			chan.sortUsers(irc);
-			client.emit("users", {
-				chan: chan.id,
-			});
+
 			msg = new Msg({
 				time: data.time,
-				from: data.nick,
+				from: user,
 				type: Msg.Type.NICK,
-				mode: chan.getMode(data.new_nick),
 				new_nick: data.new_nick,
 				self: self,
 			});
 			chan.pushMessage(client, msg);
+
+			user.nick = data.new_nick;
+
+			chan.sortUsers(irc);
+			client.emit("users", {
+				chan: chan.id,
+			});
 		});
 	});
 };

--- a/src/plugins/irc-events/quit.js
+++ b/src/plugins/irc-events/quit.js
@@ -1,29 +1,32 @@
 "use strict";
 
-var _ = require("lodash");
-var Msg = require("../../models/msg");
+const _ = require("lodash");
+const Msg = require("../../models/msg");
 
 module.exports = function(irc, network) {
-	var client = this;
+	const client = this;
+
 	irc.on("quit", function(data) {
 		network.channels.forEach((chan) => {
 			const user = chan.findUser(data.nick);
+
 			if (typeof user === "undefined") {
 				return;
 			}
+
+			const msg = new Msg({
+				time: data.time,
+				type: Msg.Type.QUIT,
+				text: data.message || "",
+				hostmask: data.ident + "@" + data.hostname,
+				from: user,
+			});
+			chan.pushMessage(client, msg);
+
 			chan.users = _.without(chan.users, user);
 			client.emit("users", {
 				chan: chan.id,
 			});
-			var msg = new Msg({
-				time: data.time,
-				type: Msg.Type.QUIT,
-				mode: user.mode || "",
-				text: data.message || "",
-				hostmask: data.ident + "@" + data.hostname,
-				from: data.nick,
-			});
-			chan.pushMessage(client, msg);
 		});
 	});
 };

--- a/src/plugins/irc-events/topic.js
+++ b/src/plugins/irc-events/topic.js
@@ -1,20 +1,21 @@
 "use strict";
 
-var Msg = require("../../models/msg");
+const Msg = require("../../models/msg");
 
 module.exports = function(irc, network) {
-	var client = this;
+	const client = this;
+
 	irc.on("topic", function(data) {
-		var chan = network.getChannel(data.channel);
+		const chan = network.getChannel(data.channel);
+
 		if (typeof chan === "undefined") {
 			return;
 		}
 
-		var msg = new Msg({
+		const msg = new Msg({
 			time: data.time,
 			type: Msg.Type.TOPIC,
-			mode: (data.nick && chan.getMode(data.nick)) || "",
-			from: data.nick,
+			from: chan.getUser(data.nick),
 			text: data.topic,
 			self: data.nick === irc.user.nick,
 		});
@@ -28,15 +29,15 @@ module.exports = function(irc, network) {
 	});
 
 	irc.on("topicsetby", function(data) {
-		var chan = network.getChannel(data.channel);
+		const chan = network.getChannel(data.channel);
+
 		if (typeof chan === "undefined") {
 			return;
 		}
 
-		var msg = new Msg({
+		const msg = new Msg({
 			type: Msg.Type.TOPIC_SET_BY,
-			mode: chan.getMode(data.nick),
-			nick: data.nick,
+			from: chan.getUser(data.nick),
 			when: new Date(data.when * 1000),
 			self: data.nick === irc.user.nick,
 		});

--- a/src/plugins/irc-events/unhandled.js
+++ b/src/plugins/irc-events/unhandled.js
@@ -1,9 +1,9 @@
 "use strict";
 
-var Msg = require("../../models/msg");
+const Msg = require("../../models/msg");
 
 module.exports = function(irc, network) {
-	var client = this;
+	const client = this;
 
 	irc.on("unknown command", function(command) {
 		// Do not display users own name

--- a/src/plugins/irc-events/welcome.js
+++ b/src/plugins/irc-events/welcome.js
@@ -1,17 +1,19 @@
 "use strict";
 
-var Msg = require("../../models/msg");
+const Msg = require("../../models/msg");
 
 module.exports = function(irc, network) {
-	var client = this;
+	const client = this;
+
 	irc.on("registered", function(data) {
 		network.setNick(data.nick);
 
-		var lobby = network.channels[0];
-		var msg = new Msg({
+		const lobby = network.channels[0];
+		const msg = new Msg({
 			text: "You're now known as " + data.nick,
 		});
 		lobby.pushMessage(client, msg);
+
 		client.save();
 		client.emit("nick", {
 			network: network.id,

--- a/src/plugins/irc-events/whois.js
+++ b/src/plugins/irc-events/whois.js
@@ -1,12 +1,13 @@
 "use strict";
 
-var Chan = require("../../models/chan");
-var Msg = require("../../models/msg");
+const Chan = require("../../models/chan");
+const Msg = require("../../models/msg");
 
 module.exports = function(irc, network) {
-	var client = this;
+	const client = this;
 	irc.on("whois", function(data) {
-		var chan = network.getChannel(data.nick);
+		let chan = network.getChannel(data.nick);
+
 		if (typeof chan === "undefined") {
 			chan = new Chan({
 				type: Chan.Type.QUERY,
@@ -20,7 +21,7 @@ module.exports = function(irc, network) {
 			});
 		}
 
-		var msg;
+		let msg;
 		if (data.error) {
 			msg = new Msg({
 				type: Msg.Type.ERROR,


### PR DESCRIPTION
This was started by `kick` event where users are sent as `User` objects instead of putting nick/mode in the message itself.

This changes all `var` to use `const` and `let` in `irc-events` folder. This also changes events like join/part/quit to send message to client first before updating the user list (just a minor improvement).