### PR TITLE
Fix default value given to `Msg.from`

### DIFF
--- a/client/views/actions/topic.tpl
+++ b/client/views/actions/topic.tpl
@@ -1,4 +1,4 @@
-{{#if from}}
+{{#if from.nick}}
 	{{> ../user_name from}}
 	has changed the topic to:
 {{else}}

--- a/client/views/msg.tpl
+++ b/client/views/msg.tpl
@@ -3,7 +3,7 @@
 		{{tz time}}
 	</span>
 	<span class="from">
-		{{#if from}}
+		{{#if from.nick}}
 			{{> user_name from}}
 		{{/if}}
 	</span>

--- a/src/models/msg.js
+++ b/src/models/msg.js
@@ -7,7 +7,7 @@ var id = 0;
 class Msg {
 	constructor(attr) {
 		_.defaults(this, attr, {
-			from: "",
+			from: {},
 			id: id++,
 			previews: [],
 			text: "",


### PR DESCRIPTION
- `{}` is not falsey so Handlebars would try to render the block (see http://handlebarsjs.com/builtin_helpers.html#conditionals), therefore with a `nick` of `undefined`, which breaks `colorClass` (doing `undefined.length)
- There does not seem to be a way to check for empty objects in Handlebars (sigh) so checking `from.nick` seems like the most reliable way to check for a non-empty value. Alternatively, we could use a helper to check `{}` but meh.

This is of course all invalidated if we want to keep `""` as the default value for `from`, but considering that we now store user objects instead of nick strings, I'm really not sure we should. @xPaw, what do you think?