### PR TITLE
Parallelize `npm test`

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test": "npm-run-all --aggregate-output --parallel --continue-on-error test:* lint:*",
     "test:mocha": "mocha --colors",
     "lint:js": "eslint . --report-unused-disable-directives --color",
-    "lint:css": "stylelint --color \"client/**/*.css\""
+    "lint:css": "stylelint --color --report-needless-disables=error \"client/**/*.css\""
   },
   "keywords": [
     "lounge",

--- a/package.json
+++ b/package.json
@@ -18,11 +18,10 @@
     "build": "npm-run-all build:*",
     "build:webpack": "webpack",
     "watch": "webpack --watch",
-    "test": "npm-run-all -c test:* lint",
-    "test:mocha": "mocha",
-    "lint": "npm-run-all -c lint:*",
-    "lint:js": "eslint . --report-unused-disable-directives",
-    "lint:css": "stylelint \"client/**/*.css\""
+    "test": "npm-run-all --aggregate-output --parallel --continue-on-error test:* lint:*",
+    "test:mocha": "mocha --colors",
+    "lint:js": "eslint . --report-unused-disable-directives --color",
+    "lint:css": "stylelint --color \"client/**/*.css\""
   },
   "keywords": [
     "lounge",


### PR DESCRIPTION
### Parallelize `npm test`

After this, tests run in ~7s locally vs. ~14s without. ¯\\\_(ツ)_/¯
One caveat is that coloring must be forced now. See why [here](https://github.com/mysticatea/npm-run-all/blob/HEAD/docs/npm-run-all.md#known-limitations).
~Let's hope this looks okay on Travis.~ It does.

### Make stylelint report unnecessary disables
 
From the man:

```
    --report-needless-disables, --rd

      Report stylelint-disable comments that are not blocking a lint warning.
      If you provide the argument "error", the process will exit with code 2
      if needless disables are found.
```