### PR TITLE
Switch CLI tool from `lounge` to `thelounge`, deprecate `lounge`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ Run this in a terminal to install (or upgrade) the latest stable release from
 When installation is complete, run:
 
 ```sh
-lounge start
+thelounge start
 ```
 
 For more information, read the [documentation](https://thelounge.github.io/docs/), [wiki](https://github.com/thelounge/lounge/wiki), or run:
 
 ```sh
-lounge --help
+thelounge --help
 ```
 
 ### Running from source
@@ -61,7 +61,7 @@ NODE_ENV=production npm run build
 npm start
 ```
 
-When installed like this, npm doesn't create a `lounge` executable. Use `npm start -- <command>` to run subcommands.
+When installed like this, npm doesn't create a `thelounge` executable. Use `npm start -- <command>` to run subcommands.
 
 ⚠️ While it is the most recent codebase, this is not production-ready! Run at
 your own risk. It is also not recommended to run this as root.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "2.6.0",
   "preferGlobal": true,
   "bin": {
-    "lounge": "index.js"
+    "lounge": "index.js",
+    "thelounge": "index.js"
   },
   "repository": {
     "type": "git",

--- a/src/clientManager.js
+++ b/src/clientManager.js
@@ -35,7 +35,7 @@ ClientManager.prototype.findClient = function(name) {
 
 ClientManager.prototype.autoloadUsers = function() {
 	const users = this.getUsers();
-	const noUsersWarning = `There are currently no users. Create one with ${colors.bold("lounge add <name>")}.`;
+	const noUsersWarning = `There are currently no users. Create one with ${colors.bold("thelounge add <name>")}.`;
 
 	if (users.length === 0) {
 		log.info(noUsersWarning);

--- a/src/command-line/index.js
+++ b/src/command-line/index.js
@@ -39,6 +39,13 @@ require("./reset");
 require("./edit");
 require("./install");
 
+// TODO: Remove this when releasing The Lounge v3
+if (process.argv[1].endsWith(`${require("path").sep}lounge`)) {
+	log.warn(`The ${colors.red("lounge")} CLI is ${colors.bold("deprecated")} and will be removed in v3.`);
+	log.warn(`Use ${colors.green("thelounge")} instead.`);
+	process.argv[1] = "thelounge";
+}
+
 program.parse(process.argv);
 
 if (!program.args.length) {

--- a/src/command-line/list.js
+++ b/src/command-line/list.js
@@ -34,6 +34,6 @@ program
 				log.info(`${i + 1}. ${colors.bold(user)}`);
 			});
 		} else {
-			log.info(`There are currently no users. Create one with ${colors.bold("lounge add <name>")}.`);
+			log.info(`There are currently no users. Create one with ${colors.bold("thelounge add <name>")}.`);
 		}
 	});


### PR DESCRIPTION
This is in preparation of The Lounge v3 which will make `thelounge` (aliased `tl`) uniform across the entire project. No more confusion!

<img width="589" alt="screen shot 2017-11-19 at 03 18 09" src="https://user-images.githubusercontent.com/113730/32988752-6f233892-ccd8-11e7-8f87-b25c45947e53.png">
