### PR TITLE
Fix nick changes wrongly reported

### DIFF
--- a/src/plugins/irc-events/nick.js
+++ b/src/plugins/irc-events/nick.js
@@ -32,10 +32,6 @@ module.exports = function(irc, network) {
 				return;
 			}
 
-			chan.removeUser(user);
-			user.nick = data.new_nick;
-			chan.setUser(user);
-
 			msg = new Msg({
 				time: data.time,
 				from: user,
@@ -45,7 +41,9 @@ module.exports = function(irc, network) {
 			});
 			chan.pushMessage(client, msg);
 
+			chan.removeUser(user);
 			user.nick = data.new_nick;
+			chan.setUser(user);
 
 			client.emit("users", {
 				chan: chan.id,


### PR DESCRIPTION
Before | After
--- | ---
<img width="286" alt="screen shot 2017-11-29 at 01 41 36" src="https://user-images.githubusercontent.com/113730/33361599-d92263dc-d4a6-11e7-88d1-f5335cf60047.png"> | <img width="289" alt="screen shot 2017-11-29 at 01 40 28" src="https://user-images.githubusercontent.com/113730/33361598-d9166f8c-d4a6-11e7-999f-f03aeb5c4284.png">

⚠️ Note that this fix will only work after #1771 gets merged. The bug this PR fixes is due to `user.nick` being set too early **and** `msg.from` being modified after instantiating `msg`.