### PR TITLE
Fix incorrect documentation url in default config

### DIFF
--- a/defaults/config.js
+++ b/defaults/config.js
@@ -51,7 +51,7 @@ module.exports = {
 
 	//
 	// Set the default theme.
-	// Find out how to add new themes at https://thelounge.github.io/docs/packages/themes
+	// Find out how to add new themes at https://thelounge.github.io/docs/plugins/themes.html
 	//
 	// @type     string
 	// @default  "example"


### PR DESCRIPTION
Just something that I found while updating my instance