### PR TITLE
Trigger keep to bottom for previews correctly

### DIFF
--- a/client/js/renderPreview.js
+++ b/client/js/renderPreview.js
@@ -29,12 +29,12 @@ function renderPreview(preview, msg) {
 
 	preview.shown = preview.shown && options.shouldOpenMessagePreview(preview.type);
 
-	const container = msg.closest(".chat");
-	const channelId = container.data("id");
-	const activeChannelId = chat.find(".chan.active").data("id");
+	const container = msg.closest(".messages");
+	const channelId = container.closest(".chan").data("id") || -1;
+	const activeChannelId = chat.find(".chan.active").data("id") || -2;
 
 	let bottom = false;
-	if (container.length && activeChannelId === channelId) {
+	if (activeChannelId === channelId) {
 		bottom = container.isScrollBottom();
 	}
 


### PR DESCRIPTION
- Other parts of the code trigger keep to bottom on `.messages` (like when appending a message)
- Do not trigger keepToBottom when rendering initial messages (undefined == undefined)
- Fix scroll not being kept to bottom when new preview arrives (I broke this in #1739)