### PR TITLE
Add missing time (and icon) of status messages on mobile

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -2256,8 +2256,8 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 		padding: 0;
 	}
 
-	#chat .condensed .time,
-	#chat .condensed .from {
+	#chat .condensed-summary .time,
+	#chat .condensed-summary .from {
 		display: none;
 	}
 


### PR DESCRIPTION
Before | After
--- | ---
<img width="306" alt="screen shot 2017-12-16 at 16 09 12" src="https://user-images.githubusercontent.com/113730/34074388-c9289bf8-e27b-11e7-83ad-5c49da81bf03.png"> | <img width="312" alt="screen shot 2017-12-16 at 16 09 56" src="https://user-images.githubusercontent.com/113730/34074389-c93ad4d0-e27b-11e7-9ac6-b6d4ad15d6a7.png">
