### PR TITLE
Deprecate existing options of `thelounge start` and add a generic `--config` override

### DIFF
--- a/src/command-line/index.js
+++ b/src/command-line/index.js
@@ -2,6 +2,7 @@
 
 global.log = require("../log.js");
 
+const _ = require("lodash");
 const fs = require("fs");
 const path = require("path");
 const program = require("commander");
@@ -16,6 +17,11 @@ if (require("semver").lt(process.version, "6.0.0")) {
 
 program.version(Helper.getVersion(), "-v, --version")
 	.option("--home <path>", `${colors.bold("[DEPRECATED]")} Use the ${colors.green("THELOUNGE_HOME")} environment variable instead.`)
+	.option(
+		"-c, --config <key=value>",
+		"override entries of the configuration file, must be specified for each entry that needs to be overriden",
+		Utils.parseConfigOptions
+	)
 	.on("--help", Utils.extraHelp)
 	.parseOptions(process.argv);
 
@@ -48,6 +54,9 @@ if (!home) {
 }
 
 Helper.setHome(home);
+
+// Merge config key-values passed as CLI options into the main config
+_.merge(Helper.config, program.config);
 
 require("./start");
 require("./config");

--- a/src/command-line/index.js
+++ b/src/command-line/index.js
@@ -11,12 +11,12 @@ const Helper = require("../helper");
 const Utils = require("./utils");
 
 if (require("semver").lt(process.version, "6.0.0")) {
-	log.warn(`Support of Node.js v4 is ${colors.bold("deprecated")} and will be removed in The Lounge v3.`);
+	log.warn(`Support of Node.js v4 is ${colors.bold.red("deprecated")} and will be removed in The Lounge v3.`);
 	log.warn("Please upgrade to Node.js v6 or more recent.");
 }
 
 program.version(Helper.getVersion(), "-v, --version")
-	.option("--home <path>", `${colors.bold("[DEPRECATED]")} Use the ${colors.green("THELOUNGE_HOME")} environment variable instead.`)
+	.option("--home <path>", `${colors.bold.red("[DEPRECATED]")} Use the ${colors.green("THELOUNGE_HOME")} environment variable instead.`)
 	.option(
 		"-c, --config <key=value>",
 		"override entries of the configuration file, must be specified for each entry that needs to be overriden",
@@ -26,7 +26,7 @@ program.version(Helper.getVersion(), "-v, --version")
 	.parseOptions(process.argv);
 
 if (program.home) {
-	log.warn(`${colors.green("--home")} is ${colors.bold("deprecated")} and will be removed in The Lounge v3.`);
+	log.warn(`${colors.green("--home")} is ${colors.bold.red("deprecated")} and will be removed in The Lounge v3.`);
 	log.warn(`Use the ${colors.green("THELOUNGE_HOME")} environment variable instead.`);
 }
 
@@ -43,7 +43,7 @@ if (!fs.existsSync(path.join(
 }
 
 if (process.env.LOUNGE_HOME) {
-	log.warn(`${colors.green("LOUNGE_HOME")} is ${colors.bold("deprecated")} and will be removed in The Lounge v3.`);
+	log.warn(`${colors.green("LOUNGE_HOME")} is ${colors.bold.red("deprecated")} and will be removed in The Lounge v3.`);
 	log.warn(`Use ${colors.green("THELOUNGE_HOME")} instead.`);
 }
 
@@ -67,7 +67,7 @@ require("./install");
 
 // TODO: Remove this when releasing The Lounge v3
 if (process.argv[1].endsWith(`${require("path").sep}lounge`)) {
-	log.warn(`The ${colors.red("lounge")} CLI is ${colors.bold("deprecated")} and will be removed in v3.`);
+	log.warn(`The ${colors.red("lounge")} CLI is ${colors.bold.red("deprecated")} and will be removed in v3.`);
 	log.warn(`Use ${colors.green("thelounge")} instead.`);
 	process.argv[1] = "thelounge";
 }

--- a/src/command-line/index.js
+++ b/src/command-line/index.js
@@ -22,12 +22,13 @@ program.version(Helper.getVersion(), "-v, --version")
 		"override entries of the configuration file, must be specified for each entry that needs to be overriden",
 		Utils.parseConfigOptions
 	)
-	.on("--help", Utils.extraHelp)
-	.parseOptions(process.argv);
+	.on("--help", Utils.extraHelp);
+
+// Parse options from `argv` returning `argv` void of these options.
+const argvWithoutOptions = program.parseOptions(process.argv);
 
 if (program.home) {
-	log.warn(`${colors.green("--home")} is ${colors.bold.red("deprecated")} and will be removed in The Lounge v3.`);
-	log.warn(`Use the ${colors.green("THELOUNGE_HOME")} environment variable instead.`);
+	log.warn(`${colors.bold("--home")} is ${colors.bold.red("deprecated")} and will be removed in The Lounge v3. Use the ${colors.bold("THELOUNGE_HOME")} environment variable instead.`);
 }
 
 // Check if the app was built before calling setHome as it wants to load manifest.json from the public folder
@@ -72,7 +73,13 @@ if (process.argv[1].endsWith(`${require("path").sep}lounge`)) {
 	process.argv[1] = "thelounge";
 }
 
-program.parse(process.argv);
+// `parse` expects to be passed `process.argv`, but we need to remove to give it
+// a version of `argv` that does not contain options already parsed by
+// `parseOptions` above.
+// This is done by giving it the updated `argv` that `parseOptions` returned,
+// except it returns an object with `args`/`unknown`, so we need to concat them.
+// See https://github.com/tj/commander.js/blob/fefda77f463292/index.js#L686-L763
+program.parse(argvWithoutOptions.args.concat(argvWithoutOptions.unknown));
 
 if (!program.args.length) {
 	program.help();

--- a/src/command-line/start.js
+++ b/src/command-line/start.js
@@ -10,17 +10,33 @@ const Utils = require("./utils");
 
 program
 	.command("start")
-	.option("-H, --host <ip>", "set the IP address or hostname for the web server to listen on")
-	.option("-P, --port <port>", "set the port to listen on")
-	.option("-B, --bind <ip>", "set the local IP to bind to for outgoing connections")
-	.option("    --public", "start in public mode")
-	.option("    --private", "start in private mode")
+	.option("-H, --host <ip>", `${colors.bold.red("[DEPRECATED]")} to set the IP address or hostname for the web server to listen on, use ${colors.bold("-c host=<ip>")} instead`)
+	.option("-P, --port <port>", `${colors.bold.red("[DEPRECATED]")} to set the port to listen on, use ${colors.bold("-c port=<port>")} instead`)
+	.option("-B, --bind <ip>", `${colors.bold.red("[DEPRECATED]")} to set the local IP to bind to for outgoing connections, use ${colors.bold("-c bind=<ip>")} instead`)
+	.option("    --public", `${colors.bold.red("[DEPRECATED]")} to start in public mode, use ${colors.bold("-c public=true")} instead`)
+	.option("    --private", `${colors.bold.red("[DEPRECATED]")} to start in private mode, use ${colors.bold("-c public=false")} instead`)
 	.description("Start the server")
 	.on("--help", Utils.extraHelp)
 	.action(function(options) {
 		initalizeConfig();
 
 		const server = require("../server");
+
+		if (options.host) {
+			log.warn(`${colors.bold("-H, --host <ip>")} is ${colors.bold.red("deprecated")} and will be removed in The Lounge v3. Use ${colors.bold("-c host=<ip>")} instead.`);
+		}
+		if (options.port) {
+			log.warn(`${colors.bold("-P, --port <port>")} is ${colors.bold.red("deprecated")} and will be removed in The Lounge v3. Use ${colors.bold("-c port=<port>")} instead.`);
+		}
+		if (options.bind) {
+			log.warn(`${colors.bold("-B, --bind <ip>")} is ${colors.bold.red("deprecated")} and will be removed in The Lounge v3. Use ${colors.bold("-c bind=<ip>")} instead.`);
+		}
+		if (options.public) {
+			log.warn(`${colors.bold("--public")} is ${colors.bold.red("deprecated")} and will be removed in The Lounge v3. Use ${colors.bold("-c public=true")} instead.`);
+		}
+		if (options.private) {
+			log.warn(`${colors.bold("--private")} is ${colors.bold.red("deprecated")} and will be removed in The Lounge v3. Use ${colors.bold("-c public=false")} instead.`);
+		}
 
 		var mode = Helper.config.public;
 		if (options.public) {

--- a/src/command-line/utils.js
+++ b/src/command-line/utils.js
@@ -16,7 +16,7 @@ class Utils {
 			"",
 			`    THELOUNGE_HOME   Path for all configuration files and folders. Defaults to ${colors.green(Helper.expandHome(Utils.defaultHome()))}.`,
 			"",
-		].forEach((e) => console.log(e)); // eslint-disable-line no-console
+		].forEach((e) => log.raw(e));
 	}
 
 	static defaultHome() {

--- a/src/command-line/utils.js
+++ b/src/command-line/utils.js
@@ -35,7 +35,7 @@ class Utils {
 			".lounge_home"
 		));
 		if (fs.existsSync(deprecatedDistConfig)) {
-			log.warn(`${colors.green(".lounge_home")} is ${colors.bold("deprecated")} and will be ignored as of The Lounge v3.`);
+			log.warn(`${colors.green(".lounge_home")} is ${colors.bold.red("deprecated")} and will be ignored as of The Lounge v3.`);
 			log.warn(`Use ${colors.green(".thelounge_home")} instead.`);
 
 			distConfig = deprecatedDistConfig;

--- a/src/helper.js
+++ b/src/helper.js
@@ -109,7 +109,7 @@ function setHome(newPath) {
 	// TODO: Remove in future release
 	// Backwards compatibility for old way of specifying themes in settings
 	if (this.config.theme.includes(".css")) {
-		log.warn(`Referring to CSS files in the ${colors.green("theme")} setting of ${colors.green(configPath)} is ${colors.bold("deprecated")} and will be removed in a future version.`);
+		log.warn(`Referring to CSS files in the ${colors.green("theme")} setting of ${colors.green(configPath)} is ${colors.bold.red("deprecated")} and will be removed in a future version.`);
 	} else {
 		this.config.theme = `themes/${this.config.theme}.css`;
 	}

--- a/src/log.js
+++ b/src/log.js
@@ -32,6 +32,11 @@ exports.info = function() {
 exports.debug = function() {
 	console.log.apply(console, timestamp(colors.green("[DEBUG]"), arguments));
 };
+
+exports.raw = function() {
+	console.log.apply(console, arguments);
+};
+
 /* eslint-enable no-console */
 
 exports.prompt = (options, callback) => {

--- a/test/src/command-line/utilsTest.js
+++ b/test/src/command-line/utilsTest.js
@@ -1,0 +1,46 @@
+"use strict";
+
+const expect = require("chai").expect;
+const TestUtil = require("../../util");
+const Utils = require("../../../src/command-line/utils");
+
+describe("Utils", function() {
+	describe(".extraHelp", function() {
+		let originalRaw;
+
+		beforeEach(function() {
+			originalRaw = log.raw;
+		});
+
+		afterEach(function() {
+			log.raw = originalRaw;
+		});
+
+		it("should start and end with empty lines to display correctly with --help", function() {
+			// Mock `log.raw` to extract its effect into an array
+			const stdout = [];
+			log.raw = TestUtil.mockLogger((str) => stdout.push(str));
+
+			Utils.extraHelp();
+
+			// Starts with 2 empty lines
+			expect(stdout[0]).to.equal("\n");
+			expect(stdout[1]).to.equal("\n");
+			expect(stdout[2]).to.not.equal("\n");
+
+			// Ends with 1 empty line
+			expect(stdout[stdout.length - 2]).to.not.equal("\n");
+			expect(stdout[stdout.length - 1]).to.equal("\n");
+		});
+
+		it("should contain information about THELOUNGE_HOME env var", function() {
+			// Mock `log.raw` to extract its effect into a concatenated string
+			let stdout = "";
+			log.raw = TestUtil.mockLogger((str) => stdout += str);
+
+			Utils.extraHelp();
+
+			expect(stdout).to.include("THELOUNGE_HOME");
+		});
+	});
+});

--- a/test/src/command-line/utilsTest.js
+++ b/test/src/command-line/utilsTest.js
@@ -43,4 +43,108 @@ describe("Utils", function() {
 			expect(stdout).to.include("THELOUNGE_HOME");
 		});
 	});
+
+	describe(".parseConfigOptions", function() {
+		describe("when it's the first option given", function() {
+			it("should return nothing when passed an invalid config", function() {
+				expect(Utils.parseConfigOptions("foo")).to.be.undefined;
+			});
+
+			it("should correctly parse boolean values", function() {
+				expect(Utils.parseConfigOptions("foo=true")).to.deep.equal({foo: true});
+				expect(Utils.parseConfigOptions("foo=false")).to.deep.equal({foo: false});
+			});
+
+			it("should correctly parse empty strings", function() {
+				expect(Utils.parseConfigOptions("foo=")).to.deep.equal({foo: ""});
+			});
+
+			it("should correctly parse null values", function() {
+				expect(Utils.parseConfigOptions("foo=null")).to.deep.equal({foo: null});
+			});
+
+			it("should correctly parse undefined values", function() {
+				expect(Utils.parseConfigOptions("foo=undefined"))
+					.to.deep.equal({foo: undefined});
+			});
+
+			it("should correctly parse array values", function() {
+				expect(Utils.parseConfigOptions("foo=[bar,true]"))
+					.to.deep.equal({foo: ["bar", true]});
+
+				expect(Utils.parseConfigOptions("foo=[bar, true]"))
+					.to.deep.equal({foo: ["bar", true]});
+			});
+
+			it("should correctly parse empty array values", function() {
+				expect(Utils.parseConfigOptions("foo=[]"))
+					.to.deep.equal({foo: []});
+			});
+
+			it("should correctly parse values that contain `=` sign", function() {
+				expect(Utils.parseConfigOptions("foo=bar=42"))
+					.to.deep.equal({foo: "bar=42"});
+			});
+
+			it("should correctly parse keys using dot-notation", function() {
+				expect(Utils.parseConfigOptions("foo.bar=value"))
+					.to.deep.equal({foo: {bar: "value"}});
+			});
+
+			it("should correctly parse keys using array-notation", function() {
+				expect(Utils.parseConfigOptions("foo[0]=value"))
+					.to.deep.equal({foo: ["value"]});
+			});
+		});
+
+		describe("when some options have already been parsed", function() {
+			it("should not modify existing options when passed an invalid config", function() {
+				const memo = {foo: "bar"};
+				expect(Utils.parseConfigOptions("foo", memo)).to.equal(memo);
+			});
+
+			it("should combine a new option with previously parsed ones", function() {
+				expect(Utils.parseConfigOptions("bar=false", {foo: true}))
+					.to.deep.equal({foo: true, bar: false});
+			});
+
+			it("should maintain existing properties of a nested object", function() {
+				expect(Utils.parseConfigOptions("foo.bar=true", {foo: {baz: false}}))
+					.to.deep.equal({foo: {bar: true, baz: false}});
+			});
+
+			it("should maintain existing entries of an array", function() {
+				expect(Utils.parseConfigOptions("foo[1]=baz", {foo: ["bar"]}))
+					.to.deep.equal({foo: ["bar", "baz"]});
+			});
+
+			describe("when given the same key multiple times", function() {
+				let originalWarn;
+
+				beforeEach(function() {
+					originalWarn = log.warn;
+				});
+
+				afterEach(function() {
+					log.warn = originalWarn;
+				});
+
+				it("should not override options", function() {
+					log.warn = () => {};
+
+					expect(Utils.parseConfigOptions("foo=baz", {foo: "bar"}))
+						.to.deep.equal({foo: "bar"});
+				});
+
+				it("should display a warning", function() {
+					let warning = "";
+					log.warn = TestUtil.mockLogger((str) => warning += str);
+
+					Utils.parseConfigOptions("foo=bar", {foo: "baz"});
+
+					expect(warning).to.include("foo was already specified");
+				});
+			});
+		});
+	});
 });

--- a/test/util.js
+++ b/test/util.js
@@ -23,6 +23,20 @@ MockClient.prototype.createMessage = function(opts) {
 	return message;
 };
 
+function mockLogger(callback) {
+	return function() {
+		// TODO: Use ...args with The Lounge v3: add `...args` as function argument
+		//       and replaced the next line with `args.join(", ")`
+		const stdout = Array.prototype.slice.call(arguments).join(", ")
+			.replace( // Removes ANSI colors. See https://stackoverflow.com/a/29497680
+				/[\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]/g,
+				""
+			);
+
+		callback(stdout + "\n");
+	};
+}
+
 module.exports = {
 	createClient: function() {
 		return new MockClient();
@@ -38,4 +52,5 @@ module.exports = {
 	createWebserver: function() {
 		return express();
 	},
+	mockLogger,
 };


### PR DESCRIPTION
Resolves https://github.com/thelounge/lounge/issues/419.

Removes the `--public` / `--private` / `--host` / `--bind` / `--port` options for `thelounge start` in favor of a new slightly-more-intricate-but-much-more-powerful `--config` / `-c` option.

Example on how to use this (note that I have successfully tested all examples given in this description):

```sh
thelounge start -c public=true \
                -c lockNetwork=true \
                -c defaults.port=6667 \
                -c defaults.tls=false
```

(Multiline for GitHub readability but it obviously works on a single line)

There are a bunch of different cases I handle, and tests for all situations I could think of.

Some more example of what is possible:

```sh
-c https.enable=true    # Supports booleans
-c port=9001    # See below for caveats on integers
-c debug.raw=true    # Supports dot-notation for objects (also comes with array-notation out-of-the-box, but not very useful in our case
-c transports=[websocket,polling]    # Supports arrays
-c "transports=[websocket, polling]"    # Supports spaces assuming option is wrapped in quotes
-c logs.format="DD MMMM YYYY HH:mm:ss"   # Can also quote just the value
-c ldap.searchDN.rootDN="cn=thelounge,ou=system-users"   # Supports values containing `=`
-c ldap.searchDN.filter='(objectClass=person)(memberOf=ou=accounts,dc=example,dc=com)'   # Complex value
```

I expect we will discover weird edge cases later, but I think this covers maybe 95% of the needs if not more.

One thing this does _not_ support is passing JavaScript code, like functions, for example for `webirc`. This would require using `eval()` which is a no-no for me considering this can affect a whole instance. I will argue that if you need to pass complex JavaScript code through the CLI, you should definitely define your own config file! (which is also valid for some complex cases, like LDAP, but it's easier and less risky to support)

Integers are not parsed as such. I have checked and tested almost all usages of integer options in our configuration files (maybe expect `identd`), and they all work fine. In some cases, we `parseInt`, but also note that strings are coerced into numbers in almost all cases in JS. For example, `"5" * 3` is `15` (as an integer) and `"5.1" * 3` is `15.3` (as a float) so all `<`/`>` comparisons work fine.
If we ever discover an issue with that, I can think of at least 3 ways of handling this, from easy to rather complex (the simplest would be to automatically `parseInt` if value is integer-looking, though I'm sure there are other pitfalls), but I think we should do this simply right now and fix as we go.
After all, this Just Works™ :)

---

About the first commit: _Define a raw logger to avoid using `console.log`, use it in extra help for environment variables, and add a test for this_

As said in commit message, this has a few benefits:

- Respects the "Do not mock what you do not own" principle, instead we mock `log.raw` when necessary
- Lets us not re-assign `console.log`, which breaks as Mocha uses `console.log` as well
- Save and restore initial `log.raw` in test hooks (before/after), otherwise this would break Mocha/Chai

This allowed me to write extra tests :)

---

Note: This PR currently fails on Node v4 but will pass once #1727 gets merged.