### PR TITLE
Fix #1703 - Keep findLinks file in npm builds

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -6,7 +6,11 @@
 .*
 !.lounge_home
 
+# Ignore client folder as it's being built into public/ folder
+# except for the findLinks.js file which is used by the server
 client/
+!client/js/libs/handlebars/ircmessageparser/findLinks.js
+
 public/js/bundle.vendor.js.map
 coverage/
 scripts/


### PR DESCRIPTION
Fix #1703