### PR TITLE
Rename thumbnail/image option to more general `media`

### DIFF
--- a/client/js/options.js
+++ b/client/js/options.js
@@ -44,7 +44,7 @@ userOptions = null;
 module.exports = options;
 
 module.exports.shouldOpenMessagePreview = function(type) {
-	return (options.links && type === "link") || (options.media && (type === "image" || type === "audio"));
+	return type === "link" ? options.links : options.media;
 };
 
 module.exports.initialize = () => {

--- a/client/views/windows/settings.tpl
+++ b/client/views/windows/settings.tpl
@@ -74,8 +74,8 @@
 		</div>
 		<div class="col-sm-6">
 			<label class="opt">
-				<input type="checkbox" name="thumbnails">
-				Auto-expand images
+				<input type="checkbox" name="media">
+				Auto-expand media
 			</label>
 		</div>
 		<div class="col-sm-6">


### PR DESCRIPTION
For #1806 and #1817, mainly. 