### PR TITLE
Fix slideout not closing on mobile when hitting a footer icon

### DIFF
--- a/client/js/lounge.js
+++ b/client/js/lounge.js
@@ -344,7 +344,7 @@ $(function() {
 		// This is a rather gross hack to account for sources that are in the
 		// sidebar specifically. Needs to be done better when window management gets
 		// refactored.
-		const inSidebar = self.parents("#sidebar").length > 0;
+		const inSidebar = self.parents("#sidebar, #footer").length > 0;
 
 		if (inSidebar) {
 			chat.data(


### PR DESCRIPTION
Fixes https://github.com/thelounge/lounge/issues/1891.

Introduced by https://github.com/thelounge/lounge/commit/9691df67e3d76219ee51cfc003dafc88e54e9ecb#diff-e5178f7b74fe45f2cfe1baf9aa1ef6faR347.
Seriously...