### PR TITLE
Fix UI issues with special channels

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -877,10 +877,6 @@ kbd {
 	right: 180px;
 }
 
-#chat .special {
-	bottom: -47px;
-}
-
 #viewport.rt .chat {
 	right: 0;
 }
@@ -923,6 +919,9 @@ kbd {
 #chat .messages {
 	padding: 10px 0;
 	touch-action: pan-y;
+}
+
+#chat .chan:not(.special) .messages {
 	margin-top: auto;
 }
 
@@ -1037,6 +1036,15 @@ kbd {
 #chat .special .time,
 #chat .special .from {
 	display: none;
+}
+
+#chat .special .date-marker-container,
+#chat .special .unread-marker {
+	display: none;
+}
+
+#chat .special table th {
+	word-break: normal;
 }
 
 /* Nicknames */


### PR DESCRIPTION
As a reminder, "special" channels right now are banlists and channel lists.

- Remove that bottom margin that was causing things to hide behind the message input. This was probably relevant before the whole UI was flexbox-based and was not removed when switching.
- Do not align to bottom on special channels
- Hide unread and date markers on special channels
- Make sure table headers in special channels are not truncated, which was for example the case with "Users" being broken up ("User" and "s" on 2 different lines)

Before | After
--- | ---
<img width="1280" alt="screen shot 2017-12-17 at 01 18 32" src="https://user-images.githubusercontent.com/113730/34077106-5bf0d648-e2c8-11e7-958b-618717dcd333.png"> | <img width="1280" alt="screen shot 2017-12-17 at 01 17 53" src="https://user-images.githubusercontent.com/113730/34077107-5f3adc36-e2c8-11e7-932e-b104570b2056.png">
<img width="1280" alt="screen shot 2017-12-17 at 01 18 42" src="https://user-images.githubusercontent.com/113730/34077109-68603d42-e2c8-11e7-8ff9-7a504fc21cc5.png"> | <img width="1280" alt="screen shot 2017-12-17 at 01 17 58" src="https://user-images.githubusercontent.com/113730/34077110-6b9892c0-e2c8-11e7-8fac-d5589eafeaaf.png">
