### PR TITLE
Clear storage folder after successful start and graceful exit

### DIFF
--- a/src/plugins/storage.js
+++ b/src/plugins/storage.js
@@ -9,7 +9,9 @@ const helper = require("../helper");
 class Storage {
 	constructor() {
 		this.references = new Map();
+	}
 
+	emptyDir() {
 		// Ensures that a directory is empty.
 		// Deletes directory contents if the directory is not empty.
 		// If the directory does not exist, it is created.

--- a/src/server.js
+++ b/src/server.js
@@ -146,6 +146,12 @@ module.exports = function() {
 				return;
 			}
 
+			if (Helper.config.prefetchStorage) {
+				log.info("Clearing prefetch storage folder, this might take a while...");
+
+				require("./plugins/storage").emptyDir();
+			}
+
 			// Forcefully exit after 3 seconds
 			suicideTimeout = setTimeout(() => process.exit(1), 3000);
 
@@ -163,6 +169,11 @@ module.exports = function() {
 
 		process.on("SIGINT", exitGracefully);
 		process.on("SIGTERM", exitGracefully);
+
+		// Clear storage folder after server starts successfully
+		if (Helper.config.prefetchStorage) {
+			require("./plugins/storage").emptyDir();
+		}
 	});
 
 	return server;


### PR DESCRIPTION
On master it clears whenever constructor runs, which might not be desirable.