### PR TITLE
Increase timeout of server tests

### DIFF
--- a/test/server.js
+++ b/test/server.js
@@ -5,7 +5,8 @@ const expect = require("chai").expect;
 const request = require("request");
 const io = require("socket.io-client");
 
-describe("Server", () => {
+describe("Server", function() {
+	this.timeout(5000);
 	let server;
 
 	before(() => {


### PR DESCRIPTION
I've noticed this in https://github.com/thelounge/lounge/pull/1726 and thought it was my fault, but `master` actually has that issue from time to time, and so did https://github.com/thelounge/lounge/pull/1767.

I don't know if we want to be okay with the tests timing out or not, so here it is. Also, I didn't want to enable this globally for all tests, because it's only about one test right now. I'd rather avoid allow this globally :man_shrugging: 