### PR TITLE
Fix join channel UI opening by itself

### DIFF
--- a/client/js/socket-events/init.js
+++ b/client/js/socket-events/init.js
@@ -59,17 +59,17 @@ function openCorrectChannel(clientActive, serverActive) {
 
 	// Open last active channel
 	if (clientActive > 0) {
-		target = sidebar.find("[data-id='" + clientActive + "']");
+		target = sidebar.find(`.chan[data-id="${clientActive}"]`);
 	}
 
 	// Open window provided in location.hash
 	if (target.length === 0 && window.location.hash) {
-		target = $("#footer, #sidebar").find("[data-target='" + escape(window.location.hash) + "']");
+		target = $("#footer, #sidebar").find(`.chan[data-target="${escape(window.location.hash)}"]`);
 	}
 
 	// Open last active channel according to the server
 	if (serverActive > 0 && target.length === 0) {
-		target = sidebar.find("[data-id='" + serverActive + "']");
+		target = sidebar.find(`.chan[data-id="${serverActive}"]`);
 	}
 
 	// Open first available channel


### PR DESCRIPTION
Follow-up of #1836.

Without this, `target` was matching all of the lobby link, the "Join a channel..." button, and the join form submit button, causing the form to open on page load.
This change restricts to the first one.