### PR TITLE
Convert users list to map

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -483,7 +483,7 @@ Client.prototype.names = function(data) {
 
 	client.emit("names", {
 		id: target.chan.id,
-		users: target.chan.users,
+		users: target.chan.getSortedUsers(target.network.irc),
 	});
 };
 

--- a/src/models/chan.js
+++ b/src/models/chan.js
@@ -28,7 +28,7 @@ function Chan(attr) {
 		firstUnread: 0,
 		unread: 0,
 		highlight: 0,
-		users: [],
+		users: new Map(),
 	});
 }
 
@@ -97,7 +97,7 @@ Chan.prototype.dereferencePreviews = function(messages) {
 	});
 };
 
-Chan.prototype.sortUsers = function(irc) {
+Chan.prototype.getSortedUsers = function(irc) {
 	var userModeSortPriority = {};
 	irc.network.options.PREFIX.forEach((prefix, index) => {
 		userModeSortPriority[prefix.symbol] = index;
@@ -105,7 +105,9 @@ Chan.prototype.sortUsers = function(irc) {
 
 	userModeSortPriority[""] = 99; // No mode is lowest
 
-	this.users = this.users.sort(function(a, b) {
+	const users = Array.from(this.users.values());
+
+	return users.sort(function(a, b) {
 		if (a.mode === b.mode) {
 			return a.nick.toLowerCase() < b.nick.toLowerCase() ? -1 : 1;
 		}
@@ -119,11 +121,19 @@ Chan.prototype.findMessage = function(msgId) {
 };
 
 Chan.prototype.findUser = function(nick) {
-	return _.find(this.users, {nick: nick});
+	return this.users.get(nick.toLowerCase());
 };
 
 Chan.prototype.getUser = function(nick) {
 	return this.findUser(nick) || new User({nick: nick});
+};
+
+Chan.prototype.setUser = function(user) {
+	this.users.set(user.nick.toLowerCase(), user);
+};
+
+Chan.prototype.removeUser = function(user) {
+	this.users.delete(user.nick.toLowerCase());
 };
 
 Chan.prototype.toJSON = function() {

--- a/src/plugins/irc-events/away.js
+++ b/src/plugins/irc-events/away.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const _ = require("lodash");
 const Msg = require("../../models/msg");
 
 module.exports = function(irc, network) {
@@ -9,7 +8,7 @@ module.exports = function(irc, network) {
 		const away = data.message;
 
 		network.channels.forEach((chan) => {
-			const user = _.find(chan.users, {nick: data.nick});
+			const user = chan.findUser(data.nick);
 
 			if (!user || user.away === away) {
 				return;

--- a/src/plugins/irc-events/join.js
+++ b/src/plugins/irc-events/join.js
@@ -35,8 +35,7 @@ module.exports = function(irc, network) {
 		});
 		chan.pushMessage(client, msg);
 
-		chan.users.push(user);
-		chan.sortUsers(irc);
+		chan.setUser(new User({nick: data.nick}));
 		client.emit("users", {
 			chan: chan.id,
 		});

--- a/src/plugins/irc-events/kick.js
+++ b/src/plugins/irc-events/kick.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const _ = require("lodash");
 const Msg = require("../../models/msg");
 
 module.exports = function(irc, network) {
@@ -25,9 +24,9 @@ module.exports = function(irc, network) {
 		chan.pushMessage(client, msg);
 
 		if (data.kicked === irc.user.nick) {
-			chan.users = [];
+			chan.users = new Map();
 		} else {
-			chan.users = _.without(chan.users, msg.target);
+			chan.removeUser(msg.target);
 		}
 
 		client.emit("users", {

--- a/src/plugins/irc-events/mode.js
+++ b/src/plugins/irc-events/mode.js
@@ -113,8 +113,6 @@ module.exports = function(irc, network) {
 			// TODO: This is horrible
 			irc.raw("NAMES", data.target);
 		} else {
-			targetChan.sortUsers(irc);
-
 			client.emit("users", {
 				chan: targetChan.id,
 			});

--- a/src/plugins/irc-events/names.js
+++ b/src/plugins/irc-events/names.js
@@ -1,7 +1,5 @@
 "use strict";
 
-const User = require("../../models/user");
-
 module.exports = function(irc, network) {
 	const client = this;
 
@@ -11,31 +9,16 @@ module.exports = function(irc, network) {
 			return;
 		}
 
-		// Create lookup map of current users,
-		// as we need to keep certain properties
-		// and we can recycle existing User objects
-		const oldUsers = new Map();
+		const newUsers = new Map();
 
-		chan.users.forEach((user) => {
-			oldUsers.set(user.nick, user);
+		data.users.forEach((user) => {
+			const newUser = chan.getUser(user.nick);
+			newUser.setModes(user.modes, network.prefixLookup);
+
+			newUsers.set(user.nick.toLowerCase(), newUser);
 		});
 
-		chan.users = data.users.map((user) => {
-			const oldUser = oldUsers.get(user.nick);
-
-			// For existing users, we only need to update mode
-			if (oldUser) {
-				oldUser.setModes(user.modes, network.prefixLookup);
-				return oldUser;
-			}
-
-			return new User({
-				nick: user.nick,
-				modes: user.modes,
-			}, network.prefixLookup);
-		});
-
-		chan.sortUsers(irc);
+		chan.users = newUsers;
 
 		client.emit("users", {
 			chan: chan.id,

--- a/src/plugins/irc-events/nick.js
+++ b/src/plugins/irc-events/nick.js
@@ -32,6 +32,10 @@ module.exports = function(irc, network) {
 				return;
 			}
 
+			chan.removeUser(user);
+			user.nick = data.new_nick;
+			chan.setUser(user);
+
 			msg = new Msg({
 				time: data.time,
 				from: user,
@@ -43,7 +47,6 @@ module.exports = function(irc, network) {
 
 			user.nick = data.new_nick;
 
-			chan.sortUsers(irc);
 			client.emit("users", {
 				chan: chan.id,
 			});

--- a/src/plugins/irc-events/part.js
+++ b/src/plugins/irc-events/part.js
@@ -32,7 +32,7 @@ module.exports = function(irc, network) {
 			});
 			chan.pushMessage(client, msg);
 
-			chan.users = _.without(chan.users, user);
+			chan.removeUser(user);
 			client.emit("users", {
 				chan: chan.id,
 			});

--- a/src/plugins/irc-events/quit.js
+++ b/src/plugins/irc-events/quit.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const _ = require("lodash");
 const Msg = require("../../models/msg");
 
 module.exports = function(irc, network) {
@@ -23,7 +22,7 @@ module.exports = function(irc, network) {
 			});
 			chan.pushMessage(client, msg);
 
-			chan.users = _.without(chan.users, user);
+			chan.removeUser(user);
 			client.emit("users", {
 				chan: chan.id,
 			});


### PR DESCRIPTION
Main reason is that `findUser` is now O(1) instead of being O(n).

This also no longer sorts user list on every update, only when the client requests the user list.