### PR TITLE
Switch CLI from `thelounge --version` to `thelounge version`

### DIFF
--- a/src/command-line/index.js
+++ b/src/command-line/index.js
@@ -14,7 +14,7 @@ if (require("semver").lt(process.version, "6.0.0")) {
 	log.warn("Please upgrade to Node.js v6 or more recent.");
 }
 
-program.version(Helper.getVersion(), "-v, --version")
+program
 	.option("--home <path>", `${colors.bold("[DEPRECATED]")} Use the ${colors.green("THELOUNGE_HOME")} environment variable instead.`)
 	.on("--help", Utils.extraHelp)
 	.parseOptions(process.argv);
@@ -57,6 +57,7 @@ require("./remove");
 require("./reset");
 require("./edit");
 require("./install");
+require("./version");
 
 // TODO: Remove this when releasing The Lounge v3
 if (process.argv[1].endsWith(`${require("path").sep}lounge`)) {

--- a/src/command-line/version.js
+++ b/src/command-line/version.js
@@ -1,0 +1,11 @@
+"use strict";
+
+const program = require("commander");
+const Helper = require("../helper");
+
+program
+	.command("version")
+	.description("Output the version number")
+	.action(() => {
+		console.log(Helper.getVersion()); // eslint-disable-line no-console
+	});


### PR DESCRIPTION
I was looking forward to having no top-level options because they're confusing:

- What does `thelounge add -v` means compared to `thelounge -v`?
- Why does `thelounge add -h` and `thelounge -h add` differ?
- `-v` often means "verbose"
- Message for `-v` is auto-generated, we do not control the wording / casing

I was planning to have the following syntax:

```
thelounge version
thelounge help
thelounge help add
```

... and so on.

~This makes my docs reboot around CLI look nicely organized...~ (Actually, I've changed the format a bit, and it doesn't matter that much anymore, but I still think the other arguments make `thelounge version` better)
Unfortunately, while `thelounge version` is possible (it's even in one of their examples), there is currently no way to remove `-h, --help` from commander.js :(

So until then, this will only "convert" `thelounge version`, which is already a win. I'll make the docs work with `--help` until a better solution arises.