### PR TITLE
Enforce dangling commas with ESLint

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -15,7 +15,9 @@ rules:
   block-scoped-var: error
   block-spacing: [error, always]
   brace-style: [error, 1tbs]
-  comma-dangle: off
+  comma-dangle:
+    - error
+    - always-multiline
   curly: [error, all]
   dot-location: [error, property]
   dot-notation: error

--- a/client/js/autocompletion.js
+++ b/client/js/autocompletion.js
@@ -26,7 +26,7 @@ const emojiStrategy = {
 	replace([, original]) {
 		return emojiMap[original];
 	},
-	index: 1
+	index: 1,
 };
 
 const nicksStrategy = {
@@ -41,13 +41,13 @@ const nicksStrategy = {
 			callback(completeNicks(term, true));
 		}
 	},
-	template([string, ]) {
+	template([string]) {
 		return string;
 	},
 	replace([, original]) {
 		return original;
 	},
-	index: 1
+	index: 1,
 };
 
 const chanStrategy = {
@@ -56,13 +56,13 @@ const chanStrategy = {
 	search(term, callback, match) {
 		callback(completeChans(match[0]));
 	},
-	template([string,]) {
+	template([string]) {
 		return string;
 	},
 	replace([, original]) {
 		return original;
 	},
-	index: 1
+	index: 1,
 };
 
 const commandStrategy = {
@@ -71,13 +71,13 @@ const commandStrategy = {
 	search(term, callback) {
 		callback(completeCommands("/" + term));
 	},
-	template([string, ]) {
+	template([string]) {
 		return string;
 	},
 	replace([, original]) {
 		return original;
 	},
-	index: 1
+	index: 1,
 };
 
 const foregroundColorStrategy = {
@@ -92,7 +92,7 @@ const foregroundColorStrategy = {
 				if (fuzzy.test(term, i[1])) {
 					return [i[0], fuzzy.match(term, i[1], {
 						pre: "<b>",
-						post: "</b>"
+						post: "</b>",
 					}).rendered];
 				}
 				return i;
@@ -106,7 +106,7 @@ const foregroundColorStrategy = {
 	replace(value) {
 		return "\x03" + value[0];
 	},
-	index: 1
+	index: 1,
 };
 
 const backgroundColorStrategy = {
@@ -120,7 +120,7 @@ const backgroundColorStrategy = {
 				if (fuzzy.test(term, pair[1])) {
 					return [pair[0], fuzzy.match(term, pair[1], {
 						pre: "<b>",
-						post: "</b>"
+						post: "</b>",
 					}).rendered];
 				}
 				return pair;
@@ -135,7 +135,7 @@ const backgroundColorStrategy = {
 	replace(value) {
 		return "\x03$1," + value[0];
 	},
-	index: 2
+	index: 2,
 };
 
 const input = $("#input")
@@ -151,17 +151,17 @@ if (options.autocomplete) {
 function enableAutocomplete() {
 	input.textcomplete([
 		emojiStrategy, nicksStrategy, chanStrategy, commandStrategy,
-		foregroundColorStrategy, backgroundColorStrategy
+		foregroundColorStrategy, backgroundColorStrategy,
 	], {
 		dropdownClassName: "textcomplete-menu",
-		placement: "top"
+		placement: "top",
 	}).on({
 		"textComplete:show": function() {
 			$(this).data("autocompleting", true);
 		},
 		"textComplete:hide": function() {
 			$(this).data("autocompleting", false);
-		}
+		},
 	});
 }
 
@@ -171,7 +171,7 @@ function fuzzyGrep(term, array) {
 		array,
 		{
 			pre: "<b>",
-			post: "</b>"
+			post: "</b>",
 		}
 	);
 	return results.map((el) => [el.string, el.original]);

--- a/client/js/condensed.js
+++ b/client/js/condensed.js
@@ -4,7 +4,7 @@ const constants = require("./constants");
 const templates = require("../views");
 
 module.exports = {
-	updateText
+	updateText,
 };
 
 function updateText(condensed, addedTypes) {

--- a/client/js/constants.js
+++ b/client/js/constants.js
@@ -65,7 +65,7 @@ const commands = [
 	"/topic",
 	"/unban",
 	"/voice",
-	"/whois"
+	"/whois",
 ];
 
 const actionTypes = [
@@ -100,7 +100,7 @@ const condensedTypes = [
 
 const timeFormats = {
 	msgDefault: "HH:mm",
-	msgWithSeconds: "HH:mm:ss"
+	msgWithSeconds: "HH:mm:ss",
 };
 
 module.exports = {
@@ -109,5 +109,5 @@ module.exports = {
 	condensedTypes: condensedTypes,
 	condensedTypesQuery: "." + condensedTypes.join(", ."),
 	actionTypes: actionTypes,
-	timeFormats: timeFormats
+	timeFormats: timeFormats,
 };

--- a/client/js/keybinds.js
+++ b/client/js/keybinds.js
@@ -9,7 +9,7 @@ const contextMenuContainer = $("#context-menu-container");
 
 Mousetrap.bind([
 	"pageup",
-	"pagedown"
+	"pagedown",
 ], function(e, key) {
 	let container = windows.find(".window.active");
 
@@ -30,7 +30,7 @@ Mousetrap.bind([
 	}
 
 	container.animate({
-		scrollTop: scrollTop
+		scrollTop: scrollTop,
 	}, 200);
 
 	return false;
@@ -40,7 +40,7 @@ Mousetrap.bind([
 	"command+up",
 	"command+down",
 	"ctrl+up",
-	"ctrl+down"
+	"ctrl+down",
 ], function(e, keys) {
 	const channels = sidebar.find(".chan");
 	const index = channels.index(channels.filter(".active"));
@@ -61,7 +61,7 @@ Mousetrap.bind([
 });
 
 Mousetrap.bind([
-	"escape"
+	"escape",
 ], function() {
 	contextMenuContainer.hide();
 });
@@ -77,7 +77,7 @@ const colorsHotkeys = {
 for (const hotkey in colorsHotkeys) {
 	Mousetrap.bind([
 		"command+" + hotkey,
-		"ctrl+" + hotkey
+		"ctrl+" + hotkey,
 	], function(e) {
 		e.preventDefault();
 

--- a/client/js/libs/handlebars/friendlydate.js
+++ b/client/js/libs/handlebars/friendlydate.js
@@ -8,6 +8,6 @@ module.exports = function(time) {
 		sameDay: "[Today]",
 		lastDay: "[Yesterday]",
 		lastWeek: "D MMMM YYYY",
-		sameElse: "D MMMM YYYY"
+		sameElse: "D MMMM YYYY",
 	});
 };

--- a/client/js/libs/handlebars/ircmessageparser/fill.js
+++ b/client/js/libs/handlebars/ircmessageparser/fill.js
@@ -13,7 +13,7 @@ function fill(existingEntries, text) {
 		if (textSegment.start > position) {
 			acc.push({
 				start: position,
-				end: textSegment.start
+				end: textSegment.start,
 			});
 		}
 		position = textSegment.end;
@@ -24,7 +24,7 @@ function fill(existingEntries, text) {
 	if (position < text.length) {
 		result.push({
 			start: position,
-			end: text.length
+			end: text.length,
 		});
 	}
 

--- a/client/js/libs/handlebars/ircmessageparser/findChannels.js
+++ b/client/js/libs/handlebars/ircmessageparser/findChannels.js
@@ -32,7 +32,7 @@ function findChannels(text, channelPrefixes, userModes) {
 			result.push({
 				start: match.index + match[0].length - match[1].length,
 				end: match.index + match[0].length,
-				channel: match[1]
+				channel: match[1],
 			});
 		}
 	} while (match);

--- a/client/js/libs/handlebars/ircmessageparser/findEmoji.js
+++ b/client/js/libs/handlebars/ircmessageparser/findEmoji.js
@@ -10,7 +10,7 @@ function findEmoji(text) {
 		result.push({
 			start: match.index,
 			end: match.index + match[0].length,
-			emoji: match[0]
+			emoji: match[0],
 		});
 	}
 

--- a/client/js/libs/handlebars/ircmessageparser/findLinks.js
+++ b/client/js/libs/handlebars/ircmessageparser/findLinks.js
@@ -55,7 +55,7 @@ function findLinks(text) {
 			result.push({
 				start: start,
 				end: end,
-				link: url
+				link: url,
 			});
 		});
 	} catch (e) {

--- a/client/js/libs/handlebars/ircmessageparser/merge.js
+++ b/client/js/libs/handlebars/ircmessageparser/merge.js
@@ -25,7 +25,7 @@ function assign(textPart, fragment) {
 	return Object_assign({}, fragment, {
 		start: start,
 		end: end,
-		text: fragment.text.slice(start - fragStart, end - fragStart)
+		text: fragment.text.slice(start - fragStart, end - fragStart),
 	});
 }
 

--- a/client/js/libs/handlebars/ircmessageparser/parseStyle.js
+++ b/client/js/libs/handlebars/ircmessageparser/parseStyle.js
@@ -70,7 +70,7 @@ function parseStyle(text) {
 				underline,
 				text: processedText,
 				start: fragmentStart,
-				end: fragmentStart + processedText.length
+				end: fragmentStart + processedText.length,
 			});
 		}
 

--- a/client/js/libs/handlebars/modes.js
+++ b/client/js/libs/handlebars/modes.js
@@ -8,7 +8,7 @@ module.exports = function(mode) {
 		"@": "op",
 		"%": "half-op",
 		"+": "voice",
-		"": "normal"
+		"": "normal",
 	};
 	return modes[mode];
 };

--- a/client/js/libs/slideout.js
+++ b/client/js/libs/slideout.js
@@ -98,6 +98,6 @@ module.exports = function slideoutMenu(viewport, menu) {
 		toggle: toggleMenu,
 		isOpen: function() {
 			return menuIsOpen;
-		}
+		},
 	};
 };

--- a/client/js/localStorage.js
+++ b/client/js/localStorage.js
@@ -15,5 +15,5 @@ module.exports = {
 	},
 	remove: function(key, value) {
 		window.localStorage.removeItem(key, value);
-	}
+	},
 };

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -82,19 +82,19 @@ $(function() {
 			output = templates.contextmenu_item({
 				class: "user",
 				text: target.text(),
-				data: target.data("name")
+				data: target.data("name"),
 			});
 		} else if (target.hasClass("chan")) {
 			output = templates.contextmenu_item({
 				class: "chan",
 				text: target.data("title"),
-				data: target.data("target")
+				data: target.data("target"),
 			});
 			output += templates.contextmenu_divider();
 			output += templates.contextmenu_item({
 				class: "close",
 				text: target.hasClass("lobby") ? "Disconnect" : target.hasClass("channel") ? "Leave" : "Close",
-				data: target.data("target")
+				data: target.data("target"),
 			});
 		}
 
@@ -196,7 +196,7 @@ $(function() {
 
 		socket.emit("input", {
 			target: chat.data("id"),
-			text: text
+			text: text,
 		});
 	});
 
@@ -240,7 +240,7 @@ $(function() {
 
 		socket.emit("input", {
 			target: chat.data("id"),
-			text: "/nick " + newNick
+			text: "/nick " + newNick,
 		});
 	}
 
@@ -275,7 +275,7 @@ $(function() {
 		} else {
 			socket.emit("input", {
 				target: chat.data("id"),
-				text: "/join " + name
+				text: "/join " + name,
 			});
 		}
 	});
@@ -294,7 +294,7 @@ $(function() {
 
 		socket.emit("input", {
 			target: chat.data("id"),
-			text: "/whois " + name
+			text: "/whois " + name,
 		});
 	});
 
@@ -434,11 +434,11 @@ $(function() {
 		}
 		socket.emit("input", {
 			target: chan.data("id"),
-			text: cmd
+			text: cmd,
 		});
 		chan.css({
 			transition: "none",
-			opacity: 0.4
+			opacity: 0.4,
 		});
 		return false;
 	});
@@ -472,7 +472,7 @@ $(function() {
 		const fuzzyOptions = {
 			pre: "<b>",
 			post: "</b>",
-			extract: (el) => $(el).text()
+			extract: (el) => $(el).text(),
 		};
 
 		const result = fuzzy.filter(
@@ -620,7 +620,7 @@ $(function() {
 			// Emit the click to the target, while making sure it is not going to be
 			// added to the state again.
 			$(clickTarget).trigger("click", {
-				pushState: false
+				pushState: false,
 			});
 		}
 	});

--- a/client/js/render.js
+++ b/client/js/render.js
@@ -17,7 +17,7 @@ require("intersection-observer");
 
 const historyObserver = window.IntersectionObserver ?
 	new window.IntersectionObserver(loadMoreHistory, {
-		root: chat.get(0)
+		root: chat.get(0),
 	}) : null;
 
 module.exports = {
@@ -175,7 +175,7 @@ function renderNetworks(data, singleNetwork) {
 	sidebar.find(".empty").hide();
 	sidebar.find(".networks").append(
 		templates.network({
-			networks: data.networks
+			networks: data.networks,
 		})
 	);
 
@@ -222,7 +222,7 @@ function renderNetworks(data, singleNetwork) {
 
 	chat.append(
 		templates.chat({
-			channels: channels
+			channels: channels,
 		})
 	);
 

--- a/client/js/socket-events/init.js
+++ b/client/js/socket-events/init.js
@@ -75,7 +75,7 @@ function openCorrectChannel(clientActive, serverActive) {
 	// If target channel is found, open it
 	if (target.length > 0) {
 		target.trigger("click", {
-			replaceHistory: true
+			replaceHistory: true,
 		});
 
 		return;
@@ -83,6 +83,6 @@ function openCorrectChannel(clientActive, serverActive) {
 
 	// Open the connect window
 	$("#footer .connect").trigger("click", {
-		pushState: false
+		pushState: false,
 	});
 }

--- a/client/js/socket-events/join.js
+++ b/client/js/socket-events/join.js
@@ -12,12 +12,12 @@ socket.on("join", function(data) {
 	const network = sidebar.find("#network-" + id);
 	network.append(
 		templates.chan({
-			channels: [data.chan]
+			channels: [data.chan],
 		})
 	);
 	chat.append(
 		templates.chat({
-			channels: [data.chan]
+			channels: [data.chan],
 		})
 	);
 	render.renderChannel(data.chan);

--- a/client/js/socket-events/more.js
+++ b/client/js/socket-events/more.js
@@ -92,6 +92,6 @@ chat.on("click", ".show-more-button", function() {
 
 	socket.emit("more", {
 		target: self.data("id"),
-		lastId: lastMessageId
+		lastId: lastMessageId,
 	});
 });

--- a/client/js/socket-events/msg.js
+++ b/client/js/socket-events/msg.js
@@ -15,7 +15,7 @@ try {
 	pop.src = "audio/pop.ogg";
 } catch (e) {
 	pop = {
-		play: $.noop
+		play: $.noop,
 	};
 }
 
@@ -134,7 +134,7 @@ function notifyMessage(targetId, channel, msg) {
 					const notify = new Notification(title, {
 						body: body,
 						icon: "img/logo-64.png",
-						tag: `lounge-${targetId}`
+						tag: `lounge-${targetId}`,
 					});
 					notify.addEventListener("click", function() {
 						window.focus();

--- a/client/js/socket-events/users.js
+++ b/client/js/socket-events/users.js
@@ -9,7 +9,7 @@ socket.on("users", function(data) {
 
 	if (chan.hasClass("active")) {
 		socket.emit("names", {
-			target: data.chan
+			target: data.chan,
 		});
 	} else {
 		chan.data("needsNamesRefresh", true);

--- a/client/js/socket.js
+++ b/client/js/socket.js
@@ -10,7 +10,7 @@ const socket = io({
 	transports: $(document.body).data("transports"),
 	path: path,
 	autoConnect: false,
-	reconnection: !$(document.body).hasClass("public")
+	reconnection: !$(document.body).hasClass("public"),
 });
 
 socket.on("disconnect", handleDisconnect);

--- a/client/js/sorting.js
+++ b/client/js/sorting.js
@@ -26,12 +26,12 @@ module.exports = function() {
 			socket.emit(
 				"sort", {
 					type: "networks",
-					order: order
+					order: order,
 				}
 			);
 
 			options.ignoreSortSync = true;
-		}
+		},
 	});
 	sidebar.find(".network").sortable({
 		axis: "y",
@@ -54,11 +54,11 @@ module.exports = function() {
 				"sort", {
 					type: "channels",
 					target: network.data("id"),
-					order: order
+					order: order,
 				}
 			);
 
 			options.ignoreSortSync = true;
-		}
+		},
 	});
 };

--- a/client/js/webpush.js
+++ b/client/js/webpush.js
@@ -68,7 +68,7 @@ function onPushButton() {
 
 			return registration.pushManager.subscribe({
 				applicationServerKey: urlBase64ToUint8Array(applicationServerKey),
-				userVisibleOnly: true
+				userVisibleOnly: true,
 			}).then((subscription) => {
 				const rawKey = subscription.getKey ? subscription.getKey("p256dh") : "";
 				const key = rawKey ? window.btoa(String.fromCharCode.apply(null, new Uint8Array(rawKey))) : "";
@@ -80,8 +80,8 @@ function onPushButton() {
 					endpoint: subscription.endpoint,
 					keys: {
 						p256dh: key,
-						auth: authSecret
-					}
+						auth: authSecret,
+					},
 				});
 
 				return true;

--- a/client/service-worker.js
+++ b/client/service-worker.js
@@ -17,7 +17,7 @@ self.addEventListener("push", function(event) {
 	event.waitUntil(
 		self.registration
 			.getNotifications({
-				tag: `chan-${payload.chanId}`
+				tag: `chan-${payload.chanId}`,
 			})
 			.then((notifications) => {
 				for (const notification of notifications) {
@@ -39,7 +39,7 @@ self.addEventListener("notificationclick", function(event) {
 	event.notification.close();
 
 	event.waitUntil(clients.matchAll({
-		type: "window"
+		type: "window",
 	}).then(function(clientList) {
 		for (var i = 0; i < clientList.length; i++) {
 			var client = clientList[i];

--- a/defaults/config.js
+++ b/defaults/config.js
@@ -172,7 +172,7 @@ module.exports = {
 		// @type     string
 		// @default  "UTC+00:00"
 		//
-		timezone: "UTC+00:00"
+		timezone: "UTC+00:00",
 	},
 
 	//
@@ -264,7 +264,7 @@ module.exports = {
 		// @type     string
 		// @default  "#thelounge"
 		//
-		join: "#thelounge"
+		join: "#thelounge",
 	},
 
 	//
@@ -316,7 +316,7 @@ module.exports = {
 		// @example  "sslcert/bundle.pem"
 		// @default  ""
 		//
-		ca: ""
+		ca: "",
 	},
 
 	//
@@ -348,7 +348,7 @@ module.exports = {
 		// @type     int
 		// @default  113
 		//
-		port: 113
+		port: 113,
 	},
 
 	//
@@ -482,9 +482,9 @@ module.exports = {
 			// @type     string
 			// @default  "sub"
 			//
-			scope: "sub"
+			scope: "sub",
 
-		}
+		},
 	},
 
 	// Extra debugging

--- a/src/client.js
+++ b/src/client.js
@@ -34,7 +34,7 @@ var events = [
 	"topic",
 	"welcome",
 	"list",
-	"whois"
+	"whois",
 ];
 var inputs = [
 	"ban",
@@ -56,7 +56,7 @@ var inputs = [
 	"raw",
 	"topic",
 	"list",
-	"whois"
+	"whois",
 ].reduce(function(plugins, name) {
 	var path = "./plugins/inputs/" + name;
 	var plugin = require(path);
@@ -78,7 +78,7 @@ function Client(manager, name, config) {
 		name: name,
 		networks: [],
 		sockets: manager.sockets,
-		manager: manager
+		manager: manager,
 	});
 
 	var client = this;
@@ -130,7 +130,7 @@ Client.prototype.find = function(channelId) {
 	if (network && chan) {
 		return {
 			network: network,
-			chan: chan
+			chan: chan,
 		};
 	}
 
@@ -171,7 +171,7 @@ Client.prototype.connect = function(args) {
 			.split(/\s+/g)
 			.map(function(chan) {
 				return new Chan({
-					name: chan
+					name: chan,
 				});
 			});
 	}
@@ -196,7 +196,7 @@ Client.prototype.connect = function(args) {
 
 	client.networks.push(network);
 	client.emit("network", {
-		networks: [network]
+		networks: [network],
 	});
 
 	if (config.lockNetwork) {
@@ -204,7 +204,7 @@ Client.prototype.connect = function(args) {
 		if (args.host && args.host.length > 0 && args.host !== config.defaults.host) {
 			network.channels[0].pushMessage(client, new Msg({
 				type: Msg.Type.ERROR,
-				text: "Hostname you specified is not allowed."
+				text: "Hostname you specified is not allowed.",
 			}), true);
 			return;
 		}
@@ -217,7 +217,7 @@ Client.prototype.connect = function(args) {
 	if (network.host.length === 0) {
 		network.channels[0].pushMessage(client, new Msg({
 			type: Msg.Type.ERROR,
-			text: "You must specify a hostname to connect."
+			text: "You must specify a hostname to connect.",
 		}), true);
 		return;
 	}
@@ -235,7 +235,7 @@ Client.prototype.connect = function(args) {
 					password: config.webirc[network.host],
 					username: pkg.name,
 					address: args.ip,
-					hostname: args.hostname
+					hostname: args.hostname,
 				};
 			}
 		} else {
@@ -270,7 +270,7 @@ Client.prototype.connect = function(args) {
 		var path = "./plugins/irc-events/" + plugin;
 		require(path).apply(client, [
 			network.irc,
-			network
+			network,
 		]);
 	});
 
@@ -311,7 +311,7 @@ Client.prototype.updateSession = function(token, ip, request) {
 	});
 
 	client.manager.updateUser(client.name, {
-		sessions: client.config.sessions
+		sessions: client.config.sessions,
 	});
 };
 
@@ -319,7 +319,7 @@ Client.prototype.setPassword = function(hash, callback) {
 	var client = this;
 
 	client.manager.updateUser(client.name, {
-		password: hash
+		password: hash,
 	}, function(err) {
 		if (err) {
 			return callback(false);
@@ -355,7 +355,7 @@ Client.prototype.inputLine = function(data) {
 		if (target.chan.type === Chan.Type.LOBBY) {
 			target.chan.pushMessage(this, new Msg({
 				type: Msg.Type.ERROR,
-				text: "Messages can not be sent to lobbies."
+				text: "Messages can not be sent to lobbies.",
 			}));
 			return;
 		}
@@ -384,7 +384,7 @@ Client.prototype.inputLine = function(data) {
 	if (!connected) {
 		target.chan.pushMessage(this, new Msg({
 			type: Msg.Type.ERROR,
-			text: "You are not connected to the IRC network, unable to send your command."
+			text: "You are not connected to the IRC network, unable to send your command.",
 		}));
 	}
 };
@@ -415,7 +415,7 @@ Client.prototype.more = function(data) {
 
 	client.emit("more", {
 		chan: chan.id,
-		messages: messages
+		messages: messages,
 	});
 };
 
@@ -483,7 +483,7 @@ Client.prototype.names = function(data) {
 
 	client.emit("names", {
 		id: target.chan.id,
-		users: target.chan.users
+		users: target.chan.users,
 	});
 };
 
@@ -530,7 +530,7 @@ Client.prototype.clientAttach = function(socketId, token) {
 
 	client.attachedClients[socketId] = {
 		token: token,
-		openChannel: client.lastActiveChannel
+		openChannel: client.lastActiveChannel,
 	};
 
 	// Update old networks to store ip and hostmask
@@ -583,15 +583,15 @@ Client.prototype.registerPushSubscription = function(session, subscription, noSa
 		endpoint: subscription.endpoint,
 		keys: {
 			p256dh: subscription.keys.p256dh,
-			auth: subscription.keys.auth
-		}
+			auth: subscription.keys.auth,
+		},
 	};
 
 	session.pushSubscription = data;
 
 	if (!noSave) {
 		this.manager.updateUser(this.name, {
-			sessions: this.config.sessions
+			sessions: this.config.sessions,
 		});
 	}
 
@@ -601,7 +601,7 @@ Client.prototype.registerPushSubscription = function(session, subscription, noSa
 Client.prototype.unregisterPushSubscription = function(token) {
 	this.config.sessions[token].pushSubscription = null;
 	this.manager.updateUser(this.name, {
-		sessions: this.config.sessions
+		sessions: this.config.sessions,
 	});
 };
 

--- a/src/command-line/add.js
+++ b/src/command-line/add.js
@@ -36,7 +36,7 @@ program
 
 		log.prompt({
 			text: "Enter password:",
-			silent: true
+			silent: true,
 		}, function(err, password) {
 			if (!password) {
 				log.error("Password cannot be empty.");
@@ -45,7 +45,7 @@ program
 			if (!err) {
 				log.prompt({
 					text: "Save logs to disk?",
-					default: "yes"
+					default: "yes",
 				}, function(err2, enableLog) {
 					if (!err2) {
 						add(

--- a/src/command-line/install.js
+++ b/src/command-line/install.js
@@ -24,7 +24,7 @@ program
 		log.info("Retrieving information about the package...");
 
 		packageJson(packageName, {
-			fullMetadata: true
+			fullMetadata: true,
 		}).then((json) => {
 			if (!("thelounge" in json)) {
 				log.error(`${colors.red(packageName)} does not have The Lounge metadata.`);
@@ -57,10 +57,10 @@ program
 					"--no-package-lock",
 					"--prefix",
 					packagesParent,
-					packageName
+					packageName,
 				],
 				{
-					stdio: "inherit"
+					stdio: "inherit",
 				}
 			);
 

--- a/src/command-line/reset.js
+++ b/src/command-line/reset.js
@@ -32,7 +32,7 @@ program
 		var user = require(file);
 		log.prompt({
 			text: "Enter new password:",
-			silent: true
+			silent: true,
 		}, function(err, password) {
 			if (err) {
 				return;

--- a/src/models/chan.js
+++ b/src/models/chan.js
@@ -28,7 +28,7 @@ function Chan(attr) {
 		firstUnread: 0,
 		unread: 0,
 		highlight: 0,
-		users: []
+		users: [],
 	});
 }
 
@@ -39,7 +39,7 @@ Chan.prototype.destroy = function() {
 Chan.prototype.pushMessage = function(client, msg, increasesUnread) {
 	var obj = {
 		chan: this.id,
-		msg: msg
+		msg: msg,
 	};
 
 	// If this channel is open in any of the clients, do not increase unread counter

--- a/src/models/msg.js
+++ b/src/models/msg.js
@@ -12,7 +12,7 @@ class Msg {
 			previews: [],
 			text: "",
 			type: Msg.Type.MESSAGE,
-			self: false
+			self: false,
 		});
 
 		if (this.time > 0) {
@@ -47,7 +47,7 @@ Msg.Type = {
 	TOPIC: "topic",
 	TOPIC_SET_BY: "topic_set_by",
 	WHOIS: "whois",
-	BANLIST: "ban_list"
+	BANLIST: "ban_list",
 };
 
 module.exports = Msg;

--- a/src/models/network.js
+++ b/src/models/network.js
@@ -37,7 +37,7 @@ function Network(attr) {
 	this.channels.unshift(
 		new Chan({
 			name: this.name,
-			type: Chan.Type.LOBBY
+			type: Chan.Type.LOBBY,
 		})
 	);
 }
@@ -86,7 +86,7 @@ Network.prototype.export = function() {
 		"realname",
 		"commands",
 		"ip",
-		"hostname"
+		"hostname",
 	]);
 
 	network.channels = this.channels

--- a/src/plugins/auth/ldap.js
+++ b/src/plugins/auth/ldap.js
@@ -8,7 +8,7 @@ function ldapAuthCommon(user, bindDN, password, callback) {
 
 	const ldapclient = ldap.createClient({
 		url: config.ldap.url,
-		tlsOptions: config.ldap.tlsOptions
+		tlsOptions: config.ldap.tlsOptions,
 	});
 
 	ldapclient.on("error", function(err) {
@@ -50,14 +50,14 @@ function advancedLdapAuth(user, password, callback) {
 
 	const ldapclient = ldap.createClient({
 		url: config.ldap.url,
-		tlsOptions: config.ldap.tlsOptions
+		tlsOptions: config.ldap.tlsOptions,
 	});
 
 	const base = config.ldap.searchDN.base;
 	const searchOptions = {
 		scope: config.ldap.searchDN.scope,
 		filter: `(&(${config.ldap.primaryKey}=${userDN})${config.ldap.searchDN.filter})`,
-		attributes: ["dn"]
+		attributes: ["dn"],
 	};
 
 	ldapclient.on("error", function(err) {
@@ -129,5 +129,5 @@ function isLdapEnabled() {
 
 module.exports = {
 	auth: ldapAuth,
-	isEnabled: isLdapEnabled
+	isEnabled: isLdapEnabled,
 };

--- a/src/plugins/auth/local.js
+++ b/src/plugins/auth/local.js
@@ -37,6 +37,6 @@ function localAuth(manager, client, user, password, callback) {
 
 module.exports = {
 	auth: localAuth,
-	isEnabled: () => true
+	isEnabled: () => true,
 };
 

--- a/src/plugins/inputs/action.js
+++ b/src/plugins/inputs/action.js
@@ -9,7 +9,7 @@ exports.input = function(network, chan, cmd, args) {
 	if (chan.type !== Chan.Type.CHANNEL && chan.type !== Chan.Type.QUERY) {
 		chan.pushMessage(this, new Msg({
 			type: Msg.Type.ERROR,
-			text: `${cmd} command can only be used in channels and queries.`
+			text: `${cmd} command can only be used in channels and queries.`,
 		}));
 
 		return;
@@ -35,7 +35,7 @@ exports.input = function(network, chan, cmd, args) {
 			irc.emit("action", {
 				nick: irc.user.nick,
 				target: chan.name,
-				message: text
+				message: text,
 			});
 		}
 

--- a/src/plugins/inputs/ban.js
+++ b/src/plugins/inputs/ban.js
@@ -6,14 +6,14 @@ var Msg = require("../../models/msg");
 exports.commands = [
 	"ban",
 	"unban",
-	"banlist"
+	"banlist",
 ];
 
 exports.input = function(network, chan, cmd, args) {
 	if (chan.type !== Chan.Type.CHANNEL) {
 		chan.pushMessage(this, new Msg({
 			type: Msg.Type.ERROR,
-			text: `${cmd} command can only be used in channels.`
+			text: `${cmd} command can only be used in channels.`,
 		}));
 
 		return;
@@ -23,7 +23,7 @@ exports.input = function(network, chan, cmd, args) {
 		if (args.length === 0) {
 			chan.pushMessage(this, new Msg({
 				type: Msg.Type.ERROR,
-				text: `Usage: /${cmd} <nick>`
+				text: `Usage: /${cmd} <nick>`,
 			}));
 
 			return;

--- a/src/plugins/inputs/connect.js
+++ b/src/plugins/inputs/connect.js
@@ -14,7 +14,7 @@ exports.input = function(network, chan, cmd, args) {
 		if (network.irc.connection.connected) {
 			chan.pushMessage(this, new Msg({
 				type: Msg.Type.ERROR,
-				text: "You are already connected."
+				text: "You are already connected.",
 			}));
 			return;
 		}

--- a/src/plugins/inputs/invite.js
+++ b/src/plugins/inputs/invite.js
@@ -15,7 +15,7 @@ exports.input = function(network, chan, cmd, args) {
 	} else {
 		chan.pushMessage(this, new Msg({
 			type: Msg.Type.ERROR,
-			text: `${cmd} command can only be used in channels or by specifying a target.`
+			text: `${cmd} command can only be used in channels or by specifying a target.`,
 		}));
 	}
 };

--- a/src/plugins/inputs/kick.js
+++ b/src/plugins/inputs/kick.js
@@ -9,7 +9,7 @@ exports.input = function(network, chan, cmd, args) {
 	if (chan.type !== Chan.Type.CHANNEL) {
 		chan.pushMessage(this, new Msg({
 			type: Msg.Type.ERROR,
-			text: `${cmd} command can only be used in channels.`
+			text: `${cmd} command can only be used in channels.`,
 		}));
 
 		return;

--- a/src/plugins/inputs/mode.js
+++ b/src/plugins/inputs/mode.js
@@ -18,7 +18,7 @@ exports.input = function(network, chan, cmd, args) {
 		if (chan.type !== Chan.Type.CHANNEL) {
 			chan.pushMessage(this, new Msg({
 				type: Msg.Type.ERROR,
-				text: `${cmd} command can only be used in channels.`
+				text: `${cmd} command can only be used in channels.`,
 			}));
 
 			return;
@@ -27,7 +27,7 @@ exports.input = function(network, chan, cmd, args) {
 		if (args.length === 0) {
 			chan.pushMessage(this, new Msg({
 				type: Msg.Type.ERROR,
-				text: `Usage: /${cmd} <nick> [...nick]`
+				text: `Usage: /${cmd} <nick> [...nick]`,
 			}));
 
 			return;
@@ -39,7 +39,7 @@ exports.input = function(network, chan, cmd, args) {
 			voice: "+v",
 			deop: "-o",
 			dehop: "-h",
-			devoice: "-v"
+			devoice: "-v",
 		}[cmd];
 
 		args.forEach(function(target) {

--- a/src/plugins/inputs/msg.js
+++ b/src/plugins/inputs/msg.js
@@ -24,7 +24,7 @@ exports.input = function(network, chan, cmd, args) {
 			irc.emit("privmsg", {
 				nick: irc.user.nick,
 				target: channel.name,
-				message: msg
+				message: msg,
 			});
 		}
 	}

--- a/src/plugins/inputs/nick.js
+++ b/src/plugins/inputs/nick.js
@@ -9,7 +9,7 @@ exports.input = function(network, chan, cmd, args) {
 	if (args.length === 0) {
 		chan.pushMessage(this, new Msg({
 			type: Msg.Type.ERROR,
-			text: "Usage: /nick <your new nick>"
+			text: "Usage: /nick <your new nick>",
 		}));
 		return;
 	}
@@ -17,7 +17,7 @@ exports.input = function(network, chan, cmd, args) {
 	if (args.length !== 1) {
 		chan.pushMessage(this, new Msg({
 			type: Msg.Type.ERROR,
-			text: "Nicknames may not contain spaces."
+			text: "Nicknames may not contain spaces.",
 		}));
 		return;
 	}
@@ -33,7 +33,7 @@ exports.input = function(network, chan, cmd, args) {
 
 		this.emit("nick", {
 			network: network.id,
-			nick: newNick
+			nick: newNick,
 		});
 	}
 };

--- a/src/plugins/inputs/notice.js
+++ b/src/plugins/inputs/notice.js
@@ -21,7 +21,7 @@ exports.input = function(network, chan, cmd, args) {
 		irc.emit("notice", {
 			nick: irc.user.nick,
 			target: targetChan.name,
-			message: message
+			message: message,
 		});
 	}
 

--- a/src/plugins/inputs/part.js
+++ b/src/plugins/inputs/part.js
@@ -22,7 +22,7 @@ exports.input = function(network, chan, cmd, args) {
 	if (target.type === Chan.Type.LOBBY) {
 		chan.pushMessage(this, new Msg({
 			type: Msg.Type.ERROR,
-			text: "You can not part from networks, use /quit instead."
+			text: "You can not part from networks, use /quit instead.",
 		}));
 		return;
 	}
@@ -30,7 +30,7 @@ exports.input = function(network, chan, cmd, args) {
 	network.channels = _.without(network.channels, target);
 	target.destroy();
 	this.emit("part", {
-		chan: target.id
+		chan: target.id,
 	});
 
 	if (target.type === Chan.Type.CHANNEL) {

--- a/src/plugins/inputs/query.js
+++ b/src/plugins/inputs/query.js
@@ -21,7 +21,7 @@ exports.input = function(network, chan, cmd, args) {
 	if (network.irc.network.options.CHANTYPES && network.irc.network.options.CHANTYPES.indexOf(char) !== -1) {
 		chan.pushMessage(this, new Msg({
 			type: Msg.Type.ERROR,
-			text: "You can not open query windows for channels, use /join instead."
+			text: "You can not open query windows for channels, use /join instead.",
 		}));
 		return;
 	}
@@ -30,7 +30,7 @@ exports.input = function(network, chan, cmd, args) {
 		if (network.irc.network.options.PREFIX[i].symbol === char) {
 			chan.pushMessage(this, new Msg({
 				type: Msg.Type.ERROR,
-				text: "You can not open query windows for names starting with a user prefix."
+				text: "You can not open query windows for names starting with a user prefix.",
 			}));
 			return;
 		}
@@ -38,11 +38,11 @@ exports.input = function(network, chan, cmd, args) {
 
 	var newChan = new Chan({
 		type: Chan.Type.QUERY,
-		name: target
+		name: target,
 	});
 	network.channels.push(newChan);
 	this.emit("join", {
 		network: network.id,
-		chan: newChan
+		chan: newChan,
 	});
 };

--- a/src/plugins/inputs/quit.js
+++ b/src/plugins/inputs/quit.js
@@ -13,7 +13,7 @@ exports.input = function(network, chan, cmd, args) {
 	network.destroy();
 	client.save();
 	client.emit("quit", {
-		network: network.id
+		network: network.id,
 	});
 
 	if (network.irc) {

--- a/src/plugins/inputs/rejoin.js
+++ b/src/plugins/inputs/rejoin.js
@@ -9,7 +9,7 @@ exports.input = function(network, chan) {
 	if (chan.type !== Chan.Type.CHANNEL) {
 		chan.pushMessage(this, new Msg({
 			type: Msg.Type.ERROR,
-			text: "You can only rejoin channels."
+			text: "You can only rejoin channels.",
 		}));
 		return;
 	}

--- a/src/plugins/inputs/topic.js
+++ b/src/plugins/inputs/topic.js
@@ -9,7 +9,7 @@ exports.input = function(network, chan, cmd, args) {
 	if (chan.type !== Chan.Type.CHANNEL) {
 		chan.pushMessage(this, new Msg({
 			type: Msg.Type.ERROR,
-			text: `${cmd} command can only be used in channels.`
+			text: `${cmd} command can only be used in channels.`,
 		}));
 
 		return;

--- a/src/plugins/irc-events/away.js
+++ b/src/plugins/irc-events/away.js
@@ -20,7 +20,7 @@ module.exports = function(irc, network) {
 				text: away || "",
 				time: data.time,
 				from: data.nick,
-				mode: user.mode
+				mode: user.mode,
 			});
 
 			chan.pushMessage(client, msg);

--- a/src/plugins/irc-events/banlist.js
+++ b/src/plugins/irc-events/banlist.js
@@ -13,7 +13,7 @@ module.exports = function(irc, network) {
 			const msg = new Msg({
 				time: Date.now(),
 				type: Msg.Type.ERROR,
-				text: "Banlist empty"
+				text: "Banlist empty",
 			});
 			network.getChannel(channel).pushMessage(client, msg, true);
 			return;
@@ -24,12 +24,12 @@ module.exports = function(irc, network) {
 		if (typeof chan === "undefined") {
 			chan = new Chan({
 				type: Chan.Type.SPECIAL,
-				name: chanName
+				name: chanName,
 			});
 			network.channels.push(chan);
 			client.emit("join", {
 				network: network.id,
-				chan: chan
+				chan: chan,
 			});
 		}
 
@@ -39,8 +39,8 @@ module.exports = function(irc, network) {
 				bans: bans.map((data) => ({
 					hostmask: data.banned,
 					banned_by: data.banned_by,
-					banned_at: data.banned_at * 1000
-				}))
+					banned_at: data.banned_at * 1000,
+				})),
 			}),
 			true
 		);

--- a/src/plugins/irc-events/connection.js
+++ b/src/plugins/irc-events/connection.js
@@ -9,13 +9,13 @@ module.exports = function(irc, network) {
 	var client = this;
 
 	network.channels[0].pushMessage(client, new Msg({
-		text: "Network created, connecting to " + network.host + ":" + network.port + "..."
+		text: "Network created, connecting to " + network.host + ":" + network.port + "...",
 	}), true);
 
 	irc.on("registered", function() {
 		if (network.irc.network.cap.enabled.length > 0) {
 			network.channels[0].pushMessage(client, new Msg({
-				text: "Enabled capabilities: " + network.irc.network.cap.enabled.join(", ")
+				text: "Enabled capabilities: " + network.irc.network.cap.enabled.join(", "),
 			}), true);
 		}
 
@@ -34,7 +34,7 @@ module.exports = function(irc, network) {
 				setTimeout(function() {
 					client.input({
 						target: network.channels[0].id,
-						text: cmd
+						text: cmd,
 					});
 				}, delay);
 				delay += 1000;
@@ -60,13 +60,13 @@ module.exports = function(irc, network) {
 		});
 
 		network.channels[0].pushMessage(client, new Msg({
-			text: "Connected to the network."
+			text: "Connected to the network.",
 		}), true);
 	});
 
 	irc.on("close", function() {
 		network.channels[0].pushMessage(client, new Msg({
-			text: "Disconnected from the network, and will not reconnect. Use /connect to reconnect again."
+			text: "Disconnected from the network, and will not reconnect. Use /connect to reconnect again.",
 		}), true);
 	});
 
@@ -95,7 +95,7 @@ module.exports = function(irc, network) {
 				from: message.from_server ? "«" : "»",
 				self: !message.from_server,
 				type: "raw",
-				text: message.line
+				text: message.line,
 			}), true);
 		});
 	}
@@ -103,19 +103,19 @@ module.exports = function(irc, network) {
 	irc.on("socket error", function(err) {
 		network.channels[0].pushMessage(client, new Msg({
 			type: Msg.Type.ERROR,
-			text: "Socket error: " + err
+			text: "Socket error: " + err,
 		}), true);
 	});
 
 	irc.on("reconnecting", function(data) {
 		network.channels[0].pushMessage(client, new Msg({
-			text: "Disconnected from the network. Reconnecting in " + Math.round(data.wait / 1000) + " seconds… (Attempt " + data.attempt + " of " + data.max_retries + ")"
+			text: "Disconnected from the network. Reconnecting in " + Math.round(data.wait / 1000) + " seconds… (Attempt " + data.attempt + " of " + data.max_retries + ")",
 		}), true);
 	});
 
 	irc.on("ping timeout", function() {
 		network.channels[0].pushMessage(client, new Msg({
-			text: "Ping timeout, disconnecting…"
+			text: "Ping timeout, disconnecting…",
 		}), true);
 	});
 
@@ -135,7 +135,7 @@ module.exports = function(irc, network) {
 
 		client.emit("network_changed", {
 			network: network.id,
-			serverOptions: network.serverOptions
+			serverOptions: network.serverOptions,
 		});
 	});
 };

--- a/src/plugins/irc-events/ctcp.js
+++ b/src/plugins/irc-events/ctcp.js
@@ -16,7 +16,7 @@ module.exports = function(irc, network) {
 			time: data.time,
 			from: data.nick,
 			ctcpType: data.type,
-			ctcpMessage: data.message
+			ctcpMessage: data.message,
 		});
 		chan.pushMessage(client, msg);
 	});

--- a/src/plugins/irc-events/error.js
+++ b/src/plugins/irc-events/error.js
@@ -33,7 +33,7 @@ module.exports = function(irc, network) {
 
 		client.emit("nick", {
 			network: network.id,
-			nick: irc.user.nick
+			nick: irc.user.nick,
 		});
 	});
 
@@ -52,7 +52,7 @@ module.exports = function(irc, network) {
 
 		client.emit("nick", {
 			network: network.id,
-			nick: irc.user.nick
+			nick: irc.user.nick,
 		});
 	});
 };

--- a/src/plugins/irc-events/invite.js
+++ b/src/plugins/irc-events/invite.js
@@ -17,7 +17,7 @@ module.exports = function(irc, network) {
 			invited: data.invited,
 			channel: data.channel,
 			highlight: true,
-			invitedYou: data.invited === irc.user.nick
+			invitedYou: data.invited === irc.user.nick,
 		});
 		chan.pushMessage(client, msg);
 	});

--- a/src/plugins/irc-events/join.js
+++ b/src/plugins/irc-events/join.js
@@ -10,13 +10,13 @@ module.exports = function(irc, network) {
 		var chan = network.getChannel(data.channel);
 		if (typeof chan === "undefined") {
 			chan = new Chan({
-				name: data.channel
+				name: data.channel,
 			});
 			network.channels.push(chan);
 			client.save();
 			client.emit("join", {
 				network: network.id,
-				chan: chan
+				chan: chan,
 			});
 
 			// Request channels' modes
@@ -25,14 +25,14 @@ module.exports = function(irc, network) {
 		chan.users.push(new User({nick: data.nick}));
 		chan.sortUsers(irc);
 		client.emit("users", {
-			chan: chan.id
+			chan: chan.id,
 		});
 		var msg = new Msg({
 			time: data.time,
 			from: data.nick,
 			hostmask: data.ident + "@" + data.hostname,
 			type: Msg.Type.JOIN,
-			self: data.nick === irc.user.nick
+			self: data.nick === irc.user.nick,
 		});
 		chan.pushMessage(client, msg);
 	});

--- a/src/plugins/irc-events/kick.js
+++ b/src/plugins/irc-events/kick.js
@@ -21,7 +21,7 @@ module.exports = function(irc, network) {
 		}
 
 		client.emit("users", {
-			chan: chan.id
+			chan: chan.id,
 		});
 
 		var msg = new Msg({
@@ -31,7 +31,7 @@ module.exports = function(irc, network) {
 			target: target,
 			text: data.message || "",
 			highlight: data.kicked === irc.user.nick,
-			self: data.nick === irc.user.nick
+			self: data.nick === irc.user.nick,
 		});
 		chan.pushMessage(client, msg);
 	});

--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -136,7 +136,7 @@ function emitPreview(client, msg, preview) {
 
 	client.emit("msg:preview", {
 		id: msg.id,
-		preview: preview
+		preview: preview,
 	});
 }
 
@@ -148,8 +148,8 @@ function fetch(uri, cb) {
 			maxRedirects: 5,
 			timeout: 5000,
 			headers: {
-				"User-Agent": "Mozilla/5.0 (compatible; The Lounge IRC Client; +https://github.com/thelounge/lounge)"
-			}
+				"User-Agent": "Mozilla/5.0 (compatible; The Lounge IRC Client; +https://github.com/thelounge/lounge)",
+			},
 		});
 	} catch (e) {
 		return cb(null);
@@ -200,7 +200,7 @@ function fetch(uri, cb) {
 			cb({
 				data: Buffer.concat(buffers, length),
 				type: type,
-				size: size
+				size: size,
 			});
 		});
 }

--- a/src/plugins/irc-events/list.js
+++ b/src/plugins/irc-events/list.js
@@ -12,7 +12,7 @@ module.exports = function(irc, network) {
 
 		updateListStatus(new Msg({
 			text: "Loading channel list, this can take a moment...",
-			type: "channel_list_loading"
+			type: "channel_list_loading",
 		}));
 	});
 
@@ -25,13 +25,13 @@ module.exports = function(irc, network) {
 			type: "channel_list",
 			channels: network.chanCache.sort(function(a, b) {
 				return b.num_users - a.num_users;
-			}).slice(0, MAX_CHANS)
+			}).slice(0, MAX_CHANS),
 		}));
 
 		if (network.chanCache.length > MAX_CHANS) {
 			updateListStatus(new Msg({
 				type: "channel_list_truncated",
-				text: "Channel list is too large: truncated to " + MAX_CHANS + " channels."
+				text: "Channel list is too large: truncated to " + MAX_CHANS + " channels.",
 			}));
 		}
 
@@ -43,18 +43,18 @@ module.exports = function(irc, network) {
 		if (typeof chan === "undefined") {
 			chan = new Chan({
 				type: Chan.Type.SPECIAL,
-				name: "Channel List"
+				name: "Channel List",
 			});
 			network.channels.push(chan);
 			client.emit("join", {
 				network: network.id,
-				chan: chan
+				chan: chan,
 			});
 		}
 
 		client.emit("msg", {
 			chan: chan.id,
-			msg: msg
+			msg: msg,
 		});
 	}
 };

--- a/src/plugins/irc-events/message.js
+++ b/src/plugins/irc-events/message.js
@@ -59,12 +59,12 @@ module.exports = function(irc, network) {
 				} else {
 					chan = new Chan({
 						type: Chan.Type.QUERY,
-						name: target
+						name: target,
 					});
 					network.channels.push(chan);
 					client.emit("join", {
 						network: network.id,
-						chan: chan
+						chan: chan,
 					});
 				}
 			}
@@ -94,7 +94,7 @@ module.exports = function(irc, network) {
 			from: data.nick,
 			text: data.message,
 			self: self,
-			highlight: highlight
+			highlight: highlight,
 		});
 
 		// No prefetch URLs unless are simple MESSAGE or ACTION types
@@ -128,7 +128,7 @@ module.exports = function(irc, network) {
 				chanId: chan.id,
 				timestamp: data.time || Date.now(),
 				title: title,
-				body: body
+				body: body,
 			}, true);
 		}
 	}

--- a/src/plugins/irc-events/mode.js
+++ b/src/plugins/irc-events/mode.js
@@ -73,7 +73,7 @@ module.exports = function(irc, network) {
 				mode: (targetChan.type !== Chan.Type.LOBBY && targetChan.getMode(data.nick)) || "",
 				from: data.nick,
 				text: text,
-				self: data.nick === irc.user.nick
+				self: data.nick === irc.user.nick,
 			});
 			targetChan.pushMessage(client, msg);
 
@@ -118,7 +118,7 @@ module.exports = function(irc, network) {
 			targetChan.sortUsers(irc);
 
 			client.emit("users", {
-				chan: targetChan.id
+				chan: targetChan.id,
 			});
 		}
 	});

--- a/src/plugins/irc-events/motd.js
+++ b/src/plugins/irc-events/motd.js
@@ -11,7 +11,7 @@ module.exports = function(irc, network) {
 			data.motd.split("\n").forEach((text) => {
 				var msg = new Msg({
 					type: Msg.Type.MOTD,
-					text: text
+					text: text,
 				});
 				lobby.pushMessage(client, msg);
 			});
@@ -20,7 +20,7 @@ module.exports = function(irc, network) {
 		if (data.error) {
 			var msg = new Msg({
 				type: Msg.Type.MOTD,
-				text: data.error
+				text: data.error,
 			});
 			lobby.pushMessage(client, msg);
 		}

--- a/src/plugins/irc-events/names.js
+++ b/src/plugins/irc-events/names.js
@@ -38,7 +38,7 @@ module.exports = function(irc, network) {
 		chan.sortUsers(irc);
 
 		client.emit("users", {
-			chan: chan.id
+			chan: chan.id,
 		});
 	});
 };

--- a/src/plugins/irc-events/nick.js
+++ b/src/plugins/irc-events/nick.js
@@ -19,7 +19,7 @@ module.exports = function(irc, network) {
 			client.save();
 			client.emit("nick", {
 				network: network.id,
-				nick: data.new_nick
+				nick: data.new_nick,
 			});
 		}
 
@@ -31,7 +31,7 @@ module.exports = function(irc, network) {
 			user.nick = data.new_nick;
 			chan.sortUsers(irc);
 			client.emit("users", {
-				chan: chan.id
+				chan: chan.id,
 			});
 			msg = new Msg({
 				time: data.time,
@@ -39,7 +39,7 @@ module.exports = function(irc, network) {
 				type: Msg.Type.NICK,
 				mode: chan.getMode(data.new_nick),
 				new_nick: data.new_nick,
-				self: self
+				self: self,
 			});
 			chan.pushMessage(client, msg);
 		});

--- a/src/plugins/irc-events/part.js
+++ b/src/plugins/irc-events/part.js
@@ -16,13 +16,13 @@ module.exports = function(irc, network) {
 			chan.destroy();
 			client.save();
 			client.emit("part", {
-				chan: chan.id
+				chan: chan.id,
 			});
 		} else {
 			const user = chan.findUser(from);
 			chan.users = _.without(chan.users, user);
 			client.emit("users", {
-				chan: chan.id
+				chan: chan.id,
 			});
 			var msg = new Msg({
 				type: Msg.Type.PART,
@@ -30,7 +30,7 @@ module.exports = function(irc, network) {
 				mode: (user && user.mode) || "",
 				text: data.message || "",
 				hostmask: data.ident + "@" + data.hostname,
-				from: from
+				from: from,
 			});
 			chan.pushMessage(client, msg);
 		}

--- a/src/plugins/irc-events/quit.js
+++ b/src/plugins/irc-events/quit.js
@@ -13,7 +13,7 @@ module.exports = function(irc, network) {
 			}
 			chan.users = _.without(chan.users, user);
 			client.emit("users", {
-				chan: chan.id
+				chan: chan.id,
 			});
 			var msg = new Msg({
 				time: data.time,
@@ -21,7 +21,7 @@ module.exports = function(irc, network) {
 				mode: user.mode || "",
 				text: data.message || "",
 				hostmask: data.ident + "@" + data.hostname,
-				from: data.nick
+				from: data.nick,
 			});
 			chan.pushMessage(client, msg);
 		});

--- a/src/plugins/irc-events/topic.js
+++ b/src/plugins/irc-events/topic.js
@@ -16,14 +16,14 @@ module.exports = function(irc, network) {
 			mode: (data.nick && chan.getMode(data.nick)) || "",
 			from: data.nick,
 			text: data.topic,
-			self: data.nick === irc.user.nick
+			self: data.nick === irc.user.nick,
 		});
 		chan.pushMessage(client, msg);
 
 		chan.topic = data.topic;
 		client.emit("topic", {
 			chan: chan.id,
-			topic: chan.topic
+			topic: chan.topic,
 		});
 	});
 
@@ -38,7 +38,7 @@ module.exports = function(irc, network) {
 			mode: chan.getMode(data.nick),
 			nick: data.nick,
 			when: new Date(data.when * 1000),
-			self: data.nick === irc.user.nick
+			self: data.nick === irc.user.nick,
 		});
 		chan.pushMessage(client, msg);
 	});

--- a/src/plugins/irc-events/unhandled.js
+++ b/src/plugins/irc-events/unhandled.js
@@ -14,7 +14,7 @@ module.exports = function(irc, network) {
 		network.channels[0].pushMessage(client, new Msg({
 			type: Msg.Type.UNHANDLED,
 			command: command.command,
-			params: command.params
+			params: command.params,
 		}), true);
 	});
 };

--- a/src/plugins/irc-events/welcome.js
+++ b/src/plugins/irc-events/welcome.js
@@ -9,13 +9,13 @@ module.exports = function(irc, network) {
 
 		var lobby = network.channels[0];
 		var msg = new Msg({
-			text: "You're now known as " + data.nick
+			text: "You're now known as " + data.nick,
 		});
 		lobby.pushMessage(client, msg);
 		client.save();
 		client.emit("nick", {
 			network: network.id,
-			nick: data.nick
+			nick: data.nick,
 		});
 	});
 };

--- a/src/plugins/irc-events/whois.js
+++ b/src/plugins/irc-events/whois.js
@@ -10,13 +10,13 @@ module.exports = function(irc, network) {
 		if (typeof chan === "undefined") {
 			chan = new Chan({
 				type: Chan.Type.QUERY,
-				name: data.nick
+				name: data.nick,
 			});
 			network.channels.push(chan);
 			client.emit("join", {
 				shouldOpen: true,
 				network: network.id,
-				chan: chan
+				chan: chan,
 			});
 		}
 
@@ -24,7 +24,7 @@ module.exports = function(irc, network) {
 		if (data.error) {
 			msg = new Msg({
 				type: Msg.Type.ERROR,
-				text: "No such nick: " + data.nick
+				text: "No such nick: " + data.nick,
 			});
 		} else {
 			// Absolute datetime in milliseconds since nick is idle
@@ -32,7 +32,7 @@ module.exports = function(irc, network) {
 
 			msg = new Msg({
 				type: Msg.Type.WHOIS,
-				whois: data
+				whois: data,
 			});
 		}
 

--- a/src/plugins/themes.js
+++ b/src/plugins/themes.js
@@ -9,7 +9,7 @@ const themes = new Map();
 
 module.exports = {
 	getAll: getAll,
-	getFilename: getFilename
+	getFilename: getFilename,
 };
 
 fs.readdir(path.join(__dirname, "..", "..", "public", "themes"), (err, builtInThemes) => {
@@ -50,7 +50,7 @@ function makeLocalThemeObject(css) {
 	return {
 		displayName: themeName.charAt(0).toUpperCase() + themeName.slice(1),
 		filename: path.join(__dirname, "..", "..", "public", "themes", `${themeName}.css`),
-		name: themeName
+		name: themeName,
 	};
 }
 
@@ -80,6 +80,6 @@ function makePackageThemeObject(moduleName) {
 	return {
 		displayName: displayName,
 		filename: filename,
-		name: moduleName
+		name: moduleName,
 	};
 }

--- a/src/server.js
+++ b/src/server.js
@@ -49,8 +49,8 @@ module.exports = function() {
 		.engine("html", expressHandlebars({
 			extname: ".html",
 			helpers: {
-				tojson: (c) => JSON.stringify(c)
-			}
+				tojson: (c) => JSON.stringify(c),
+			},
 		}))
 		.set("view engine", "html")
 		.set("views", path.join(__dirname, "..", "public"));
@@ -98,7 +98,7 @@ module.exports = function() {
 		server = server.createServer({
 			key: fs.readFileSync(keyPath),
 			cert: fs.readFileSync(certPath),
-			ca: caPath ? fs.readFileSync(caPath) : undefined
+			ca: caPath ? fs.readFileSync(caPath) : undefined,
 		}, app);
 	}
 
@@ -131,7 +131,7 @@ module.exports = function() {
 
 		const sockets = io(server, {
 			serveClient: false,
-			transports: config.transports
+			transports: config.transports,
 		});
 
 		sockets.on("connect", (socket) => {
@@ -276,13 +276,13 @@ function initializeClient(socket, client, token, lastMessage) {
 				var p2 = data.verify_password;
 				if (typeof p1 === "undefined" || p1 === "") {
 					socket.emit("change-password", {
-						error: "Please enter a new password"
+						error: "Please enter a new password",
 					});
 					return;
 				}
 				if (p1 !== p2) {
 					socket.emit("change-password", {
-						error: "Both new password fields must match"
+						error: "Both new password fields must match",
 					});
 					return;
 				}
@@ -292,7 +292,7 @@ function initializeClient(socket, client, token, lastMessage) {
 					.then((matching) => {
 						if (!matching) {
 							socket.emit("change-password", {
-								error: "The current password field does not match your account password"
+								error: "The current password field does not match your account password",
 							});
 							return;
 						}
@@ -368,7 +368,7 @@ function initializeClient(socket, client, token, lastMessage) {
 				type: "notification",
 				timestamp: Date.now(),
 				title: "The Lounge",
-				body: "🚀 Push notifications have been enabled"
+				body: "🚀 Push notifications have been enabled",
 			});
 		}
 	});
@@ -409,7 +409,7 @@ function initializeClient(socket, client, token, lastMessage) {
 		delete client.config.sessions[tokenToSignOut];
 
 		client.manager.updateUser(client.name, {
-			sessions: client.config.sessions
+			sessions: client.config.sessions,
 		});
 
 		_.map(client.attachedClients, (attachedClient, socketId) => {
@@ -450,7 +450,7 @@ function initializeClient(socket, client, token, lastMessage) {
 			pushSubscription: client.config.sessions[token],
 			active: client.lastActiveChannel,
 			networks: networks,
-			token: tokenToSend
+			token: tokenToSend,
 		});
 	};
 

--- a/test/client/js/libs/handlebars/ircmessageparser/findChannels.js
+++ b/test/client/js/libs/handlebars/ircmessageparser/findChannels.js
@@ -9,7 +9,7 @@ describe("findChannels", () => {
 		const expected = [{
 			channel: "#a",
 			start: 0,
-			end: 2
+			end: 2,
 		}];
 
 		const actual = findChannels(input, ["#"], ["@", "+"]);
@@ -22,7 +22,7 @@ describe("findChannels", () => {
 		const expected = [{
 			channel: "#äöü",
 			start: 0,
-			end: 4
+			end: 4,
 		}];
 
 		const actual = findChannels(input, ["#"], ["@", "+"]);
@@ -35,7 +35,7 @@ describe("findChannels", () => {
 		const expected = [{
 			channel: "#channel",
 			start: 7,
-			end: 15
+			end: 15,
 		}];
 
 		const actual = findChannels(input, ["#"], ["@", "+"]);
@@ -48,7 +48,7 @@ describe("findChannels", () => {
 		const expected = [{
 			channel: "#chan",
 			start: 0,
-			end: 5
+			end: 5,
 		}];
 
 		const actual = findChannels(input, ["#"], ["@", "+"]);
@@ -61,7 +61,7 @@ describe("findChannels", () => {
 		const expected = [{
 			channel: "#1,000",
 			start: 0,
-			end: 6
+			end: 6,
 		}];
 
 		const actual = findChannels(input, ["#"], ["@", "+"]);
@@ -74,7 +74,7 @@ describe("findChannels", () => {
 		const expected = [{
 			channel: "#a",
 			start: 1,
-			end: 3
+			end: 3,
 		}];
 
 		const actual = findChannels(input, ["#"], ["@", "+"]);
@@ -87,7 +87,7 @@ describe("findChannels", () => {
 		const expected = [{
 			channel: "#a",
 			start: 4,
-			end: 6
+			end: 6,
 		}];
 
 		const actual = findChannels(input, ["#"], ["!", "@", "%", "+"]);
@@ -100,7 +100,7 @@ describe("findChannels", () => {
 		const expected = [{
 			channel: "@a",
 			start: 0,
-			end: 2
+			end: 2,
 		}];
 
 		const actual = findChannels(input, ["@"], ["#", "+"]);
@@ -113,7 +113,7 @@ describe("findChannels", () => {
 		const expected = [{
 			channel: "##test",
 			start: 0,
-			end: 6
+			end: 6,
 		}];
 
 		const actual = findChannels(input, ["#"], ["@", "+"]);

--- a/test/client/js/libs/handlebars/ircmessageparser/findLinks.js
+++ b/test/client/js/libs/handlebars/ircmessageparser/findLinks.js
@@ -22,7 +22,7 @@ describe("findLinks", () => {
 		const expected = [{
 			start: 0,
 			end: 24,
-			link: "http://www.nooooooooooooooo.com"
+			link: "http://www.nooooooooooooooo.com",
 		}];
 
 		const actual = findLinks(input);
@@ -35,7 +35,7 @@ describe("findLinks", () => {
 		const expected = [{
 			link: "https://thelounge.github.io/",
 			start: 8,
-			end: 36
+			end: 36,
 		}];
 
 		const actual = findLinks(input);
@@ -48,7 +48,7 @@ describe("findLinks", () => {
 		const expected = [{
 			link: "http://www.duckduckgo.com",
 			start: 4,
-			end: 22
+			end: 22,
 		}];
 
 		const actual = findLinks(input);
@@ -61,7 +61,7 @@ describe("findLinks", () => {
 		const expected = [{
 			link: "https://theos.kyriasis.com/~kyrias/stats/archlinux.html",
 			start: 1,
-			end: 56
+			end: 56,
 		}];
 
 		const actual = findLinks(input);
@@ -74,7 +74,7 @@ describe("findLinks", () => {
 		const expected = [{
 			link: "http://www.github.com",
 			start: 2,
-			end: 16
+			end: 16,
 		}];
 
 		const actual = findLinks(input);
@@ -96,7 +96,7 @@ describe("findLinks", () => {
 		const expected = [{
 			link: "http://www.www.test.com",
 			start: 0,
-			end: 16
+			end: 16,
 		}];
 
 		const actual = findLinks(input);
@@ -109,11 +109,11 @@ describe("findLinks", () => {
 		const expected = [{
 			start: 0,
 			end: 15,
-			link: "http://www.example.com"
+			link: "http://www.example.com",
 		}, {
 			end: 42,
 			start: 16,
-			link: "ssh://-oProxyCommand=whois"
+			link: "ssh://-oProxyCommand=whois",
 		}];
 
 		const actual = findLinks(input);
@@ -124,7 +124,7 @@ describe("findLinks", () => {
 		const expected2 = [{
 			start: 0,
 			end: 15,
-			link: "http://www.example.com"
+			link: "http://www.example.com",
 		}];
 
 		const actual2 = findLinks(input2);
@@ -137,11 +137,11 @@ describe("findLinks", () => {
 		const expected = [{
 			start: 0,
 			end: 15,
-			link: "http://www.example.com"
+			link: "http://www.example.com",
 		}, {
 			start: 30,
 			end: 51,
-			link: "http://thelounge.chat"
+			link: "http://thelounge.chat",
 		}];
 
 		const actual = findLinks(input);

--- a/test/client/js/libs/handlebars/ircmessageparser/merge.js
+++ b/test/client/js/libs/handlebars/ircmessageparser/merge.js
@@ -8,24 +8,24 @@ describe("merge", () => {
 		const textParts = [{
 			start: 0,
 			end: 10,
-			flag1: true
+			flag1: true,
 		}, {
 			start: 10,
 			end: 20,
-			flag2: true
+			flag2: true,
 		}];
 		const styleFragments = [{
 			start: 0,
 			end: 5,
-			text: "01234"
+			text: "01234",
 		}, {
 			start: 5,
 			end: 15,
-			text: "5678901234"
+			text: "5678901234",
 		}, {
 			start: 15,
 			end: 20,
-			text: "56789"
+			text: "56789",
 		}];
 
 		const expected = [{
@@ -35,12 +35,12 @@ describe("merge", () => {
 			fragments: [{
 				start: 0,
 				end: 5,
-				text: "01234"
+				text: "01234",
 			}, {
 				start: 5,
 				end: 10,
-				text: "56789"
-			}]
+				text: "56789",
+			}],
 		}, {
 			start: 10,
 			end: 20,
@@ -48,12 +48,12 @@ describe("merge", () => {
 			fragments: [{
 				start: 10,
 				end: 15,
-				text: "01234"
+				text: "01234",
 			}, {
 				start: 15,
 				end: 20,
-				text: "56789"
-			}]
+				text: "56789",
+			}],
 		}];
 
 		const actual = merge(textParts, styleFragments);

--- a/test/client/js/libs/handlebars/ircmessageparser/parseStyle.js
+++ b/test/client/js/libs/handlebars/ircmessageparser/parseStyle.js
@@ -18,7 +18,7 @@ describe("parseStyle", () => {
 			text: "textwithcontrolcodes",
 
 			start: 0,
-			end: 20
+			end: 20,
 		}];
 
 		const actual = parseStyle(input);
@@ -40,7 +40,7 @@ describe("parseStyle", () => {
 			text: "bold",
 
 			start: 0,
-			end: 4
+			end: 4,
 		}];
 
 		const actual = parseStyle(input);
@@ -62,7 +62,7 @@ describe("parseStyle", () => {
 			text: "yellowText",
 
 			start: 0,
-			end: 10
+			end: 10,
 		}];
 
 		const actual = parseStyle(input);
@@ -84,7 +84,7 @@ describe("parseStyle", () => {
 			text: "yellowBG redText",
 
 			start: 0,
-			end: 16
+			end: 16,
 		}];
 
 		const actual = parseStyle(input);
@@ -106,7 +106,7 @@ describe("parseStyle", () => {
 			text: "italic",
 
 			start: 0,
-			end: 6
+			end: 6,
 		}];
 
 		const actual = parseStyle(input);
@@ -128,7 +128,7 @@ describe("parseStyle", () => {
 			text: "test ",
 
 			start: 0,
-			end: 5
+			end: 5,
 		}, {
 			bold: false,
 			textColor: undefined,
@@ -141,7 +141,7 @@ describe("parseStyle", () => {
 			text: "nice ",
 
 			start: 5,
-			end: 10
+			end: 10,
 		}, {
 			bold: true,
 			textColor: undefined,
@@ -154,7 +154,7 @@ describe("parseStyle", () => {
 			text: "RES006 ",
 
 			start: 10,
-			end: 17
+			end: 17,
 		}, {
 			bold: true,
 			textColor: 3,
@@ -167,7 +167,7 @@ describe("parseStyle", () => {
 			text: "colored",
 
 			start: 17,
-			end: 24
+			end: 24,
 		}, {
 			bold: true,
 			textColor: 3,
@@ -180,7 +180,7 @@ describe("parseStyle", () => {
 			text: " background",
 
 			start: 24,
-			end: 35
+			end: 35,
 		}, {
 			bold: false,
 			textColor: undefined,
@@ -193,7 +193,7 @@ describe("parseStyle", () => {
 			text: "?",
 
 			start: 35,
-			end: 36
+			end: 36,
 		}];
 
 		const actual = parseStyle(input);
@@ -215,7 +215,7 @@ describe("parseStyle", () => {
 			text: "bold",
 
 			start: 0,
-			end: 4
+			end: 4,
 		}, {
 			bold: true,
 			textColor: 8,
@@ -228,7 +228,7 @@ describe("parseStyle", () => {
 			text: "yellow",
 
 			start: 4,
-			end: 10
+			end: 10,
 		}, {
 			bold: false,
 			textColor: 8,
@@ -241,7 +241,7 @@ describe("parseStyle", () => {
 			text: "nonBold",
 
 			start: 10,
-			end: 17
+			end: 17,
 		}, {
 			bold: false,
 			textColor: undefined,
@@ -254,7 +254,7 @@ describe("parseStyle", () => {
 			text: "default",
 
 			start: 17,
-			end: 24
+			end: 24,
 		}];
 
 		const actual = parseStyle(input);
@@ -276,7 +276,7 @@ describe("parseStyle", () => {
 			text: "bold",
 
 			start: 0,
-			end: 4
+			end: 4,
 		}, {
 			bold: false,
 			textColor: undefined,
@@ -289,7 +289,7 @@ describe("parseStyle", () => {
 			text: " ",
 
 			start: 4,
-			end: 5
+			end: 5,
 		}, {
 			bold: true,
 			textColor: undefined,
@@ -302,7 +302,7 @@ describe("parseStyle", () => {
 			text: "bold",
 
 			start: 5,
-			end: 9
+			end: 9,
 		}];
 
 		const actual = parseStyle(input);
@@ -324,7 +324,7 @@ describe("parseStyle", () => {
 			text: "full",
 
 			start: 0,
-			end: 4
+			end: 4,
 		}, {
 			bold: false,
 			textColor: undefined,
@@ -337,7 +337,7 @@ describe("parseStyle", () => {
 			text: "none",
 
 			start: 4,
-			end: 8
+			end: 8,
 		}];
 
 		const actual = parseStyle(input);
@@ -359,7 +359,7 @@ describe("parseStyle", () => {
 			text: "a",
 
 			start: 0,
-			end: 1
+			end: 1,
 		}];
 
 		const actual = parseStyle(input);
@@ -383,7 +383,7 @@ describe("parseStyle", () => {
 			text: rawString,
 
 			start: 0,
-			end: rawString.length
+			end: rawString.length,
 		}];
 
 		const actual = parseStyle(input);

--- a/test/client/js/libs/handlebars/parse.js
+++ b/test/client/js/libs/handlebars/parse.js
@@ -7,10 +7,10 @@ describe("parse Handlebars helper", () => {
 	it("should not introduce xss", () => {
 		const testCases = [{
 			input: "<img onerror='location.href=\"//youtube.com\"'>",
-			expected: "&lt;img onerror&#x3D;&#x27;location.href&#x3D;&quot;//youtube.com&quot;&#x27;&gt;"
+			expected: "&lt;img onerror&#x3D;&#x27;location.href&#x3D;&quot;//youtube.com&quot;&#x27;&gt;",
 		}, {
 			input: "#&\">bug",
-			expected: "<span class=\"inline-channel\" role=\"button\" tabindex=\"0\" data-chan=\"#&amp;&quot;&gt;bug\">#&amp;&quot;&gt;bug</span>"
+			expected: "<span class=\"inline-channel\" role=\"button\" tabindex=\"0\" data-chan=\"#&amp;&quot;&gt;bug\">#&amp;&quot;&gt;bug</span>",
 		}];
 
 		const actual = testCases.map((testCase) => parse(testCase.input));
@@ -22,7 +22,7 @@ describe("parse Handlebars helper", () => {
 	it("should skip control codes", () => {
 		const testCases = [{
 			input: "text\x01with\x04control\x05codes",
-			expected: "textwithcontrolcodes"
+			expected: "textwithcontrolcodes",
 		}];
 
 		const actual = testCases.map((testCase) => parse(testCase.input));
@@ -37,13 +37,13 @@ describe("parse Handlebars helper", () => {
 			expected:
 				"<a href=\"irc://freenode.net/thelounge\" target=\"_blank\" rel=\"noopener\">" +
 					"irc://freenode.net/thelounge" +
-				"</a>"
+				"</a>",
 		}, {
 			input: "www.nooooooooooooooo.com",
 			expected:
 				"<a href=\"http://www.nooooooooooooooo.com\" target=\"_blank\" rel=\"noopener\">" +
 					"www.nooooooooooooooo.com" +
-				"</a>"
+				"</a>",
 		}, {
 			input: "look at https://thelounge.github.io/ for more information",
 			expected:
@@ -51,7 +51,7 @@ describe("parse Handlebars helper", () => {
 				"<a href=\"https://thelounge.github.io/\" target=\"_blank\" rel=\"noopener\">" +
 					"https://thelounge.github.io/" +
 				"</a>" +
-				" for more information"
+				" for more information",
 		}, {
 			input: "use www.duckduckgo.com for privacy reasons",
 			expected:
@@ -59,13 +59,13 @@ describe("parse Handlebars helper", () => {
 				"<a href=\"http://www.duckduckgo.com\" target=\"_blank\" rel=\"noopener\">" +
 					"www.duckduckgo.com" +
 				"</a>" +
-				" for privacy reasons"
+				" for privacy reasons",
 		}, {
 			input: "svn+ssh://example.org",
 			expected:
 				"<a href=\"svn+ssh://example.org\" target=\"_blank\" rel=\"noopener\">" +
 					"svn+ssh://example.org" +
-				"</a>"
+				"</a>",
 		}];
 
 		const actual = testCases.map((testCase) => parse(testCase.input));
@@ -96,7 +96,7 @@ describe("parse Handlebars helper", () => {
 				"<a href=\"https://theos.kyriasis.com/~kyrias/stats/archlinux.html\" target=\"_blank\" rel=\"noopener\">" +
 					"https://theos.kyriasis.com/~kyrias/stats/archlinux.html" +
 				"</a>" +
-				"&gt;"
+				"&gt;",
 		}, {
 			input: "abc (www.example.com)",
 			expected:
@@ -104,19 +104,19 @@ describe("parse Handlebars helper", () => {
 				"<a href=\"http://www.example.com\" target=\"_blank\" rel=\"noopener\">" +
 					"www.example.com" +
 				"</a>" +
-				")"
+				")",
 		}, {
 			input: "http://example.com/Test_(Page)",
 			expected:
 				"<a href=\"http://example.com/Test_(Page)\" target=\"_blank\" rel=\"noopener\">" +
 					"http://example.com/Test_(Page)" +
-				"</a>"
+				"</a>",
 		}, {
 			input: "www.example.com/Test_(Page)",
 			expected:
 				"<a href=\"http://www.example.com/Test_(Page)\" target=\"_blank\" rel=\"noopener\">" +
 					"www.example.com/Test_(Page)" +
-				"</a>"
+				"</a>",
 		}];
 
 		const actual = testCases.map((testCase) => parse(testCase.input));
@@ -128,10 +128,10 @@ describe("parse Handlebars helper", () => {
 	it("should not find urls", () => {
 		const testCases = [{
 			input: "text www. text",
-			expected: "text www. text"
+			expected: "text www. text",
 		}, {
 			input: "http://.",
-			expected: "http://."
+			expected: "http://.",
 		}];
 
 		const actual = testCases.map((testCase) => parse(testCase.input));
@@ -146,19 +146,19 @@ describe("parse Handlebars helper", () => {
 			expected:
 				"<span class=\"inline-channel\" role=\"button\" tabindex=\"0\" data-chan=\"#a\">" +
 					"#a" +
-				"</span>"
+				"</span>",
 		}, {
 			input: "#test",
 			expected:
 				"<span class=\"inline-channel\" role=\"button\" tabindex=\"0\" data-chan=\"#test\">" +
 					"#test" +
-				"</span>"
+				"</span>",
 		}, {
 			input: "#äöü",
 			expected:
 				"<span class=\"inline-channel\" role=\"button\" tabindex=\"0\" data-chan=\"#äöü\">" +
 					"#äöü" +
-				"</span>"
+				"</span>",
 		}, {
 			input: "inline #channel text",
 			expected:
@@ -166,20 +166,20 @@ describe("parse Handlebars helper", () => {
 				"<span class=\"inline-channel\" role=\"button\" tabindex=\"0\" data-chan=\"#channel\">" +
 					"#channel" +
 				"</span>" +
-				" text"
+				" text",
 		}, {
 			input: "#1,000",
 			expected:
 				"<span class=\"inline-channel\" role=\"button\" tabindex=\"0\" data-chan=\"#1,000\">" +
 					"#1,000" +
-				"</span>"
+				"</span>",
 		}, {
 			input: "@#a",
 			expected:
 				"@" +
 				"<span class=\"inline-channel\" role=\"button\" tabindex=\"0\" data-chan=\"#a\">" +
 					"#a" +
-				"</span>"
+				"</span>",
 		}];
 
 		const actual = testCases.map((testCase) => parse(testCase.input));
@@ -191,10 +191,10 @@ describe("parse Handlebars helper", () => {
 	it("should not find channels", () => {
 		const testCases = [{
 			input: "hi#test",
-			expected: "hi#test"
+			expected: "hi#test",
 		}, {
 			input: "#",
-			expected: "#"
+			expected: "#",
 		}];
 
 		const actual = testCases.map((testCase) => parse(testCase.input));
@@ -206,35 +206,35 @@ describe("parse Handlebars helper", () => {
 	it("should style like mirc", () => {
 		const testCases = [{
 			input: "\x02bold",
-			expected: "<span class=\"irc-bold\">bold</span>"
+			expected: "<span class=\"irc-bold\">bold</span>",
 		}, {
 			input: "\x038yellowText",
-			expected: "<span class=\"irc-fg8\">yellowText</span>"
+			expected: "<span class=\"irc-fg8\">yellowText</span>",
 		}, {
 			input: "\x030,0white,white",
-			expected: "<span class=\"irc-fg0 irc-bg0\">white,white</span>"
+			expected: "<span class=\"irc-fg0 irc-bg0\">white,white</span>",
 		}, {
 			input: "\x034,8yellowBGredText",
-			expected: "<span class=\"irc-fg4 irc-bg8\">yellowBGredText</span>"
+			expected: "<span class=\"irc-fg4 irc-bg8\">yellowBGredText</span>",
 		}, {
 			input: "\x1ditalic",
-			expected: "<span class=\"irc-italic\">italic</span>"
+			expected: "<span class=\"irc-italic\">italic</span>",
 		}, {
 			input: "\x1funderline",
-			expected: "<span class=\"irc-underline\">underline</span>"
+			expected: "<span class=\"irc-underline\">underline</span>",
 		}, {
 			input: "\x02bold\x038yellow\x02nonBold\x03default",
 			expected:
 				"<span class=\"irc-bold\">bold</span>" +
 				"<span class=\"irc-bold irc-fg8\">yellow</span>" +
 				"<span class=\"irc-fg8\">nonBold</span>" +
-				"default"
+				"default",
 		}, {
 			input: "\x02bold\x02 \x02bold\x02",
 			expected:
 				"<span class=\"irc-bold\">bold</span>" +
 				" " +
-				"<span class=\"irc-bold\">bold</span>"
+				"<span class=\"irc-bold\">bold</span>",
 		}];
 
 		const actual = testCases.map((testCase) => parse(testCase.input));
@@ -253,14 +253,14 @@ describe("parse Handlebars helper", () => {
 					"<span class=\"irc-italic\">freenode.net</span>" +
 					"/" +
 					"<span class=\"irc-fg4 irc-bg8\">thelounge</span>" +
-				"</a>"
+				"</a>",
 		}, {
 			input: "\x02#\x038,9thelounge",
 			expected:
 				"<span class=\"inline-channel\" role=\"button\" tabindex=\"0\" data-chan=\"#thelounge\">" +
 					"<span class=\"irc-bold\">#</span>" +
 					"<span class=\"irc-bold irc-fg8 irc-bg9\">thelounge</span>" +
-				"</span>"
+				"</span>",
 		}];
 
 		const actual = testCases.map((testCase) => parse(testCase.input));
@@ -276,7 +276,7 @@ describe("parse Handlebars helper", () => {
 			"test " +
 				"<span class=\"inline-channel\" role=\"button\" tabindex=\"0\" data-chan=\"#&quot;testa\">" +
 				"<span class=\"irc-fg12\">#&quot;testa</span>" +
-			"</span>"
+			"</span>",
 		}];
 
 		const actual = testCases.map((testCase) => parse(testCase.input));
@@ -292,14 +292,14 @@ describe("parse Handlebars helper", () => {
 				"like.." +
 				"<a href=\"http://example.com\" target=\"_blank\" rel=\"noopener\">" +
 					"http://example.com" +
-				"</a>"
+				"</a>",
 		}, {
 			input: "like..HTTP://example.com",
 			expected:
 				"like.." +
 				"<a href=\"HTTP://example.com\" target=\"_blank\" rel=\"noopener\">" +
 					"HTTP://example.com" +
-				"</a>"
+				"</a>",
 		}];
 
 		const actual = testCases.map((testCase) => parse(testCase.input));
@@ -315,7 +315,7 @@ describe("parse Handlebars helper", () => {
 				"" +
 				"<a href=\"http://example.com/#hash\" target=\"_blank\" rel=\"noopener\">" +
 					"http://example.com/#hash" +
-				"</a>"
+				"</a>",
 		}];
 
 		const actual = testCases.map((testCase) => parse(testCase.input));

--- a/test/commands/mode.js
+++ b/test/commands/mode.js
@@ -8,12 +8,12 @@ var ModeCommand = require("../../src/plugins/inputs/mode");
 describe("Commands", function() {
 	describe("/mode", function() {
 		const channel = new Chan({
-			name: "#thelounge"
+			name: "#thelounge",
 		});
 
 		const lobby = new Chan({
 			name: "Network Lobby",
-			type: Chan.Type.LOBBY
+			type: Chan.Type.LOBBY,
 		});
 
 		const testableNetwork = {
@@ -22,8 +22,8 @@ describe("Commands", function() {
 			irc: {
 				raw: function() {
 					testableNetwork.lastCommand = Array.prototype.join.call(arguments, " ");
-				}
-			}
+				},
+			},
 		};
 
 		it("should not mess with the given target", function() {

--- a/test/models/chan.js
+++ b/test/models/chan.js
@@ -12,10 +12,10 @@ describe("Chan", function() {
 			messages: [
 				new Msg(),
 				new Msg({
-					text: "Message to be found"
+					text: "Message to be found",
 				}),
-				new Msg()
-			]
+				new Msg(),
+			],
 		});
 
 		it("should find a message in the list of messages", function() {
@@ -36,10 +36,10 @@ describe("Chan", function() {
 						{symbol: "&", mode: "a"},
 						{symbol: "@", mode: "o"},
 						{symbol: "%", mode: "h"},
-						{symbol: "+", mode: "v"}
-					]
-				}
-			}
+						{symbol: "+", mode: "v"},
+					],
+				},
+			},
 		};
 
 		var prefixLookup = {};
@@ -58,12 +58,12 @@ describe("Chan", function() {
 
 		it("should sort a simple user list", function() {
 			var chan = new Chan({users: [
-				"JocelynD", "YaManicKill", "astorije", "xPaw", "Max-P"
+				"JocelynD", "YaManicKill", "astorije", "xPaw", "Max-P",
 			].map(makeUser)});
 			chan.sortUsers(network);
 
 			expect(getUserNames(chan)).to.deep.equal([
-				"astorije", "JocelynD", "Max-P", "xPaw", "YaManicKill"
+				"astorije", "JocelynD", "Max-P", "xPaw", "YaManicKill",
 			]);
 		});
 
@@ -78,7 +78,7 @@ describe("Chan", function() {
 			chan.sortUsers(network);
 
 			expect(getUserNames(chan)).to.deep.equal([
-				"xPaw", "JocelynD", "Max-P", "astorije", "YaManicKill"
+				"xPaw", "JocelynD", "Max-P", "astorije", "YaManicKill",
 			]);
 		});
 
@@ -107,13 +107,13 @@ describe("Chan", function() {
 		it("should parse special characters successfully", function() {
 			var chan = new Chan({users: [
 				"[foo", "]foo", "(foo)", "{foo}", "<foo>", "_foo", "@foo", "^foo",
-				"&foo", "!foo", "+foo", "Foo"
+				"&foo", "!foo", "+foo", "Foo",
 			].map(makeUser)});
 			chan.sortUsers(network);
 
 			expect(getUserNames(chan)).to.deep.equal([
 				"!foo", "&foo", "(foo)", "+foo", "<foo>", "@foo", "[foo", "]foo",
-				"^foo", "_foo", "Foo", "{foo}"
+				"^foo", "_foo", "Foo", "{foo}",
 			]);
 		});
 	});

--- a/test/models/msg.js
+++ b/test/models/msg.js
@@ -21,7 +21,7 @@ describe("Msg", function() {
 				thumb: "",
 				type: "link",
 				shown: true,
-			}]
+			}],
 		});
 
 		it("should find a preview given an existing link", function() {

--- a/test/models/network.js
+++ b/test/models/network.js
@@ -19,7 +19,7 @@ describe("Network", function() {
 					new Chan({name: "&secure", key: "bar"}),
 					new Chan({name: "Channel List", type: Chan.Type.SPECIAL}),
 					new Chan({name: "PrivateChat", type: Chan.Type.QUERY}),
-				]
+				],
 			});
 			network.setNick("chillin`");
 
@@ -41,7 +41,7 @@ describe("Network", function() {
 					{name: "&foobar", key: ""},
 					{name: "#secret", key: "foo"},
 					{name: "&secure", key: "bar"},
-				]
+				],
 			});
 		});
 
@@ -52,7 +52,7 @@ describe("Network", function() {
 					new Chan({name: "AAAA!", type: Chan.Type.QUERY}),
 					new Chan({name: "#thelounge"}),
 					new Chan({name: "&foobar"}),
-				]
+				],
 			});
 			network.channels.push(new Chan({name: "#swag"}));
 
@@ -65,24 +65,24 @@ describe("Network", function() {
 				name: "#506-bug-fix",
 				messages: [
 					new Msg({
-						text: "message in constructor"
-					})
-				]
+						text: "message in constructor",
+					}),
+				],
 			});
 
 			var network = new Network({
 				name: "networkName",
 				channels: [
-					chan
-				]
+					chan,
+				],
 			});
 
 			chan.messages.push(new Msg({
-				text: "message in original instance"
+				text: "message in original instance",
 			}));
 
 			network.channels[1].messages.push(new Msg({
-				text: "message after network creation"
+				text: "message after network creation",
 			}));
 
 			expect(network.channels[1].messages).to.have.lengthOf(3);

--- a/test/plugins/auth/ldap.js
+++ b/test/plugins/auth/ldap.js
@@ -63,8 +63,8 @@ function startLdapServer(callback) {
 				cn: ["john doe"],
 				sn: ["johnny"],
 				uid: ["johndoe"],
-				memberof: [baseDN]
-			}
+				memberof: [baseDN],
+			},
 		};
 
 		if (req.filter.matches(obj.attributes)) {

--- a/test/plugins/link.js
+++ b/test/plugins/link.js
@@ -29,7 +29,7 @@ describe("Link plugin", function() {
 	it("should be able to fetch basic information about URLs", function(done) {
 		const url = "http://localhost:9002/basic";
 		const message = this.irc.createMessage({
-			text: url
+			text: url,
 		});
 
 		link(this.irc, this.network.channels[0], message);
@@ -60,7 +60,7 @@ describe("Link plugin", function() {
 
 	it("should prefer og:title over title", function(done) {
 		const message = this.irc.createMessage({
-			text: "http://localhost:9002/basic-og"
+			text: "http://localhost:9002/basic-og",
 		});
 
 		link(this.irc, this.network.channels[0], message);
@@ -77,7 +77,7 @@ describe("Link plugin", function() {
 
 	it("should prefer og:description over description", function(done) {
 		const message = this.irc.createMessage({
-			text: "http://localhost:9002/description-og"
+			text: "http://localhost:9002/description-og",
 		});
 
 		link(this.irc, this.network.channels[0], message);
@@ -94,7 +94,7 @@ describe("Link plugin", function() {
 
 	it("should find og:image with full url", function(done) {
 		const message = this.irc.createMessage({
-			text: "http://localhost:9002/thumb"
+			text: "http://localhost:9002/thumb",
 		});
 
 		link(this.irc, this.network.channels[0], message);
@@ -112,7 +112,7 @@ describe("Link plugin", function() {
 
 	it("should find image_src", function(done) {
 		const message = this.irc.createMessage({
-			text: "http://localhost:9002/thumb-image-src"
+			text: "http://localhost:9002/thumb-image-src",
 		});
 
 		link(this.irc, this.network.channels[0], message);
@@ -129,7 +129,7 @@ describe("Link plugin", function() {
 
 	it("should correctly resolve relative protocol", function(done) {
 		const message = this.irc.createMessage({
-			text: "http://localhost:9002/thumb-image-src"
+			text: "http://localhost:9002/thumb-image-src",
 		});
 
 		link(this.irc, this.network.channels[0], message);
@@ -146,7 +146,7 @@ describe("Link plugin", function() {
 
 	it("should resolve url correctly for relative url", function(done) {
 		const message = this.irc.createMessage({
-			text: "http://localhost:9002/relative-thumb"
+			text: "http://localhost:9002/relative-thumb",
 		});
 
 		link(this.irc, this.network.channels[0], message);
@@ -165,7 +165,7 @@ describe("Link plugin", function() {
 
 	it("should send untitled page if there is a thumbnail", function(done) {
 		const message = this.irc.createMessage({
-			text: "http://localhost:9002/thumb-no-title"
+			text: "http://localhost:9002/thumb-no-title",
 		});
 
 		link(this.irc, this.network.channels[0], message);
@@ -184,7 +184,7 @@ describe("Link plugin", function() {
 
 	it("should not send thumbnail if image is 404", function(done) {
 		const message = this.irc.createMessage({
-			text: "http://localhost:9002/thumb-404"
+			text: "http://localhost:9002/thumb-404",
 		});
 
 		link(this.irc, this.network.channels[0], message);
@@ -203,7 +203,7 @@ describe("Link plugin", function() {
 
 	it("should send image preview", function(done) {
 		const message = this.irc.createMessage({
-			text: "http://localhost:9002/real-test-image.png"
+			text: "http://localhost:9002/real-test-image.png",
 		});
 
 		link(this.irc, this.network.channels[0], message);
@@ -218,7 +218,7 @@ describe("Link plugin", function() {
 
 	it("should load multiple URLs found in messages", function(done) {
 		const message = this.irc.createMessage({
-			text: "http://localhost:9002/one http://localhost:9002/two"
+			text: "http://localhost:9002/one http://localhost:9002/two",
 		});
 
 		link(this.irc, this.network.channels[0], message);

--- a/test/plugins/storage.js
+++ b/test/plugins/storage.js
@@ -34,7 +34,7 @@ describe("Image storage", function() {
 
 	it("should store the thumbnail", function(done) {
 		const message = this.irc.createMessage({
-			text: "http://localhost:9003/thumb"
+			text: "http://localhost:9003/thumb",
 		});
 
 		link(this.irc, this.network.channels[0], message);
@@ -53,7 +53,7 @@ describe("Image storage", function() {
 
 	it("should store the image", function(done) {
 		const message = this.irc.createMessage({
-			text: "http://localhost:9003/real-test-image.png"
+			text: "http://localhost:9003/real-test-image.png",
 		});
 
 		link(this.irc, this.network.channels[0], message);

--- a/test/server.js
+++ b/test/server.js
@@ -56,8 +56,8 @@ describe("Server", () => {
 				reconnection: false,
 				timeout: 1000,
 				transports: [
-					"websocket"
-				]
+					"websocket",
+				],
 			});
 
 			// Server emits events faster than the test can bind them

--- a/test/tests/cleanircmessages.js
+++ b/test/tests/cleanircmessages.js
@@ -7,37 +7,37 @@ describe("Clean IRC messages", function() {
 	it("should remove all formatting", function() {
 		const testCases = [{
 			input: "\x0303",
-			expected: ""
+			expected: "",
 		}, {
 			input: "\x02bold",
-			expected: "bold"
+			expected: "bold",
 		}, {
 			input: "\x038yellowText",
-			expected: "yellowText"
+			expected: "yellowText",
 		}, {
 			input: "\x030,0white,white",
-			expected: "white,white"
+			expected: "white,white",
 		}, {
 			input: "\x034,8yellowBGredText",
-			expected: "yellowBGredText"
+			expected: "yellowBGredText",
 		}, {
 			input: "\x1ditalic",
-			expected: "italic"
+			expected: "italic",
 		}, {
 			input: "\x1funderline",
-			expected: "underline"
+			expected: "underline",
 		}, {
 			input: "\x02bold\x038yellow\x02nonBold\x03default",
-			expected: "boldyellownonBolddefault"
+			expected: "boldyellownonBolddefault",
 		}, {
 			input: "\x02bold\x02 \x02bold\x02",
-			expected: "bold bold"
+			expected: "bold bold",
 		}, {
 			input: "\x02irc\x0f://\x1dfreenode.net\x0f/\x034,8thelounge",
-			expected: "irc://freenode.net/thelounge"
+			expected: "irc://freenode.net/thelounge",
 		}, {
 			input: "\x02#\x038,9thelounge",
-			expected: "#thelounge"
+			expected: "#thelounge",
 		}];
 
 		const actual = testCases.map((testCase) => Helper.cleanIrcMessage(testCase.input));

--- a/test/util.js
+++ b/test/util.js
@@ -35,11 +35,11 @@ module.exports = {
 		return new Network({
 			host: "example.com",
 			channels: [new Chan({
-				name: "#test-channel"
-			})]
+				name: "#test-channel",
+			})],
 		});
 	},
 	createWebserver: function() {
 		return express();
-	}
+	},
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,7 +16,7 @@ const config = {
 	output: {
 		path: path.resolve(__dirname, "public"),
 		filename: "[name]",
-		publicPath: "/"
+		publicPath: "/",
 	},
 	module: {
 		rules: [
@@ -31,12 +31,12 @@ const config = {
 						presets: [
 							["env", {
 								targets: {
-									browsers: "last 2 versions"
-								}
-							}]
-						]
-					}
-				}
+									browsers: "last 2 versions",
+								},
+							}],
+						],
+					},
+				},
 			},
 			{
 				test: /\.tpl$/,
@@ -47,15 +47,15 @@ const config = {
 					loader: "handlebars-loader",
 					options: {
 						helperDirs: [
-							path.resolve(__dirname, "client/js/libs/handlebars")
+							path.resolve(__dirname, "client/js/libs/handlebars"),
 						],
 						extensions: [
-							".tpl"
+							".tpl",
 						],
-					}
-				}
+					},
+				},
 			},
-		]
+		],
 	},
 	externals: {
 		json3: "JSON", // socket.io uses json3.js, but we do not target any browsers that need it
@@ -64,31 +64,31 @@ const config = {
 		new CopyPlugin([
 			{
 				from: "./node_modules/font-awesome/fonts/fontawesome-webfont.woff*",
-				to: "fonts/[name].[ext]"
+				to: "fonts/[name].[ext]",
 			},
 			{
 				from: "./client/js/loading-slow-alert.js",
-				to: "js/[name].[ext]"
+				to: "js/[name].[ext]",
 			},
 			{ // TODO: Build index.html with handlebars
 				from: "./client/*",
-				to: "[name].[ext]"
+				to: "[name].[ext]",
 			},
 			{
 				from: "./client/audio/*",
-				to: "audio/[name].[ext]"
+				to: "audio/[name].[ext]",
 			},
 			{
 				from: "./client/img/*",
-				to: "img/[name].[ext]"
+				to: "img/[name].[ext]",
 			},
 			{
 				from: "./client/themes/*",
-				to: "themes/[name].[ext]"
+				to: "themes/[name].[ext]",
 			},
 			{ // TODO: Build css with postcss
 				from: "./client/css/*",
-				to: "css/[name].[ext]"
+				to: "css/[name].[ext]",
 			},
 		]),
 		// socket.io uses debug, we don't need it
@@ -96,9 +96,9 @@ const config = {
 		// automatically split all vendor dependencies into a separate bundle
 		new webpack.optimize.CommonsChunkPlugin({
 			name: "js/bundle.vendor.js",
-			minChunks: (module) => module.context && module.context.indexOf("node_modules") !== -1
-		})
-	]
+			minChunks: (module) => module.context && module.context.indexOf("node_modules") !== -1,
+		}),
+	],
 };
 
 // *********************************
@@ -108,7 +108,7 @@ const config = {
 if (process.env.NODE_ENV === "production") {
 	config.plugins.push(new webpack.optimize.UglifyJsPlugin({
 		sourceMap: true,
-		comments: false
+		comments: false,
 	}));
 }
 


### PR DESCRIPTION
¯\\\_(ツ)\_/¯

All those changes are the result of `npm run lint:js -- --fix`, no manual edits.