### PR TITLE
Get rid of `Object.assign` polyfill

### DIFF
--- a/client/js/libs/handlebars/ircmessageparser/merge.js
+++ b/client/js/libs/handlebars/ircmessageparser/merge.js
@@ -3,26 +3,13 @@
 const anyIntersection = require("./anyIntersection");
 const fill = require("./fill");
 
-let Object_assign = Object.assign;
-
-if (typeof Object_assign !== "function") {
-	Object_assign = function(target) {
-		Array.prototype.slice.call(arguments, 1).forEach(function(obj) {
-			Object.keys(obj).forEach(function(key) {
-				target[key] = obj[key];
-			});
-		});
-		return target;
-	};
-}
-
 // Merge text part information within a styling fragment
 function assign(textPart, fragment) {
 	const fragStart = fragment.start;
 	const start = Math.max(fragment.start, textPart.start);
 	const end = Math.min(fragment.end, textPart.end);
 
-	return Object_assign({}, fragment, {
+	return Object.assign({}, fragment, {
 		start: start,
 		end: end,
 		text: fragment.text.slice(start - fragStart, end - fragStart),


### PR DESCRIPTION
As far as I know, this is only required for IE at this point, and we have already made changes that removed support of any version of IE.

Not sure if this is a v2.7.0 or v3.0.0 PR. @xPaw, what do you think?