### PR TITLE
Display the correct window on page reload

### DIFF
--- a/client/js/socket-events/init.js
+++ b/client/js/socket-events/init.js
@@ -64,7 +64,8 @@ function openCorrectChannel(clientActive, serverActive) {
 
 	// Open window provided in location.hash
 	if (target.length === 0 && window.location.hash) {
-		target = $("#footer, #sidebar").find(`.chan[data-target="${escape(window.location.hash)}"]`);
+		target = $("#footer, #sidebar, #help")
+			.find(`[data-target="${escape(window.location.hash)}"]`);
 	}
 
 	// Open last active channel according to the server


### PR DESCRIPTION
This commit packs 2 fixes:

- Fixes #1888: Reloading the page while viewing the settings or help window would now send you to a channel window. This was broken when fixing an issue with the "Join a channel..." form (#1881)
- Reloading the page while viewing the changelog would also send you to a channel window. This is because, on reload, the click emitted was restricted to sidebar and footer, while it had to be emitted from the help page. It was already a bug while working on #1327. It is yet another aspect of our wonky window management and hopefully we can make this much more robust with a better overall solution.