### PR TITLE
Improve wording of join channel UI form restrictions

### DIFF
--- a/client/views/join_channel.tpl
+++ b/client/views/join_channel.tpl
@@ -1,5 +1,5 @@
 <form id="join-channel-{{id}}" class="join-form" method="post" action="" autocomplete="off">
-	<input type="text" class="input" name="channel" placeholder="Channel" pattern="[^\s]+" maxlength="200" title="Should be a valid channel name" required>
-	<input type="password" class="input" name="key" placeholder="Password (optional)" pattern="[^\s]+" title="Should be a valid channel key" maxlength="200" >
+	<input type="text" class="input" name="channel" placeholder="Channel" pattern="[^\s]+" maxlength="200" title="The channel name may not contain spaces" required>
+	<input type="password" class="input" name="key" placeholder="Password (optional)" pattern="[^\s]+" maxlength="200" title="The channel password may not contain spaces">
 	<button type="submit" class="btn joinchan:submit" data-id="{{id}}">Join</button>
 </form>


### PR DESCRIPTION
This gives a more actionable message to the user if they do not enter a valid value:

<img width="329" alt="screen shot 2017-12-23 at 03 06 32" src="https://user-images.githubusercontent.com/113730/34318158-5223daaa-e78e-11e7-9242-91f9f0726e68.png">
