### PR TITLE
Remove dead code in tests, and fix a link test

### DIFF
--- a/test/fixtures/env.js
+++ b/test/fixtures/env.js
@@ -1,11 +1,6 @@
 "use strict";
 
-global.log = {
-	error: () => console.error.apply(console, arguments), // eslint-disable-line no-console
-	warn: () => {},
-	info: () => {},
-	debug: () => {},
-};
+global.log = require("../../src/log.js");
 
 var home = require("path").join(__dirname, ".lounge");
 require("../../src/helper").setHome(home);

--- a/test/plugins/auth/ldap.js
+++ b/test/plugins/auth/ldap.js
@@ -111,15 +111,23 @@ function testLdapAuth() {
 describe("LDAP authentication plugin", function() {
 	this.slow(200);
 
-	before((done) => {
-		this.server = startLdapServer(done);
+	let server;
+	let originalLogInfo;
+
+	before(function(done) {
+		originalLogInfo = log.info;
+		log.info = () => {};
+
+		server = startLdapServer(done);
 	});
 
-	after(() => {
-		this.server.close();
+	after(function() {
+		server.close();
+
+		log.info = originalLogInfo;
 	});
 
-	beforeEach(() => {
+	beforeEach(function() {
 		Helper.config.public = false;
 		Helper.config.ldap.enable = true;
 		Helper.config.ldap.url = "ldap://localhost:" + String(serverPort);

--- a/test/plugins/link.js
+++ b/test/plugins/link.js
@@ -9,23 +9,23 @@ const link = require("../../src/plugins/irc-events/link.js");
 describe("Link plugin", function() {
 	this.slow(200);
 
-	before(function(done) {
-		this.app = util.createWebserver();
-		this.app.get("/real-test-image.png", function(req, res) {
+	let app;
+
+	beforeEach(function(done) {
+		app = util.createWebserver();
+		app.get("/real-test-image.png", function(req, res) {
 			res.sendFile(path.resolve(__dirname, "../../client/img/apple-touch-icon-120x120.png"));
 		});
-		this.connection = this.app.listen(9002, done);
-	});
+		this.connection = app.listen(9002, done);
 
-	after(function(done) {
-		this.connection.close(done);
-	});
-
-	beforeEach(function() {
 		this.irc = util.createClient();
 		this.network = util.createNetwork();
 
 		Helper.config.prefetchStorage = false;
+	});
+
+	afterEach(function(done) {
+		this.connection.close(done);
 	});
 
 	it("should be able to fetch basic information about URLs", function(done) {
@@ -45,7 +45,7 @@ describe("Link plugin", function() {
 			shown: true,
 		}]);
 
-		this.app.get("/basic", function(req, res) {
+		app.get("/basic", function(req, res) {
 			res.send("<title>test title</title><meta name='description' content='simple description'>");
 		});
 
@@ -67,7 +67,7 @@ describe("Link plugin", function() {
 
 		link(this.irc, this.network.channels[0], message);
 
-		this.app.get("/basic-og", function(req, res) {
+		app.get("/basic-og", function(req, res) {
 			res.send("<title>test</title><meta property='og:title' content='opengraph test'>");
 		});
 
@@ -84,7 +84,7 @@ describe("Link plugin", function() {
 
 		link(this.irc, this.network.channels[0], message);
 
-		this.app.get("/description-og", function(req, res) {
+		app.get("/description-og", function(req, res) {
 			res.send("<meta name='description' content='simple description'><meta property='og:description' content='opengraph description'>");
 		});
 
@@ -101,7 +101,7 @@ describe("Link plugin", function() {
 
 		link(this.irc, this.network.channels[0], message);
 
-		this.app.get("/thumb", function(req, res) {
+		app.get("/thumb", function(req, res) {
 			res.send("<title>Google</title><meta property='og:image' content='http://localhost:9002/real-test-image.png'>");
 		});
 
@@ -119,7 +119,7 @@ describe("Link plugin", function() {
 
 		link(this.irc, this.network.channels[0], message);
 
-		this.app.get("/thumb-image-src", function(req, res) {
+		app.get("/thumb-image-src", function(req, res) {
 			res.send("<link rel='image_src' href='http://localhost:9002/real-test-image.png'>");
 		});
 
@@ -136,7 +136,7 @@ describe("Link plugin", function() {
 
 		link(this.irc, this.network.channels[0], message);
 
-		this.app.get("/thumb-image-src", function(req, res) {
+		app.get("/thumb-image-src", function(req, res) {
 			res.send("<link rel='image_src' href='//localhost:9002/real-test-image.png'>");
 		});
 
@@ -153,7 +153,7 @@ describe("Link plugin", function() {
 
 		link(this.irc, this.network.channels[0], message);
 
-		this.app.get("/relative-thumb", function(req, res) {
+		app.get("/relative-thumb", function(req, res) {
 			res.send("<title>test relative image</title><meta property='og:image' content='/real-test-image.png'>");
 		});
 
@@ -172,7 +172,7 @@ describe("Link plugin", function() {
 
 		link(this.irc, this.network.channels[0], message);
 
-		this.app.get("/thumb-no-title", function(req, res) {
+		app.get("/thumb-no-title", function(req, res) {
 			res.send("<meta property='og:image' content='http://localhost:9002/real-test-image.png'>");
 		});
 
@@ -191,7 +191,7 @@ describe("Link plugin", function() {
 
 		link(this.irc, this.network.channels[0], message);
 
-		this.app.get("/thumb-404", function(req, res) {
+		app.get("/thumb-404", function(req, res) {
 			res.send("<title>404 image</title><meta property='og:image' content='http://localhost:9002/this-image-does-not-exist.png'>");
 		});
 
@@ -241,11 +241,11 @@ describe("Link plugin", function() {
 			shown: true,
 		}]);
 
-		this.app.get("/one", function(req, res) {
+		app.get("/one", function(req, res) {
 			res.send("<title>first title</title>");
 		});
 
-		this.app.get("/two", function(req, res) {
+		app.get("/two", function(req, res) {
 			res.send("<title>second title</title>");
 		});
 

--- a/test/server.js
+++ b/test/server.js
@@ -8,13 +8,19 @@ const io = require("socket.io-client");
 describe("Server", function() {
 	this.timeout(5000);
 	let server;
+	let originalLogInfo;
 
-	before(() => {
+	before(function() {
+		originalLogInfo = log.info;
+		log.info = () => {};
+
 		server = require("../src/server")();
 	});
 
-	after((done) => {
+	after(function(done) {
 		server.close(done);
+
+		log.info = originalLogInfo;
 	});
 
 	const webURL = `http://${Helper.config.host}:${Helper.config.port}/`;

--- a/test/util.js
+++ b/test/util.js
@@ -7,12 +7,8 @@ var express = require("express");
 var Network = require("../src/models/network");
 var Chan = require("../src/models/chan");
 
-function MockClient(opts) {
+function MockClient() {
 	this.user = {nick: "test-user"};
-
-	for (var k in opts) {
-		this[k] = opts[k];
-	}
 }
 util.inherits(MockClient, EventEmitter);
 


### PR DESCRIPTION
I used `npm run coverage` while *not* excluding the test folder to detect dead code in our test folder, it is actually pretty useful to do so (as a one-shot, not to do that in our config).

Only remaining unreached path is [L40 in `test/plugins/auth/ldap.js`](https://github.com/thelounge/lounge/blob/a8fb892873721a9ac8eb138533c999180f333313/test/plugins/auth/ldap.js#L40), but it does seem to me that it might be useful in case of failures, so I preferred to leave it there.

Proof of no more dead code (read this as non-dead code coverage and not test coverage, of course):

<img width="844" alt="screen shot 2017-12-09 at 19 07 49" src="https://user-images.githubusercontent.com/113730/33800729-51470fb4-dd14-11e7-8b76-7a526e3983d7.png">

**Leftovers:**

<img width="300" alt="screen shot 2017-12-09 at 19 05 55" src="https://user-images.githubusercontent.com/113730/33800720-1fb2abd4-dd14-11e7-8dc5-3d8597fa1b50.png"> <img width="300" alt="screen shot 2017-12-09 at 19 06 16" src="https://user-images.githubusercontent.com/113730/33800721-1fc358a8-dd14-11e7-9787-7683f52f4741.png">
