### PR TITLE
Fix nicks and modes for messages being unintentionally updated later on

### DIFF
--- a/src/models/user.js
+++ b/src/models/user.js
@@ -30,3 +30,10 @@ User.prototype.toJSON = function() {
 		lastMessage: this.lastMessage,
 	};
 };
+
+User.prototype.value = function() {
+	return {
+		nick: this.nick,
+		mode: this.mode,
+	};
+};

--- a/src/plugins/irc-events/away.js
+++ b/src/plugins/irc-events/away.js
@@ -18,7 +18,7 @@ module.exports = function(irc, network) {
 				type: away ? Msg.Type.AWAY : Msg.Type.BACK,
 				text: away || "",
 				time: data.time,
-				from: user,
+				from: user.value(),
 			});
 
 			chan.pushMessage(client, msg);

--- a/src/plugins/irc-events/ctcp.js
+++ b/src/plugins/irc-events/ctcp.js
@@ -15,7 +15,7 @@ module.exports = function(irc, network) {
 		const msg = new Msg({
 			type: Msg.Type.CTCP,
 			time: data.time,
-			from: chan.getUser(data.nick),
+			from: chan.getUser(data.nick).value(),
 			ctcpType: data.type,
 			ctcpMessage: data.message,
 		});

--- a/src/plugins/irc-events/invite.js
+++ b/src/plugins/irc-events/invite.js
@@ -15,8 +15,8 @@ module.exports = function(irc, network) {
 		const msg = new Msg({
 			type: Msg.Type.INVITE,
 			time: data.time,
-			from: chan.getUser(data.nick),
-			invited: chan.getUser(data.invited),
+			from: chan.getUser(data.nick).value(),
+			invited: chan.getUser(data.invited).value(),
 			channel: data.channel,
 			highlight: true,
 			invitedYou: data.invited === irc.user.nick,

--- a/src/plugins/irc-events/join.js
+++ b/src/plugins/irc-events/join.js
@@ -28,7 +28,7 @@ module.exports = function(irc, network) {
 		const user = new User({nick: data.nick});
 		const msg = new Msg({
 			time: data.time,
-			from: user,
+			from: user.value(),
 			hostmask: data.ident + "@" + data.hostname,
 			type: Msg.Type.JOIN,
 			self: data.nick === irc.user.nick,

--- a/src/plugins/irc-events/kick.js
+++ b/src/plugins/irc-events/kick.js
@@ -15,8 +15,8 @@ module.exports = function(irc, network) {
 		const msg = new Msg({
 			type: Msg.Type.KICK,
 			time: data.time,
-			from: chan.getUser(data.nick),
-			target: chan.getUser(data.kicked),
+			from: chan.getUser(data.nick).value(),
+			target: chan.getUser(data.kicked).value(),
 			text: data.message || "",
 			highlight: data.kicked === irc.user.nick,
 			self: data.nick === irc.user.nick,

--- a/src/plugins/irc-events/message.js
+++ b/src/plugins/irc-events/message.js
@@ -100,7 +100,7 @@ module.exports = function(irc, network) {
 		const msg = new Msg({
 			type: data.type,
 			time: data.time,
-			from: user,
+			from: user.value(),
 			text: data.message,
 			self: self,
 			highlight: highlight,

--- a/src/plugins/irc-events/mode.js
+++ b/src/plugins/irc-events/mode.js
@@ -69,7 +69,7 @@ module.exports = function(irc, network) {
 			const msg = new Msg({
 				time: data.time,
 				type: Msg.Type.MODE,
-				from: targetChan.getUser(data.nick),
+				from: targetChan.getUser(data.nick).value(),
 				text: text,
 				self: data.nick === irc.user.nick,
 			});

--- a/src/plugins/irc-events/nick.js
+++ b/src/plugins/irc-events/nick.js
@@ -38,7 +38,7 @@ module.exports = function(irc, network) {
 
 			msg = new Msg({
 				time: data.time,
-				from: user,
+				from: user.value(),
 				type: Msg.Type.NICK,
 				new_nick: data.new_nick,
 				self: self,

--- a/src/plugins/irc-events/part.js
+++ b/src/plugins/irc-events/part.js
@@ -28,7 +28,7 @@ module.exports = function(irc, network) {
 				time: data.time,
 				text: data.message || "",
 				hostmask: data.ident + "@" + data.hostname,
-				from: user,
+				from: user.value(),
 			});
 			chan.pushMessage(client, msg);
 

--- a/src/plugins/irc-events/quit.js
+++ b/src/plugins/irc-events/quit.js
@@ -18,7 +18,7 @@ module.exports = function(irc, network) {
 				type: Msg.Type.QUIT,
 				text: data.message || "",
 				hostmask: data.ident + "@" + data.hostname,
-				from: user,
+				from: user.value(),
 			});
 			chan.pushMessage(client, msg);
 

--- a/src/plugins/irc-events/topic.js
+++ b/src/plugins/irc-events/topic.js
@@ -15,7 +15,7 @@ module.exports = function(irc, network) {
 		const msg = new Msg({
 			time: data.time,
 			type: Msg.Type.TOPIC,
-			from: data.nick && chan.getUser(data.nick),
+			from: data.nick && chan.getUser(data.nick).value(),
 			text: data.topic,
 			self: data.nick === irc.user.nick,
 		});
@@ -37,7 +37,7 @@ module.exports = function(irc, network) {
 
 		const msg = new Msg({
 			type: Msg.Type.TOPIC_SET_BY,
-			from: chan.getUser(data.nick),
+			from: chan.getUser(data.nick).value(),
 			when: new Date(data.when * 1000),
 			self: data.nick === irc.user.nick,
 		});


### PR DESCRIPTION
Fixes #1765

I probably would have just stuck in a `_.clone` in there, but @xPaw made the point that it should probably only have those values.
```
<PolarizedIons>  hmm :\ thought it was an easy fix, and you could just put in a _.clone in there, but then modes don't get updated
<+xPaw>  Msg has to store a clone, yes
<+xPaw>  but getUser must not return one
<+xPaw>  and ideally with just 2 keys, nick+mode, and not whatever else is in user obj
```

I had to do the check that it is an object, because if `from` is a string, and I `_.pick` from it, it would return an empty object, which would crash on the client when trying to render the (undefined) nickname.

I did a quick test to see if it was working, and it doesn't look like the other fields in `from` were being used