### PR TITLE
Add a `notEqual` block helper for Handlebars and tests for `equal`

### DIFF
--- a/client/js/libs/handlebars/equal.js
+++ b/client/js/libs/handlebars/equal.js
@@ -1,8 +1,13 @@
 "use strict";
 
 module.exports = function(a, b, opt) {
+	if (arguments.length !== 3) {
+		throw new Error("Handlebars helper `equal` expects 3 arguments");
+	}
+
 	a = a.toString();
 	b = b.toString();
+
 	if (a === b) {
 		return opt.fn(this);
 	}

--- a/client/js/libs/handlebars/notEqual.js
+++ b/client/js/libs/handlebars/notEqual.js
@@ -1,0 +1,18 @@
+"use strict";
+
+module.exports = function(a, b, opt) {
+	if (arguments.length !== 3) {
+		throw new Error("Handlebars helper `notEqual` expects 3 arguments");
+	}
+
+	a = a.toString();
+	b = b.toString();
+
+	if (a !== b) {
+		return opt.fn(this);
+	}
+
+	if (opt.inverse(this) !== "") {
+		throw new Error("Handlebars helper `notEqual` does not take an `else` block");
+	}
+};

--- a/client/views/actions/whois.tpl
+++ b/client/views/actions/whois.tpl
@@ -10,7 +10,7 @@
 
 {{#if whois.actualhost}}
 	<dt>Actual host:</dt>
-	<dd class="hostmask"><a href="https://ipinfo.io/{{whois.actualip}}" target="_blank" rel="noopener">{{whois.actualip}}</a>{{#equal whois.actualhost whois.actualip}}{{else}} ({{whois.actualhost}}){{/equal}}</dd>
+	<dd class="hostmask"><a href="https://ipinfo.io/{{whois.actualip}}" target="_blank" rel="noopener">{{whois.actualip}}</a>{{#notEqual whois.actualhost whois.actualip}} ({{whois.actualhost}}){{/notEqual}}</dd>
 {{/if}}
 
 {{#if whois.real_name}}

--- a/test/client/js/libs/handlebars/equalTest.js
+++ b/test/client/js/libs/handlebars/equalTest.js
@@ -1,0 +1,26 @@
+"use strict";
+
+const expect = require("chai").expect;
+const equal = require("../../../../../client/js/libs/handlebars/equal");
+
+describe("equal Handlebars helper", function() {
+	const block = {
+		fn: () => "fn",
+		inverse: () => "inverse",
+	};
+
+	it("should render the first block if both values are equal", function() {
+		expect(equal("foo", "foo", block)).to.equal("fn");
+	});
+
+	it("should render the inverse block if values are not equal", function() {
+		expect(equal("foo", "bar", block)).to.equal("inverse");
+	});
+
+	it("should throw if too few or too many arguments are given", function() {
+		expect(() => equal("foo", block)).to.throw(Error, /expects 3 arguments/);
+
+		expect(() => equal("foo", "bar", "baz", block))
+			.to.throw(Error, /expects 3 arguments/);
+	});
+});

--- a/test/client/js/libs/handlebars/notEqualTest.js
+++ b/test/client/js/libs/handlebars/notEqualTest.js
@@ -1,0 +1,30 @@
+"use strict";
+
+const expect = require("chai").expect;
+const notEqual = require("../../../../../client/js/libs/handlebars/notEqual");
+
+describe("notEqual Handlebars helper", function() {
+	const block = {
+		fn: () => "fn",
+	};
+
+	it("should render the block if both values are equal", function() {
+		expect(notEqual("foo", "bar", block)).to.equal("fn");
+	});
+
+	it("should throw if too few or too many arguments are given", function() {
+		expect(() => notEqual("foo", block)).to.throw(Error, /expects 3 arguments/);
+
+		expect(() => notEqual("foo", "bar", "baz", block))
+			.to.throw(Error, /expects 3 arguments/);
+	});
+
+	it("should throw if too few or too many arguments are given", function() {
+		const blockWithElse = {
+			fn: () => "fn",
+			inverse: () => "inverse",
+		};
+
+		expect(() => notEqual("foo", "foo", blockWithElse)).to.throw(Error, /else/);
+	});
+});


### PR DESCRIPTION
It turns out, we already had a case of `{{equal a b}}{{else}}Something{{/equal}}`.

This will be useful for #1833, which has something similar.