### PR TITLE
Call callback on fetch error

### DIFF
--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -175,7 +175,7 @@ function fetch(uri, cb) {
 				limit = 1024 * 50;
 			}
 		})
-		.on("error", function() {})
+		.on("error", () => cb(null))
 		.on("data", (data) => {
 			length += data.length;
 			buffers.push(data);


### PR DESCRIPTION
With storage enabled, it was possible for thumbnails to retain their original urls if fetch failed (usually a timeout).