### PR TITLE
Only show in active if the document is active

### DIFF
--- a/client/js/socket-events/msg.js
+++ b/client/js/socket-events/msg.js
@@ -34,7 +34,7 @@ function processReceivedMessage(data) {
 
 	// Display received notices and errors in currently active channel.
 	// Reloading the page will put them back into the lobby window.
-	if (data.msg.showInActive) {
+	if (data.msg.showInActive && document.hasFocus()) {
 		const activeOnNetwork = sidebarTarget.parent().find(".active");
 
 		// We only want to put errors/notices in active channel if they arrive on the same network


### PR DESCRIPTION
Something I was thinking about when doing #1868 

If the user isn't actively looking at the lounge, we probably don't want to show something in the active window. Just a thought.