### PR TITLE
Add actualip to the actualhost line in the whois output

### DIFF
--- a/client/views/actions/whois.tpl
+++ b/client/views/actions/whois.tpl
@@ -2,11 +2,9 @@
 	{{> ../user_name nick=whois.nick}}
 	<i class="hostmask">({{whois.user}}@{{whois.host}})</i>
 </div>
-{{#if whois.actuallhost}}
+{{#if whois.actualhost}}
 <div>
-	Actual host
-	{{> ../user_name nick=whois.nick}}
-	<i class="hostmask">({{whois.user}}@{{whois.actuallhost}})</i>
+	{{> ../user_name nick=whois.nick}}'s actual host is: <i>{{whois.actualhost}}</i> (<i>{{whois.actualip}}</i>)
 </div>
 {{/if}}
 {{#if whois.real_name}}


### PR DESCRIPTION
Requires #1782 to be merged first.

irc-fw 2.10.0 has added a new `actualip` key to the whois object, and made it so the actualhosts are displayed on more networks eg. freenode when logged in. (It also breakes the current whois template because it changed the key from `actuallhost` to `actualhost`)

I know @xPaw wasn't the biggest fan of displaying the hostmask again, and it felt weird to just add more onto it, so I changed the formatting too.

The only "problem" right now is if the ircd doesn't resolve a host for you, it will display the ip twice. I couldn't figure out how to check string inequality in handlerbars to "solve" this, but if it is really important, I could look into it again.

How it looked before:
![](https://i.imgur.com/MCV548P.png)

After:
![](https://i.imgur.com/ccerEwA.png)