### PR TITLE
Clone instances of `User` in `Msg` to avoid unintentional mutations

### DIFF
--- a/client/views/actions/invite.tpl
+++ b/client/views/actions/invite.tpl
@@ -3,7 +3,7 @@ invited
 {{#if invitedYou}}
 	you
 {{else}}
-	{{> ../user_name invited}}
+	{{> ../user_name target}}
 {{/if}}
 to
 {{{parse channel}}}

--- a/src/models/msg.js
+++ b/src/models/msg.js
@@ -6,6 +6,18 @@ var id = 0;
 
 class Msg {
 	constructor(attr) {
+		// Some properties need to be copied in the Msg object instead of referenced
+		if (attr) {
+			["from", "target"].forEach((prop) => {
+				if (attr[prop]) {
+					this[prop] = {
+						mode: attr[prop].mode,
+						nick: attr[prop].nick,
+					};
+				}
+			});
+		}
+
 		_.defaults(this, attr, {
 			from: "",
 			id: id++,

--- a/src/plugins/irc-events/invite.js
+++ b/src/plugins/irc-events/invite.js
@@ -16,7 +16,7 @@ module.exports = function(irc, network) {
 			type: Msg.Type.INVITE,
 			time: data.time,
 			from: chan.getUser(data.nick),
-			invited: chan.getUser(data.invited),
+			target: chan.getUser(data.invited),
 			channel: data.channel,
 			highlight: true,
 			invitedYou: data.invited === irc.user.nick,

--- a/test/models/msg.js
+++ b/test/models/msg.js
@@ -3,8 +3,27 @@
 const expect = require("chai").expect;
 
 const Msg = require("../../src/models/msg");
+const User = require("../../src/models/user");
 
 describe("Msg", function() {
+	["from", "target"].forEach((prop) => {
+		it(`should keep a copy of the original user in the \`${prop}\` property`, function() {
+			const prefixLookup = {a: "&", o: "@"};
+			const user = new User({
+				modes: ["o"],
+				nick: "foo",
+			}, prefixLookup);
+			const msg = new Msg({[prop]: user});
+
+			// Mutating the user
+			user.setModes(["a"], prefixLookup);
+			user.nick = "bar";
+
+			// Message's `.from`/etc. should still refer to the original user
+			expect(msg[prop]).to.deep.equal({mode: "@", nick: "foo"});
+		});
+	});
+
 	describe("#findPreview(link)", function() {
 		const msg = new Msg({
 			previews: [{


### PR DESCRIPTION
Fixes #1765.

This supersedes #1767. I find this way preferable because we have better ways to ensure this security. Also, test case!

Ah, if only we were using https://github.com/facebook/immutable-js/ :trollface: 