### PR TITLE
Try to find og:video and og:audio on html pages

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1245,6 +1245,11 @@ kbd {
 	max-width: 100%;
 }
 
+#chat video {
+	max-width: 640px;
+	max-height: 240px;
+}
+
 /* Do not display an empty div when there are no previews. Useful for example in
 part/quit messages where we don't load previews (adds a blank line otherwise) */
 #chat .preview:empty {

--- a/client/views/msg_preview.tpl
+++ b/client/views/msg_preview.tpl
@@ -7,13 +7,13 @@
 	{{/equal}}
 	{{#equal type "audio"}}
 		<audio controls preload="metadata">
-			<source src="{{link}}" type="{{res}}">
+			<source src="{{media}}" type="{{mediaType}}">
 			Your browser does not support the audio element.
 		</audio>
 	{{/equal}}
 	{{#equal type "video"}}
 		<video preload="metadata" controls>
-			<source src="{{link}}" type="{{res}}">
+			<source src="{{media}}" type="{{mediaType}}">
 			Your browser does not support the video element.
 		</video>
 	{{/equal}}

--- a/client/views/msg_preview.tpl
+++ b/client/views/msg_preview.tpl
@@ -12,7 +12,7 @@
 		</audio>
 	{{/equal}}
 	{{#equal type "video"}}
-		<video width="320" height="240" preload="metadata" controls>
+		<video preload="metadata" controls>
 			<source src="{{link}}" type="{{res}}">
 			Your browser does not support the video element.
 		</video>


### PR DESCRIPTION
Takes video/audio embeds further. This works on gfycat for example.

Code most likely needs a cleanup.