### PR TITLE
Remove deprecated support for CSS filenames in theme configuration

### DIFF
--- a/client/index.html.tpl
+++ b/client/index.html.tpl
@@ -10,7 +10,7 @@
 	<link rel="stylesheet" href="css/bootstrap.css">
 	<link rel="stylesheet" href="css/primer-tooltips.css">
 	<link rel="stylesheet" href="css/style.css">
-	<link id="theme" rel="stylesheet" href="<%- theme %>">
+	<link id="theme" rel="stylesheet" href="themes/<%- theme %>.css" data-server-theme="<%- theme %>">
 	<% _.forEach(stylesheets, function(css) { %>
 		<link rel="stylesheet" href="packages/<%- css %>">
 	<% }); %>

--- a/client/js/options.js
+++ b/client/js/options.js
@@ -22,13 +22,11 @@ const options = {
 	notifyAllMessages: false,
 	showSeconds: false,
 	statusMessages: "condensed",
-	theme: $("#theme").prop("href").match(/themes\/(.*?)\.css$/), // TODO: Make this a data attribute in v3
+	theme: $("#theme").data("server-theme"),
 	media: true,
 	userStyles: userStyles.text(),
 };
 let userOptions = JSON.parse(storage.get("settings")) || {};
-
-options.theme = options.theme ? options.theme[1] : "example"; // TODO: Remove in v3
 
 for (const key in options) {
 	if (userOptions[key] !== undefined) {

--- a/src/helper.js
+++ b/src/helper.js
@@ -99,14 +99,6 @@ function setHome(newPath) {
 	// Load theme color from manifest.json
 	const manifest = require("../public/manifest.json");
 	this.config.themeColor = manifest.theme_color;
-
-	// TODO: Remove in future release
-	// Backwards compatibility for old way of specifying themes in settings
-	if (this.config.theme.includes(".css")) {
-		log.warn(`Referring to CSS files in the ${colors.green("theme")} setting of ${colors.green(configPath)} is ${colors.bold.red("deprecated")} and will be removed in a future version.`);
-	} else {
-		this.config.theme = `themes/${this.config.theme}.css`;
-	}
 }
 
 function getHomePath() {


### PR DESCRIPTION
Fixes #1596. Fixes #2034.

I very briefly tested this and, as far as I can tell, it works.