### PR TITLE
Add visual feedback on focused buttons, for example when tabbing to it

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -124,7 +124,8 @@ kbd {
 }
 
 .btn:disabled,
-.btn:hover {
+.btn:hover,
+.btn:focus {
 	background: #84ce88;
 	color: #fff;
 	opacity: 1;


### PR DESCRIPTION
This is nice for keyboard navigation (and accessibility).

Before | After
--- | ---
![before](https://user-images.githubusercontent.com/113730/34276084-df8d771a-e66d-11e7-8640-17f36ecb0132.gif) | ![after](https://user-images.githubusercontent.com/113730/34276082-df82038a-e66d-11e7-8148-68b435f25cfa.gif)

Note that this example is not the best because users can (and probably do) hit <kbd>Enter</kbd> to submit, but buttons are not necessarily for submitting forms, in which case it looks like the focus is lost.