### PR TITLE
Fix possible issues with `from` in messages

### DIFF
--- a/src/plugins/irc-events/message.js
+++ b/src/plugins/irc-events/message.js
@@ -38,11 +38,13 @@ module.exports = function(irc, network) {
 
 	function handleMessage(data) {
 		let chan;
+		const from = chan.getUser(data.nick);
 		const msg = new Msg({
 			type: data.type,
 			time: data.time,
 			text: data.message,
 			self: data.nick === irc.user.nick,
+			from: from,
 			highlight: false,
 			users: [],
 		});
@@ -50,7 +52,6 @@ module.exports = function(irc, network) {
 		// Server messages go to server window, no questions asked
 		if (data.from_server) {
 			chan = network.channels[0];
-			msg.from = chan.getUser(data.nick);
 		} else {
 			let target = data.target;
 
@@ -79,13 +80,11 @@ module.exports = function(irc, network) {
 				}
 			}
 
-			msg.from = chan.getUser(data.nick);
-
 			// Query messages (unless self) always highlight
 			if (chan.type === Chan.Type.QUERY) {
 				msg.highlight = !msg.self;
 			} else if (chan.type === Chan.Type.CHANNEL) {
-				msg.from.lastMessage = data.time || Date.now();
+				from.lastMessage = data.time || Date.now();
 			}
 		}
 


### PR DESCRIPTION
Was looking at that code and it looked sketchy. `from` is supposed to be cloned in `Msg` constructor, but it was being assigned later on.