### PR TITLE
Use better icons for channel/query list and context menu actions

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -221,22 +221,23 @@ kbd {
 #chat button.menu::before { content: "\f142"; /* http://fontawesome.io/icon/ellipsis-v/ */ }
 
 .context-menu-user::before { content: "\f007"; /* http://fontawesome.io/icon/user/ */ }
-.context-menu-chan::before { content: "\f292"; /* http://fontawesome.io/icon/hashtag/ */ }
 .context-menu-close::before { content: "\f00d"; /* http://fontawesome.io/icon/times/ */ }
 .context-menu-list::before { content: "\f03a"; /* http://fontawesome.io/icon/list/ */ }
 .context-menu-action-whois::before { content: "\f05a"; /* http://fontawesome.io/icon/info-circle/  */ }
-.context-menu-action-query::before { content: "\f0e6"; /* http://fontawesome.io/icon/comments-o/ */ }
 .context-menu-action-kick::before { content: "\f05e"; /* http://fontawesome.io/icon/ban/ */ }
 
 .context-menu-network::before,
 #sidebar .chan.lobby::before,
 #chat .lobby .title::before { content: "\f0a0"; /* http://fontawesome.io/icon/hdd-o/ */ }
 
+.context-menu-query::before,
+.context-menu-action-query::before,
 #sidebar .chan.query::before,
-#chat .query .title::before { content: "\f007"; /* http://fontawesome.io/icon/user/ */ }
+#chat .query .title::before { content: "\f0e5"; /* http://fontawesome.io/icon/comment-o/ */ }
 
+.context-menu-chan::before,
 #sidebar .chan.channel::before,
-#chat .channel .title::before { content: "\f292"; /* http://fontawesome.io/icon/hashtag/ */ }
+#chat .channel .title::before { content: "\f086"; /* http://fontawesome.io/icon/comments/ */ }
 
 #sidebar .chan.special::before,
 #chat .special .title::before { content: "\f03a"; /* http://fontawesome.io/icon/list/ */ }

--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -113,7 +113,7 @@ $(function() {
 			if (target.hasClass("lobby")) {
 				itemClass = "network";
 			} else if (target.hasClass("query")) {
-				itemClass = "user";
+				itemClass = "query";
 			} else {
 				itemClass = "chan";
 			}


### PR DESCRIPTION
Follow-up of #1824.

I did not do a great job at all with #1824:

- Some people pointed out the duplication of the hash character ("**#** #thelounge") in channel list and window title. Even more so with channels wtarting with `##`. It also is unrealistic to strip the first `#` of the channel because it becomes even more confusing, with all those different channels: `#channel`, `##channel`, `&channel`, etc.

- The :hash: and 👤 icons do not have the same width, so channel names and query names are now misaligned in the channel list. Good job me 👏

- I mistakenly attempted to make the 👤 icon consistently used to represent a user and a query window, but that just doesn't work. #1722 showed that even more clearly, because 👤 is used for the user name, and 💬 is used for the query window, which is correct.

Anyway, I'm making a new attempt with this PR. Channel windows are consistently using http://fontawesome.io/icon/comment/, query windows are consistently using http://fontawesome.io/icon/comment-o/, and users are still correctly using http://fontawesome.io/icon/user/. Results below:

Channel window / action | User menu | Query window / action
--- | --- | ---
<img width="1280" alt="screen shot 2017-12-12 at 00 51 05" src="https://user-images.githubusercontent.com/113730/33869634-dff686a8-ded7-11e7-8a18-9b47ca03d975.png"> <img width="1280" alt="screen shot 2017-12-12 at 00 51 15" src="https://user-images.githubusercontent.com/113730/33869635-e015fcea-ded7-11e7-8e17-db18d918a5d0.png"> | <img width="1208" alt="screen shot 2017-12-12 at 00 51 22" src="https://user-images.githubusercontent.com/113730/33869636-e0356b84-ded7-11e7-802d-b4966dbe5ab7.png"> | <img width="1280" alt="screen shot 2017-12-12 at 00 51 32" src="https://user-images.githubusercontent.com/113730/33869639-e398f20a-ded7-11e7-8986-dc5c16962b93.png"> <img width="1280" alt="screen shot 2017-12-12 at 00 51 40" src="https://user-images.githubusercontent.com/113730/33869640-e3b88ac0-ded7-11e7-8925-097f02c17a99.png">

I think it works better than what we originally had (and was buggy in context menus), and definitely better than my attempt in #1824. I'm open to suggestions obviously if people think these icons are 💩.