### PR TITLE
Deprecate support of Node v4 in preparation of The Lounge v3

### DIFF
--- a/src/command-line/index.js
+++ b/src/command-line/index.js
@@ -7,13 +7,18 @@ const colors = require("colors/safe");
 const Helper = require("../helper");
 const Utils = require("./utils");
 
+if (require("semver").lt(process.version, "6.0.0")) {
+	log.warn(`Support of Node.js v4 is ${colors.bold("deprecated")} and will be removed in The Lounge v3.`);
+	log.warn("Please upgrade to Node.js v6 or more recent.");
+}
+
 program.version(Helper.getVersion(), "-v, --version")
 	.option("--home <path>", `${colors.bold("[DEPRECATED]")} Use the ${colors.green("LOUNGE_HOME")} environment variable instead.`)
 	.on("--help", Utils.extraHelp)
 	.parseOptions(process.argv);
 
 if (program.home) {
-	log.warn(`${colors.green("--home")} is ${colors.bold("deprecated")} and will be removed in a future version.`);
+	log.warn(`${colors.green("--home")} is ${colors.bold("deprecated")} and will be removed in The Lounge v3.`);
 	log.warn(`Use the ${colors.green("LOUNGE_HOME")} environment variable instead.`);
 }
 

--- a/src/server.js
+++ b/src/server.js
@@ -30,7 +30,7 @@ var manager = null;
 
 module.exports = function() {
 	log.info(`The Lounge ${colors.green(Helper.getVersion())} \
-(node ${colors.green(process.versions.node)} on ${colors.green(process.platform)} ${process.arch})`);
+(Node.js ${colors.green(process.versions.node)} on ${colors.green(process.platform)} ${process.arch})`);
 	log.info(`Configuration file: ${colors.green(Helper.CONFIG_PATH)}`);
 
 	if (!fs.existsSync("public/js/bundle.js")) {


### PR DESCRIPTION
This is one step towards #1663, the actual removal will happen with The Lounge v3.

<img width="711" alt="screen shot 2017-11-18 at 13 45 04" src="https://user-images.githubusercontent.com/113730/32983754-e0af8112-cc67-11e7-9752-9c62c472416d.png">
