### PR TITLE
Improve user and channel icons in channel list and context menu

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -221,7 +221,7 @@ kbd {
 #chat button.menu::before { content: "\f142"; /* http://fontawesome.io/icon/ellipsis-v/ */ }
 
 .context-menu-user::before { content: "\f007"; /* http://fontawesome.io/icon/user/ */ }
-.context-menu-chan::before { content: "\f0f6"; /* http://fontawesome.io/icon/file-text-o/ */ }
+.context-menu-chan::before { content: "\f292"; /* http://fontawesome.io/icon/hashtag/ */ }
 .context-menu-close::before { content: "\f00d"; /* http://fontawesome.io/icon/times/ */ }
 .context-menu-list::before { content: "\f03a"; /* http://fontawesome.io/icon/list/ */ }
 
@@ -233,7 +233,7 @@ kbd {
 #chat .query .title::before { content: "\f007"; /* http://fontawesome.io/icon/user/ */ }
 
 #sidebar .chan.channel::before,
-#chat .channel .title::before { content: "\f0f6"; /* http://fontawesome.io/icon/file-text-o/ */ }
+#chat .channel .title::before { content: "\f292"; /* http://fontawesome.io/icon/hashtag/ */ }
 
 #sidebar .chan.special::before,
 #chat .special .title::before { content: "\f03a"; /* http://fontawesome.io/icon/list/ */ }

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -230,7 +230,7 @@ kbd {
 #chat .lobby .title::before { content: "\f0a0"; /* http://fontawesome.io/icon/hdd-o/ */ }
 
 #sidebar .chan.query::before,
-#chat .query .title::before { content: "\f0e6"; /* http://fontawesome.io/icon/comments-o/ */ }
+#chat .query .title::before { content: "\f007"; /* http://fontawesome.io/icon/user/ */ }
 
 #sidebar .chan.channel::before,
 #chat .channel .title::before { content: "\f0f6"; /* http://fontawesome.io/icon/file-text-o/ */ }

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -83,8 +83,18 @@ $(function() {
 				data: target.data("name"),
 			});
 		} else if (target.hasClass("chan")) {
+			let itemClass;
+
+			if (target.hasClass("lobby")) {
+				itemClass = "network";
+			} else if (target.hasClass("query")) {
+				itemClass = "user";
+			} else {
+				itemClass = "chan";
+			}
+
 			output = templates.contextmenu_item({
-				class: target.hasClass("lobby") ? "network" : "chan",
+				class: itemClass,
 				text: target.data("title"),
 				data: target.data("target"),
 			});


### PR DESCRIPTION
Follow-up of https://github.com/thelounge/lounge/pull/1816.

Before | After
--- | ---
<img width="187" alt="screen shot 2017-12-11 at 01 16 31" src="https://user-images.githubusercontent.com/113730/33818201-8d0e705c-de11-11e7-851f-fa80eff4b8a3.png"> | <img width="183" alt="screen shot 2017-12-11 at 01 15 44" src="https://user-images.githubusercontent.com/113730/33818207-9392bfc8-de11-11e7-8b28-6641e1bb0df6.png">
<img width="192" alt="screen shot 2017-12-11 at 01 16 38" src="https://user-images.githubusercontent.com/113730/33818202-8d1a735c-de11-11e7-8c42-f78e3d2bfab3.png"> | <img width="197" alt="screen shot 2017-12-11 at 01 15 50" src="https://user-images.githubusercontent.com/113730/33818206-915136cc-de11-11e7-94df-b9fc142dd7ee.png">

Now:

- Right-clicking on a user in the network list, on a nick in a message, or opening the context menu in the query window all consistently use that 👤 icon
- That sad file icon in channel list is now a :hash: 