### PR TITLE
Heavily improve performance of "init" event

### DIFF
--- a/client/views/chat.tpl
+++ b/client/views/chat.tpl
@@ -12,7 +12,7 @@
 		<span title="{{topic}}" class="topic">{{{parse topic}}}</span>
 	</div>
 	<div class="chat">
-		<div class="show-more {{#equal messages.length 100}}show{{/equal}}">
+		<div class="show-more{{#if messages.length}} show{{/if}}">
 			<button class="show-more-button" data-id="{{id}}">Show older messages</button>
 		</div>
 		<div class="messages"></div>

--- a/src/client.js
+++ b/src/client.js
@@ -196,7 +196,7 @@ Client.prototype.connect = function(args) {
 
 	client.networks.push(network);
 	client.emit("network", {
-		networks: [network],
+		networks: [network.getFilteredClone(this.lastActiveChannel, -1)],
 	});
 
 	if (config.lockNetwork) {

--- a/src/models/chan.js
+++ b/src/models/chan.js
@@ -139,7 +139,7 @@ Chan.prototype.removeUser = function(user) {
 Chan.prototype.toJSON = function() {
 	var clone = _.clone(this);
 	clone.users = []; // Do not send user list, the client will explicitly request it when needed
-	clone.messages = clone.messages.slice(-100);
+	clone.messages = clone.messages.slice(-1);
 	return clone;
 };
 

--- a/src/models/chan.js
+++ b/src/models/chan.js
@@ -136,11 +136,39 @@ Chan.prototype.removeUser = function(user) {
 	this.users.delete(user.nick.toLowerCase());
 };
 
-Chan.prototype.toJSON = function() {
-	var clone = _.clone(this);
-	clone.users = []; // Do not send user list, the client will explicitly request it when needed
-	clone.messages = clone.messages.slice(-1);
-	return clone;
+/**
+ * Get a clean clone of this channel that will be sent to the client.
+ * This function performs manual cloning of channel object for
+ * better control of performance and memory usage.
+ *
+ * @param {(int|bool)} lastActiveChannel - Last known active user channel id (needed to control how many messages are sent)
+ *                                         If true, channel is assumed active.
+ * @param {int} lastMessage - Last message id seen by active client to avoid sending duplicates.
+ */
+Chan.prototype.getFilteredClone = function(lastActiveChannel, lastMessage) {
+	return Object.keys(this).reduce((newChannel, prop) => {
+		if (prop === "users") {
+			// Do not send users, client requests updated user list whenever needed
+			newChannel[prop] = [];
+		} else if (prop === "messages") {
+			// If channel is active, send up to 100 last messages, for all others send just 1
+			// Client will automatically load more messages whenever needed based on last seen messages
+			const messagesToSend = lastActiveChannel === true || this.id === lastActiveChannel ? -100 : -1;
+
+			// If client is reconnecting, only send new messages that client has not seen yet
+			if (lastMessage > -1) {
+				newChannel[prop] = this[prop]
+					.filter((m) => m.id > lastMessage)
+					.slice(messagesToSend);
+			} else {
+				newChannel[prop] = this[prop].slice(messagesToSend);
+			}
+		} else {
+			newChannel[prop] = this[prop];
+		}
+
+		return newChannel;
+	}, {});
 };
 
 function writeUserLog(client, msg) {

--- a/src/plugins/inputs/query.js
+++ b/src/plugins/inputs/query.js
@@ -47,6 +47,6 @@ exports.input = function(network, chan, cmd, args) {
 	network.channels.push(newChan);
 	this.emit("join", {
 		network: network.id,
-		chan: newChan,
+		chan: newChan.getFilteredClone(true),
 	});
 };

--- a/src/plugins/irc-events/banlist.js
+++ b/src/plugins/irc-events/banlist.js
@@ -29,7 +29,7 @@ module.exports = function(irc, network) {
 			network.channels.push(chan);
 			client.emit("join", {
 				network: network.id,
-				chan: chan,
+				chan: chan.getFilteredClone(true),
 			});
 		}
 

--- a/src/plugins/irc-events/join.js
+++ b/src/plugins/irc-events/join.js
@@ -18,7 +18,7 @@ module.exports = function(irc, network) {
 			client.save();
 			client.emit("join", {
 				network: network.id,
-				chan: chan,
+				chan: chan.getFilteredClone(true),
 			});
 
 			// Request channels' modes

--- a/src/plugins/irc-events/list.js
+++ b/src/plugins/irc-events/list.js
@@ -49,7 +49,7 @@ module.exports = function(irc, network) {
 			network.channels.push(chan);
 			client.emit("join", {
 				network: network.id,
-				chan: chan,
+				chan: chan.getFilteredClone(true),
 			});
 		}
 

--- a/src/plugins/irc-events/message.js
+++ b/src/plugins/irc-events/message.js
@@ -68,7 +68,7 @@ module.exports = function(irc, network) {
 					network.channels.push(chan);
 					client.emit("join", {
 						network: network.id,
-						chan: chan,
+						chan: chan.getFilteredClone(true),
 					});
 				}
 			}

--- a/src/plugins/irc-events/whois.js
+++ b/src/plugins/irc-events/whois.js
@@ -17,7 +17,7 @@ module.exports = function(irc, network) {
 			client.emit("join", {
 				shouldOpen: true,
 				network: network.id,
-				chan: chan,
+				chan: chan.getFilteredClone(true),
 			});
 		}
 

--- a/src/server.js
+++ b/src/server.js
@@ -420,24 +420,11 @@ function initializeClient(socket, client, token, lastMessage) {
 	socket.join(client.id);
 
 	const sendInitEvent = (tokenToSend) => {
-		let networks = client.networks;
-
-		if (lastMessage > -1) {
-			// We need a deep cloned object because we are going to remove unneeded messages
-			networks = _.cloneDeep(networks);
-
-			networks.forEach((network) => {
-				network.channels.forEach((channel) => {
-					channel.messages = channel.messages.filter((m) => m.id > lastMessage);
-				});
-			});
-		}
-
 		socket.emit("init", {
 			applicationServerKey: manager.webPush.vapidKeys.publicKey,
 			pushSubscription: client.config.sessions[token],
 			active: client.lastActiveChannel,
-			networks: networks,
+			networks: client.networks.map((network) => network.getFilteredClone(client.lastActiveChannel, lastMessage)),
 			token: tokenToSend,
 		});
 	};

--- a/test/models/chan.js
+++ b/test/models/chan.js
@@ -145,4 +145,91 @@ describe("Chan", function() {
 			]);
 		});
 	});
+
+	describe("#getFilteredClone(lastActiveChannel, lastMessage)", function() {
+		it("should send empty user list", function() {
+			const chan = new Chan();
+			chan.setUser(new User({nick: "test"}));
+
+			expect(chan.getFilteredClone().users).to.be.empty;
+		});
+
+		it("should keep necessary properties", function() {
+			const chan = new Chan();
+
+			expect(chan.getFilteredClone()).to.be.an("object").that.has.all.keys(
+				"firstUnread",
+				"highlight",
+				"id",
+				"key",
+				"messages",
+				"name",
+				"topic",
+				"type",
+				"unread",
+				"users"
+			);
+		});
+
+		it("should send only last message for non active channel", function() {
+			const chan = new Chan({
+				id: 1337,
+				messages: [
+					new Msg({id: 10}),
+					new Msg({id: 11}),
+					new Msg({id: 12}),
+					new Msg({id: 13}),
+				],
+			});
+
+			expect(chan.id).to.equal(1337);
+
+			const messages = chan.getFilteredClone(999).messages;
+
+			expect(messages).to.have.lengthOf(1);
+			expect(messages[0].id).to.equal(13);
+		});
+
+		it("should send more messages for active channel", function() {
+			const chan = new Chan({
+				id: 1337,
+				messages: [
+					new Msg({id: 10}),
+					new Msg({id: 11}),
+					new Msg({id: 12}),
+					new Msg({id: 13}),
+				],
+			});
+
+			expect(chan.id).to.equal(1337);
+
+			const messages = chan.getFilteredClone(1337).messages;
+
+			expect(messages).to.have.lengthOf(4);
+			expect(messages[0].id).to.equal(10);
+			expect(messages[3].id).to.equal(13);
+		});
+
+		it("should only send new messages", function() {
+			const chan = new Chan({
+				id: 1337,
+				messages: [
+					new Msg({id: 10}),
+					new Msg({id: 11}),
+					new Msg({id: 12}),
+					new Msg({id: 13}),
+					new Msg({id: 14}),
+					new Msg({id: 15}),
+				],
+			});
+
+			expect(chan.id).to.equal(1337);
+
+			const messages = chan.getFilteredClone(1337, 12).messages;
+
+			expect(messages).to.have.lengthOf(3);
+			expect(messages[0].id).to.equal(13);
+			expect(messages[2].id).to.equal(15);
+		});
+	});
 });

--- a/test/models/chan.js
+++ b/test/models/chan.js
@@ -208,6 +208,8 @@ describe("Chan", function() {
 			expect(messages).to.have.lengthOf(4);
 			expect(messages[0].id).to.equal(10);
 			expect(messages[3].id).to.equal(13);
+
+			expect(chan.getFilteredClone(true).messages).to.have.lengthOf(4);
 		});
 
 		it("should only send new messages", function() {

--- a/test/models/network.js
+++ b/test/models/network.js
@@ -1,10 +1,10 @@
 "use strict";
 
-var expect = require("chai").expect;
-
-var Chan = require("../../src/models/chan");
-var Msg = require("../../src/models/msg");
-var Network = require("../../src/models/network");
+const expect = require("chai").expect;
+const Chan = require("../../src/models/chan");
+const Msg = require("../../src/models/msg");
+const User = require("../../src/models/user");
+const Network = require("../../src/models/network");
 
 describe("Network", function() {
 	describe("#export()", function() {
@@ -89,6 +89,40 @@ describe("Network", function() {
 			expect(network.channels[1].messages[0].text).to.equal("message in constructor");
 			expect(network.channels[1].messages[1].text).to.equal("message in original instance");
 			expect(network.channels[1].messages[2].text).to.equal("message after network creation");
+		});
+	});
+
+	describe("#getFilteredClone(lastActiveChannel, lastMessage)", function() {
+		it("should filter channels", function() {
+			const chan = new Chan();
+			chan.setUser(new User({nick: "test"}));
+
+			const network = new Network({
+				channels: [
+					chan,
+				],
+			});
+
+			expect(network.channels[0].users).to.be.empty;
+		});
+
+		it("should keep necessary properties", function() {
+			const network = new Network();
+
+			expect(network.getFilteredClone()).to.be.an("object").that.has.all.keys(
+				"channels",
+				"commands",
+				"host",
+				"hostname",
+				"id",
+				"ip",
+				"name",
+				"port",
+				"realname",
+				"serverOptions",
+				"tls",
+				"username"
+			);
 		});
 	});
 });


### PR DESCRIPTION
- Fixes #1145: Send 100 messages for active channel, and 1 message for all others on init.
- Fixes #1575: Do not perform heavy cloning of network and channel objects on init (especially when reconnecting)

Getting rid of lodash methods allows us to fine tune performance instead of blindly cloning entire object and then dropping values we don't need (heavy offenders being users and message arrays).