### PR TITLE
Do not expand paths when displaying them to the user

### DIFF
--- a/src/clientManager.js
+++ b/src/clientManager.js
@@ -43,7 +43,7 @@ ClientManager.prototype.autoloadUsers = function() {
 
 	users.forEach((name) => this.loadUser(name));
 
-	fs.watch(Helper.USERS_PATH, _.debounce(() => {
+	fs.watch(Helper.getUsersPath(), _.debounce(() => {
 		const loaded = this.clients.map((c) => c.name);
 		const updatedUsers = this.getUsers();
 
@@ -88,7 +88,7 @@ ClientManager.prototype.loadUser = function(name) {
 
 ClientManager.prototype.getUsers = function() {
 	return fs
-		.readdirSync(Helper.USERS_PATH)
+		.readdirSync(Helper.getUsersPath())
 		.filter((file) => file.endsWith(".json"))
 		.map((file) => file.slice(0, -5));
 };

--- a/src/command-line/add.js
+++ b/src/command-line/add.js
@@ -11,8 +11,8 @@ program
 	.description("Add a new user")
 	.on("--help", Utils.extraHelp)
 	.action(function(name) {
-		if (!fs.existsSync(Helper.USERS_PATH)) {
-			log.error(`${Helper.USERS_PATH} does not exist.`);
+		if (!fs.existsSync(Helper.getUsersPath())) {
+			log.error(`${Helper.getUsersPath({expanded: false})} does not exist.`);
 			return;
 		}
 

--- a/src/command-line/config.js
+++ b/src/command-line/config.js
@@ -9,20 +9,20 @@ const Utils = require("./utils");
 
 program
 	.command("config")
-	.description(`Edit configuration file located at ${colors.green(Helper.CONFIG_PATH)}.`)
+	.description(`Edit configuration file located at ${colors.green(Helper.getConfigPath({expanded: false}))}.`)
 	.on("--help", Utils.extraHelp)
 	.action(function() {
-		if (!fs.existsSync(Helper.CONFIG_PATH)) {
-			log.error(`${Helper.CONFIG_PATH} does not exist.`);
+		if (!fs.existsSync(Helper.getConfigPath())) {
+			log.error(`${Helper.getConfigPath({expanded: false})} does not exist.`);
 			return;
 		}
 
 		var child_spawn = child.spawn(
 			process.env.EDITOR || "vi",
-			[Helper.CONFIG_PATH],
+			[Helper.getConfigPath()],
 			{stdio: "inherit"}
 		);
 		child_spawn.on("error", function() {
-			log.error(`Unable to open ${colors.green(Helper.CONFIG_PATH)}. ${colors.bold("$EDITOR")} is not set, and ${colors.bold("vi")} was not found.`);
+			log.error(`Unable to open ${colors.green(Helper.getConfigPath({expanded: false}))}. ${colors.bold("$EDITOR")} is not set, and ${colors.bold("vi")} was not found.`);
 		});
 	});

--- a/src/command-line/edit.js
+++ b/src/command-line/edit.js
@@ -9,11 +9,11 @@ const Utils = require("./utils");
 
 program
 	.command("edit <name>")
-	.description(`Edit user file located at ${colors.green(Helper.getUserConfigPath("<name>"))}.`)
+	.description(`Edit user file located at ${colors.green(Helper.getUserConfigPath("<name>", {expanded: false}))}.`)
 	.on("--help", Utils.extraHelp)
 	.action(function(name) {
-		if (!fs.existsSync(Helper.USERS_PATH)) {
-			log.error(`${Helper.USERS_PATH} does not exist.`);
+		if (!fs.existsSync(Helper.getUsersPath())) {
+			log.error(`${Helper.getUsersPath({expanded: false})} does not exist.`);
 			return;
 		}
 
@@ -35,6 +35,6 @@ program
 			{stdio: "inherit"}
 		);
 		child_spawn.on("error", function() {
-			log.error(`Unable to open ${colors.green(Helper.getUserConfigPath(name))}. ${colors.bold("$EDITOR")} is not set, and ${colors.bold("vi")} was not found.`);
+			log.error(`Unable to open ${colors.green(Helper.getUserConfigPath(name, {expanded: false}))}. ${colors.bold("$EDITOR")} is not set, and ${colors.bold("vi")} was not found.`);
 		});
 	});

--- a/src/command-line/install.js
+++ b/src/command-line/install.js
@@ -16,8 +16,8 @@ program
 		const child = require("child_process");
 		const packageJson = require("package-json");
 
-		if (!fs.existsSync(Helper.CONFIG_PATH)) {
-			log.error(`${Helper.CONFIG_PATH} does not exist.`);
+		if (!fs.existsSync(Helper.getConfigPath())) {
+			log.error(`${Helper.getConfigPath({expanded: false})} does not exist.`);
 			return;
 		}
 

--- a/src/command-line/list.js
+++ b/src/command-line/list.js
@@ -11,8 +11,8 @@ program
 	.description("List all users")
 	.on("--help", Utils.extraHelp)
 	.action(function() {
-		if (!fs.existsSync(Helper.USERS_PATH)) {
-			log.error(`${Helper.USERS_PATH} does not exist.`);
+		if (!fs.existsSync(Helper.getUsersPath())) {
+			log.error(`${Helper.getUsersPath({expanded: false})} does not exist.`);
 			return;
 		}
 

--- a/src/command-line/remove.js
+++ b/src/command-line/remove.js
@@ -11,8 +11,8 @@ program
 	.description("Remove an existing user")
 	.on("--help", Utils.extraHelp)
 	.action(function(name) {
-		if (!fs.existsSync(Helper.USERS_PATH)) {
-			log.error(`${Helper.USERS_PATH} does not exist.`);
+		if (!fs.existsSync(Helper.getUsersPath())) {
+			log.error(`${Helper.getUsersPath({expanded: false})} does not exist.`);
 			return;
 		}
 

--- a/src/command-line/reset.js
+++ b/src/command-line/reset.js
@@ -11,8 +11,8 @@ program
 	.description("Reset user password")
 	.on("--help", Utils.extraHelp)
 	.action(function(name) {
-		if (!fs.existsSync(Helper.USERS_PATH)) {
-			log.error(`${Helper.USERS_PATH} does not exist.`);
+		if (!fs.existsSync(Helper.getUsersPath())) {
+			log.error(`${Helper.getUsersPath({expanded: false})} does not exist.`);
 			return;
 		}
 

--- a/src/command-line/start.js
+++ b/src/command-line/start.js
@@ -38,18 +38,18 @@ program
 	});
 
 function initalizeConfig() {
-	if (!fs.existsSync(Helper.CONFIG_PATH)) {
-		fsextra.ensureDirSync(Helper.HOME);
-		fs.chmodSync(Helper.HOME, "0700");
+	if (!fs.existsSync(Helper.getConfigPath())) {
+		fsextra.ensureDirSync(Helper.getHomePath());
+		fs.chmodSync(Helper.getHomePath(), "0700");
 		fsextra.copySync(path.resolve(path.join(
 			__dirname,
 			"..",
 			"..",
 			"defaults",
 			"config.js"
-		)), Helper.CONFIG_PATH);
-		log.info(`Configuration file created at ${colors.green(Helper.CONFIG_PATH)}.`);
+		)), Helper.getConfigPath());
+		log.info(`Configuration file created at ${colors.green(Helper.getConfigPath({expanded: false}))}.`);
 	}
 
-	fsextra.ensureDirSync(Helper.USERS_PATH);
+	fsextra.ensureDirSync(Helper.getUsersPath());
 }

--- a/src/plugins/webpush.js
+++ b/src/plugins/webpush.js
@@ -8,7 +8,7 @@ const Helper = require("../helper");
 
 class WebPush {
 	constructor() {
-		const vapidPath = path.join(Helper.HOME, "vapid.json");
+		const vapidPath = path.join(Helper.getHomePath(), "vapid.json");
 
 		if (fs.existsSync(vapidPath)) {
 			const data = fs.readFileSync(vapidPath, "utf-8");

--- a/src/server.js
+++ b/src/server.js
@@ -30,7 +30,7 @@ var manager = null;
 module.exports = function() {
 	log.info(`The Lounge ${colors.green(Helper.getVersion())} \
 (Node.js ${colors.green(process.versions.node)} on ${colors.green(process.platform)} ${process.arch})`);
-	log.info(`Configuration file: ${colors.green(Helper.CONFIG_PATH)}`);
+	log.info(`Configuration file: ${colors.green(Helper.getConfigPath({expanded: false}))}`);
 
 	var app = express()
 		.disable("x-powered-by")


### PR DESCRIPTION
This refactor has a few benefits, for example there cannot be a rogue update of `Helper.CONFIG_PATH` or something.

It kinda bugged me that the everything but the defaults location (last line of `thelounge -h`) was showing an unexpanded version, hated the inconsistency :)

Before | After
--- | ---
<img width="648" alt="screen shot 2017-12-06 at 22 59 18" src="https://user-images.githubusercontent.com/113730/33698252-541d5d66-dad9-11e7-8324-959b82314eb9.png"> | <img width="642" alt="screen shot 2017-12-06 at 22 56 14" src="https://user-images.githubusercontent.com/113730/33698246-4f4984c2-dad9-11e7-9456-2ccba2f1bca9.png">
<img width="636" alt="screen shot 2017-12-06 at 22 59 33" src="https://user-images.githubusercontent.com/113730/33698253-5428e88e-dad9-11e7-988c-c7ca2c33cc13.png"> | <img width="632" alt="screen shot 2017-12-06 at 22 57 00" src="https://user-images.githubusercontent.com/113730/33698247-4f547c7e-dad9-11e7-9994-9048b33b366c.png">
<img width="639" alt="screen shot 2017-12-06 at 22 59 43" src="https://user-images.githubusercontent.com/113730/33698254-5437e866-dad9-11e7-8b7c-033220e2bf69.png"> | <img width="637" alt="screen shot 2017-12-06 at 22 57 29" src="https://user-images.githubusercontent.com/113730/33698248-4f602484-dad9-11e7-87be-b64e87c25aea.png">
<img width="630" alt="screen shot 2017-12-06 at 23 00 19" src="https://user-images.githubusercontent.com/113730/33698255-5445d066-dad9-11e7-96c7-6bea8e6a3a3e.png"> | <img width="608" alt="screen shot 2017-12-06 at 22 58 02" src="https://user-images.githubusercontent.com/113730/33698249-4f7b1bc2-dad9-11e7-849a-0731d51ab0a0.png">






