### PR TITLE
 Link nicks mentioned in messages 

### DIFF
--- a/client/js/libs/handlebars/ircmessageparser/findNames.js
+++ b/client/js/libs/handlebars/ircmessageparser/findNames.js
@@ -1,0 +1,17 @@
+"use strict";
+
+function findNames(text, users) {
+	const result = [];
+	let index = 0;
+	users.forEach((nick) => {
+		index = text.indexOf(nick, index);
+		result.push({
+			start: index,
+			end: index + nick.length,
+			nick: nick,
+		});
+	});
+	return result;
+}
+
+module.exports = findNames;

--- a/client/views/msg.tpl
+++ b/client/views/msg.tpl
@@ -8,7 +8,7 @@
 		{{/if}}
 	</span>
 	<span class="content">
-		<span class="text">{{{parse text}}}</span>
+		<span class="text">{{{parse text users}}}</span>
 
 		{{#each previews}}
 			<div class="preview" data-url="{{link}}"></div>

--- a/src/plugins/irc-events/message.js
+++ b/src/plugins/irc-events/message.js
@@ -4,6 +4,7 @@ const Chan = require("../../models/chan");
 const Msg = require("../../models/msg");
 const LinkPrefetch = require("./link");
 const cleanIrcMessage = require("../../../client/js/libs/handlebars/ircmessageparser/cleanIrcMessage");
+const nickRegExp = /[\w[\]\\`^{|}-]{4,}/gi;
 
 module.exports = function(irc, network) {
 	const client = this;
@@ -88,6 +89,14 @@ module.exports = function(irc, network) {
 			highlight = network.highlightRegex.test(data.message);
 		}
 
+		const users = [];
+		let match;
+		while ((match = nickRegExp.exec(data.message))) {
+			if (chan.findUser(match[0])) {
+				users.push(match[0]);
+			}
+		}
+
 		const msg = new Msg({
 			type: data.type,
 			time: data.time,
@@ -95,6 +104,7 @@ module.exports = function(irc, network) {
 			text: data.message,
 			self: self,
 			highlight: highlight,
+			users: users,
 		});
 
 		// No prefetch URLs unless are simple MESSAGE or ACTION types

--- a/test/client/js/libs/handlebars/ircmessageparser/findNames.js
+++ b/test/client/js/libs/handlebars/ircmessageparser/findNames.js
@@ -1,0 +1,26 @@
+"use strict";
+
+const expect = require("chai").expect;
+const findNames = require("../../../../../../client/js/libs/handlebars/ircmessageparser/findNames");
+
+describe("findNames", () => {
+	it("should find nicks in text", () => {
+		const input = "<MaxLeiter>: Hello, xPaw, how's it going?";
+		const expected = [
+			{
+				start: 1,
+				end: 10,
+				nick: "MaxLeiter",
+			},
+			{
+				start: 20,
+				end: 24,
+				nick: "xPaw",
+			},
+		];
+		const nicks = ["MaxLeiter", "xPaw"];
+		const actual = findNames(input, nicks);
+
+		expect(actual).to.deep.equal(expected);
+	});
+});

--- a/test/client/js/libs/handlebars/parse.js
+++ b/test/client/js/libs/handlebars/parse.js
@@ -243,6 +243,49 @@ describe("parse Handlebars helper", () => {
 		expect(actual).to.deep.equal(expected);
 	});
 
+	it("should find nicks", () => {
+		const testCases = [{
+			users: ["MaxLeiter"],
+			input: "test, MaxLeiter",
+			expected:
+				"test, " +
+				"<span role=\"button\" class=\"user color-12\" data-name=\"MaxLeiter\">" +
+					"MaxLeiter" +
+				"</span>",
+		}];
+
+		const actual = testCases.map((testCase) => parse(testCase.input, testCase.users));
+		const expected = testCases.map((testCase) => testCase.expected);
+
+		expect(actual).to.deep.equal(expected);
+	});
+
+	it("should not find nicks", () => {
+		const testCases = [{
+			users: ["MaxLeiter, test"],
+			input: "#test-channelMaxLeiter",
+			expected:
+				"<span class=\"inline-channel\" role=\"button\" tabindex=\"0\" data-chan=\"#test-channelMaxLeiter\">" +
+					"#test-channelMaxLeiter" +
+				"</span>",
+		},
+		{
+			users: ["MaxLeiter, test"],
+			input: "https://www.MaxLeiter.com/test",
+			expected:
+				"<a href=\"https://www.MaxLeiter.com/test\" target=\"_blank\" rel=\"noopener\">" +
+					"https://www.MaxLeiter.com/test" +
+				"</a>",
+		},
+
+		];
+
+		const actual = testCases.map((testCase) => parse(testCase.input));
+		const expected = testCases.map((testCase) => testCase.expected);
+
+		expect(actual).to.deep.equal(expected);
+	});
+
 	it("should go bonkers like mirc", () => {
 		const testCases = [{
 			input: "\x02irc\x0f://\x1dfreenode.net\x0f/\x034,8thelounge",


### PR DESCRIPTION
Not sure how I like this. kiwi does it. Can disable in settings (but requires reload to change sent messages, which is fine imo). Setting probably needs better wording.

Should be good to go.

<img width="609" alt="screen shot 2017-11-14 at 6 50 54 pm" src="https://user-images.githubusercontent.com/8675906/32816349-08706980-c96d-11e7-9a6c-b02a94bb7e2c.png">

relies on #1712 


