### PR TITLE
Open and focus correct channel when clicking on push notifications

### DIFF
--- a/client/js/webpush.js
+++ b/client/js/webpush.js
@@ -8,6 +8,14 @@ let pushNotificationsButton;
 let clientSubscribed = null;
 let applicationServerKey;
 
+if ("serviceWorker" in navigator) {
+	navigator.serviceWorker.addEventListener("message", (event) => {
+		if (event.data && event.data.type === "open") {
+			$("#sidebar").find(`.chan[data-target="#${event.data.channel}"]`).click();
+		}
+	});
+}
+
 module.exports.hasServiceWorker = false;
 
 module.exports.configurePushNotifications = (subscribedOnServer, key) => {


### PR DESCRIPTION
Fixes #1550.

If service worker is registered, all notifications are sent via SW when the page is open, and that broke focusing correct channel when clicking that notification. This is now fixed.

When clicking on a notification, it tries to find a client that is already in `focus` (or is `visible`) and opens the channel where the notification came from there. If no suited client is found, it uses the first client. (This only really affects users that have multiple Lounge tabs open for some reason)

When there are no Lounge tabs (clients) open, it opens a new window with `#chan-1` hash in the url so that upon page load it opens the correct channel where the notification came from.