### PR TITLE
Do not rename home file as it is very likely to have permission issues

### DIFF
--- a/src/command-line/utils.js
+++ b/src/command-line/utils.js
@@ -23,12 +23,7 @@ class Utils {
 			return home;
 		}
 
-		const distConfig = path.resolve(path.join(
-			__dirname,
-			"..",
-			"..",
-			".thelounge_home"
-		));
+		let distConfig;
 
 		// TODO: Remove this section when releasing The Lounge v3
 		const deprecatedDistConfig = path.resolve(path.join(
@@ -39,9 +34,16 @@ class Utils {
 		));
 		if (fs.existsSync(deprecatedDistConfig)) {
 			log.warn(`${colors.green(".lounge_home")} is ${colors.bold("deprecated")} and will be ignored as of The Lounge v3.`);
-			log.warn(`Renaming to ${colors.green(".thelounge_home")} instead.`);
+			log.warn(`Use ${colors.green(".thelounge_home")} instead.`);
 
-			fs.renameSync(deprecatedDistConfig, distConfig);
+			distConfig = deprecatedDistConfig;
+		} else {
+			distConfig = path.resolve(path.join(
+				__dirname,
+				"..",
+				"..",
+				".thelounge_home"
+			));
 		}
 
 		home = fs.readFileSync(distConfig, "utf-8").trim();


### PR DESCRIPTION
On most systems (Linux at least), to install a npm package locally, one must use `sudo`. When The Lounge runs, it usually does not run with `sudo`. This causes the program to crash as user running The Lounge cannot create/delete files there.

We will let people manually convert this file instead of doing it for them. This file is mainly intended for package authors anyway, most users will never have to touch it.

```js
2017-12-01 02:55:15 [WARN] .lounge_home is deprecated and will be ignored as of The Lounge v3.
2017-12-01 02:55:15 [WARN] Renaming to .thelounge_home instead.
fs.js:681
  return binding.rename(pathModule._makeLong(oldPath),
                 ^

Error: EACCES: permission denied, rename '/usr/lib/node_modules/thelounge/.lounge_home' -> '/usr/lib/node_modules/thelounge/.thelounge_home'
    at Error (native)
    at Object.fs.renameSync (fs.js:681:18)
    at Function.defaultHome (/usr/lib/node_modules/thelounge/src/command-line/utils.js:44:7)
    at Object.<anonymous> (/usr/lib/node_modules/thelounge/src/command-line/index.js:47:15)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
```