### PR TITLE
views/join_channel: disable autocompletion of form inputs

### DIFF
--- a/client/views/join_channel.tpl
+++ b/client/views/join_channel.tpl
@@ -1,5 +1,5 @@
 <form id="join-channel-{{id}}" class="join-form" method="post" action="" autocomplete="off">
 	<input type="text" class="input" name="channel" placeholder="Channel" pattern="[^\s]+" maxlength="200" title="The channel name may not contain spaces" required>
-	<input type="password" class="input" name="key" placeholder="Password (optional)" pattern="[^\s]+" maxlength="200" title="The channel password may not contain spaces">
+	<input type="password" class="input" name="key" placeholder="Password (optional)" pattern="[^\s]+" maxlength="200" title="The channel password may not contain spaces" autocomplete="new-password">
 	<button type="submit" class="btn btn-small" data-id="{{id}}">Join</button>
 </form>


### PR DESCRIPTION
Browsers tend to be a bit aggressive with automatically filling form fields, even if `autocomplete="off"`. This form in particular resembles a log in form a lot as well. This trick disables autocompletion of both fields (tested in Chrome and iOS Safari).