### PR TITLE
Remove deprecated support for the `--home` option and `$LOUNGE_HOME` environment variable

### DIFF
--- a/src/command-line/index.js
+++ b/src/command-line/index.js
@@ -16,7 +16,6 @@ if (require("semver").lt(process.version, "6.0.0")) {
 }
 
 program.version(Helper.getVersion(), "-v, --version")
-	.option("--home <path>", `${colors.bold.red("[DEPRECATED]")} Use the ${colors.green("THELOUNGE_HOME")} environment variable instead.`)
 	.option(
 		"-c, --config <key=value>",
 		"override entries of the configuration file, must be specified for each entry that needs to be overriden",
@@ -26,10 +25,6 @@ program.version(Helper.getVersion(), "-v, --version")
 
 // Parse options from `argv` returning `argv` void of these options.
 const argvWithoutOptions = program.parseOptions(process.argv);
-
-if (program.home) {
-	log.warn(`${colors.bold("--home")} is ${colors.bold.red("deprecated")} and will be removed in The Lounge v3. Use the ${colors.bold("THELOUNGE_HOME")} environment variable instead.`);
-}
 
 // Check if the app was built before calling setHome as it wants to load manifest.json from the public folder
 if (!fs.existsSync(path.join(
@@ -43,18 +38,7 @@ if (!fs.existsSync(path.join(
 	process.exit(1);
 }
 
-if (process.env.LOUNGE_HOME) {
-	log.warn(`${colors.green("LOUNGE_HOME")} is ${colors.bold.red("deprecated")} and will be removed in The Lounge v3.`);
-	log.warn(`Use ${colors.green("THELOUNGE_HOME")} instead.`);
-}
-
-let home = process.env.THELOUNGE_HOME || program.home || process.env.LOUNGE_HOME;
-
-if (!home) {
-	home = Utils.defaultHome();
-}
-
-Helper.setHome(home);
+Helper.setHome(process.env.THELOUNGE_HOME || Utils.defaultHome());
 
 // Merge config key-values passed as CLI options into the main config
 _.merge(Helper.config, program.config);


### PR DESCRIPTION
Resolves https://github.com/thelounge/lounge/issues/1594.
This is a follow-up of https://github.com/thelounge/lounge/pull/1717 meant to remove the deprecated notice and support.