### PR TITLE
Align message container to the bottom

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -862,6 +862,8 @@ kbd {
 	will-change: transform, scroll-position;
 	-webkit-overflow-scrolling: touch;
 	position: absolute;
+	display: flex;
+	flex-direction: column;
 }
 
 #chat .channel .chat {
@@ -914,6 +916,7 @@ kbd {
 #chat .messages {
 	padding: 10px 0;
 	touch-action: pan-y;
+	margin-top: auto;
 }
 
 #chat .msg {


### PR DESCRIPTION
Fixes message jumping when all the messages are visible without a scrollbar and new messages load in (if there are 90 condensed messages, there are only a couple of lines visible). Also makes it much nicer with lazy-init when there's only 1 message visible.

This pretty much matches behaviour of other chat apps where they begin stacking from the bottom.

![01-104224060](https://user-images.githubusercontent.com/613331/33479270-2bc89350-d695-11e7-8d7f-1a4427e37a7b.png)
