### PR TITLE
Warn if user configuration being loaded is empty

### DIFF
--- a/src/helper.js
+++ b/src/helper.js
@@ -79,7 +79,14 @@ function setHome(newPath) {
 
 	// Reload config from new home location
 	if (fs.existsSync(configPath)) {
-		var userConfig = require(configPath);
+		const userConfig = require(configPath);
+
+		if (_.isEmpty(userConfig)) {
+			log.warn(`The file located at ${colors.green(configPath)} does not appear to expose anything.`);
+			log.warn(`Make sure it is non-empty and the configuration is exported using ${colors.bold("module.exports = { ... }")}.`);
+			log.warn("Using default configuration...");
+		}
+
 		this.config = _.merge(this.config, userConfig);
 	}
 


### PR DESCRIPTION
Resolves https://github.com/thelounge/lounge/issues/1805.

I ended up using Lodash's function instead of a [native alternative](https://stackoverflow.com/a/32108184/1935861) because it is stupidly not simple, and because we were already using Lodash on the next line.

<img width="838" alt="screen shot 2017-12-10 at 01 01 44" src="https://user-images.githubusercontent.com/113730/33802474-1c83a85a-dd46-11e7-99bb-f51844e54b59.png">
