### PR TITLE
Do not load user commands or display them on `--help` if public mode or using LDAP

### DIFF
--- a/src/command-line/index.js
+++ b/src/command-line/index.js
@@ -51,7 +51,9 @@ Helper.setHome(home);
 
 require("./start");
 require("./config");
-require("./users");
+if (!Helper.config.public && !Helper.config.ldap.enable) {
+	require("./users");
+}
 require("./install");
 
 // TODO: Remove this when releasing The Lounge v3

--- a/src/command-line/index.js
+++ b/src/command-line/index.js
@@ -51,11 +51,7 @@ Helper.setHome(home);
 
 require("./start");
 require("./config");
-require("./list");
-require("./add");
-require("./remove");
-require("./reset");
-require("./edit");
+require("./users");
 require("./install");
 
 // TODO: Remove this when releasing The Lounge v3

--- a/src/command-line/users/add.js
+++ b/src/command-line/users/add.js
@@ -17,11 +17,6 @@ program
 		}
 
 		const ClientManager = require("../../clientManager");
-
-		if (Helper.config.public) {
-			log.warn(`Users have no effect in ${colors.bold("public")} mode.`);
-		}
-
 		const manager = new ClientManager();
 		const users = manager.getUsers();
 

--- a/src/command-line/users/add.js
+++ b/src/command-line/users/add.js
@@ -3,8 +3,8 @@
 const colors = require("colors/safe");
 const program = require("commander");
 const fs = require("fs");
-const Helper = require("../helper");
-const Utils = require("./utils");
+const Helper = require("../../helper");
+const Utils = require("../utils");
 
 program
 	.command("add <name>")
@@ -16,7 +16,7 @@ program
 			return;
 		}
 
-		const ClientManager = require("../clientManager");
+		const ClientManager = require("../../clientManager");
 
 		if (Helper.config.public) {
 			log.warn(`Users have no effect in ${colors.bold("public")} mode.`);

--- a/src/command-line/users/edit.js
+++ b/src/command-line/users/edit.js
@@ -18,8 +18,7 @@ program
 		}
 
 		const ClientManager = require("../../clientManager");
-
-		var users = new ClientManager().getUsers();
+		const users = new ClientManager().getUsers();
 
 		if (users === undefined) { // There was an error, already logged
 			return;

--- a/src/command-line/users/edit.js
+++ b/src/command-line/users/edit.js
@@ -4,8 +4,8 @@ const program = require("commander");
 const child = require("child_process");
 const colors = require("colors/safe");
 const fs = require("fs");
-const Helper = require("../helper");
-const Utils = require("./utils");
+const Helper = require("../../helper");
+const Utils = require("../utils");
 
 program
 	.command("edit <name>")
@@ -17,7 +17,7 @@ program
 			return;
 		}
 
-		const ClientManager = require("../clientManager");
+		const ClientManager = require("../../clientManager");
 
 		var users = new ClientManager().getUsers();
 

--- a/src/command-line/users/index.js
+++ b/src/command-line/users/index.js
@@ -1,0 +1,7 @@
+"use strict";
+
+require("./list");
+require("./add");
+require("./remove");
+require("./reset");
+require("./edit");

--- a/src/command-line/users/list.js
+++ b/src/command-line/users/list.js
@@ -3,8 +3,8 @@
 const colors = require("colors/safe");
 const program = require("commander");
 const fs = require("fs");
-const Helper = require("../helper");
-const Utils = require("./utils");
+const Helper = require("../../helper");
+const Utils = require("../utils");
 
 program
 	.command("list")
@@ -16,7 +16,7 @@ program
 			return;
 		}
 
-		const ClientManager = require("../clientManager");
+		const ClientManager = require("../../clientManager");
 
 		if (Helper.config.public) {
 			log.warn(`Users have no effect in ${colors.bold("public")} mode.`);

--- a/src/command-line/users/list.js
+++ b/src/command-line/users/list.js
@@ -17,12 +17,7 @@ program
 		}
 
 		const ClientManager = require("../../clientManager");
-
-		if (Helper.config.public) {
-			log.warn(`Users have no effect in ${colors.bold("public")} mode.`);
-		}
-
-		var users = new ClientManager().getUsers();
+		const users = new ClientManager().getUsers();
 
 		if (users === undefined) { // There was an error, already logged
 			return;

--- a/src/command-line/users/remove.js
+++ b/src/command-line/users/remove.js
@@ -3,8 +3,8 @@
 const colors = require("colors/safe");
 const program = require("commander");
 const fs = require("fs");
-const Helper = require("../helper");
-const Utils = require("./utils");
+const Helper = require("../../helper");
+const Utils = require("../utils");
 
 program
 	.command("remove <name>")
@@ -16,7 +16,7 @@ program
 			return;
 		}
 
-		const ClientManager = require("../clientManager");
+		const ClientManager = require("../../clientManager");
 		const manager = new ClientManager();
 
 		try {

--- a/src/command-line/users/reset.js
+++ b/src/command-line/users/reset.js
@@ -17,8 +17,7 @@ program
 		}
 
 		const ClientManager = require("../../clientManager");
-
-		var users = new ClientManager().getUsers();
+		const users = new ClientManager().getUsers();
 
 		if (users === undefined) { // There was an error, already logged
 			return;

--- a/src/command-line/users/reset.js
+++ b/src/command-line/users/reset.js
@@ -3,8 +3,8 @@
 const colors = require("colors/safe");
 const program = require("commander");
 const fs = require("fs");
-const Helper = require("../helper");
-const Utils = require("./utils");
+const Helper = require("../../helper");
+const Utils = require("../utils");
 
 program
 	.command("reset <name>")
@@ -16,7 +16,7 @@ program
 			return;
 		}
 
-		const ClientManager = require("../clientManager");
+		const ClientManager = require("../../clientManager");
 
 		var users = new ClientManager().getUsers();
 


### PR DESCRIPTION
Also move user commands to their own subfolder (which should unfold even more nicely in v3 I think).

Commands like `list` do not make sense when using LDAP (or public) as they load the user config files, and commands like `add` only make sense in private, non-LDAP mode.
In the future, we should allow plugins to add their own commands, in which case LDAP integration could itself have meaningful commands there. In the meantime, my understanding is that it's noise.

@gramakri, could you give your 👍 to confirm this PR?

(You can see I'm working on the re-docs for the CLI because I'm going to open a couple PRs on this 😅)