### PR TITLE
Fix stylelint

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -300,6 +300,7 @@ kbd {
 #chat .toggle-button {
 	display: inline-block;
 	margin-right: 5px;
+
 	/* These 2 directives are loosely taken from .fa-fw */
 	width: 1.35em;
 	text-align: center;
@@ -979,7 +980,6 @@ kbd {
 	touch-action: pan-y;
 }
 
-
 /**
   * Toggled via JavaScript
   */
@@ -1576,9 +1576,6 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 
 #help .help-item {
 	display: table-row;
-}
-
-#help .help-item {
 	font-size: 14px;
 }
 
@@ -1993,17 +1990,17 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 .irc-fg49 { color: #7500b5; }
 .irc-fg50 { color: #b500b5; }
 .irc-fg51 { color: #b5006b; }
-.irc-fg52 { color: #ff0000; }
+.irc-fg52 { color: #f00; }
 .irc-fg53 { color: #ff8c00; }
-.irc-fg54 { color: #ffff00; }
+.irc-fg54 { color: #ff0; }
 .irc-fg55 { color: #b2ff00; }
-.irc-fg56 { color: #00ff00; }
+.irc-fg56 { color: #0f0; }
 .irc-fg57 { color: #00ffa0; }
-.irc-fg58 { color: #00ffff; }
+.irc-fg58 { color: #0ff; }
 .irc-fg59 { color: #008cff; }
-.irc-fg60 { color: #0000ff; }
+.irc-fg60 { color: #00f; }
 .irc-fg61 { color: #a500ff; }
-.irc-fg62 { color: #ff00ff; }
+.irc-fg62 { color: #f0f; }
 .irc-fg63 { color: #ff0098; }
 .irc-fg64 { color: #ff5959; }
 .irc-fg65 { color: #ffb459; }
@@ -2015,7 +2012,7 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 .irc-fg71 { color: #59b4ff; }
 .irc-fg72 { color: #5959ff; }
 .irc-fg73 { color: #c459ff; }
-.irc-fg74 { color: #ff66ff; }
+.irc-fg74 { color: #f6f; }
 .irc-fg75 { color: #ff59bc; }
 .irc-fg76 { color: #ff9c9c; }
 .irc-fg77 { color: #ffd39c; }
@@ -2029,7 +2026,7 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 .irc-fg85 { color: #dc9cff; }
 .irc-fg86 { color: #ff9cff; }
 .irc-fg87 { color: #ff94d3; }
-.irc-fg88 { color: #000000; }
+.irc-fg88 { color: #000; }
 .irc-fg89 { color: #131313; }
 .irc-fg90 { color: #282828; }
 .irc-fg91 { color: #363636; }
@@ -2039,7 +2036,7 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 .irc-fg95 { color: #9f9f9f; }
 .irc-fg96 { color: #bcbcbc; }
 .irc-fg97 { color: #e2e2e2; }
-.irc-fg98 { color: #ffffff; }
+.irc-fg98 { color: #fff; }
 .irc-bg16 { background-color: #470000; }
 .irc-bg17 { background-color: #472100; }
 .irc-bg18 { background-color: #474700; }
@@ -2076,17 +2073,17 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 .irc-bg49 { background-color: #7500b5; }
 .irc-bg50 { background-color: #b500b5; }
 .irc-bg51 { background-color: #b5006b; }
-.irc-bg52 { background-color: #ff0000; }
+.irc-bg52 { background-color: #f00; }
 .irc-bg53 { background-color: #ff8c00; }
-.irc-bg54 { background-color: #ffff00; }
+.irc-bg54 { background-color: #ff0; }
 .irc-bg55 { background-color: #b2ff00; }
-.irc-bg56 { background-color: #00ff00; }
+.irc-bg56 { background-color: #0f0; }
 .irc-bg57 { background-color: #00ffa0; }
-.irc-bg58 { background-color: #00ffff; }
+.irc-bg58 { background-color: #0ff; }
 .irc-bg59 { background-color: #008cff; }
-.irc-bg60 { background-color: #0000ff; }
+.irc-bg60 { background-color: #00f; }
 .irc-bg61 { background-color: #a500ff; }
-.irc-bg62 { background-color: #ff00ff; }
+.irc-bg62 { background-color: #f0f; }
 .irc-bg63 { background-color: #ff0098; }
 .irc-bg64 { background-color: #ff5959; }
 .irc-bg65 { background-color: #ffb459; }
@@ -2098,7 +2095,7 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 .irc-bg71 { background-color: #59b4ff; }
 .irc-bg72 { background-color: #5959ff; }
 .irc-bg73 { background-color: #c459ff; }
-.irc-bg74 { background-color: #ff66ff; }
+.irc-bg74 { background-color: #f6f; }
 .irc-bg75 { background-color: #ff59bc; }
 .irc-bg76 { background-color: #ff9c9c; }
 .irc-bg77 { background-color: #ffd39c; }
@@ -2112,7 +2109,7 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 .irc-bg85 { background-color: #dc9cff; }
 .irc-bg86 { background-color: #ff9cff; }
 .irc-bg87 { background-color: #ff94d3; }
-.irc-bg88 { background-color: #000000; }
+.irc-bg88 { background-color: #000; }
 .irc-bg89 { background-color: #131313; }
 .irc-bg90 { background-color: #282828; }
 .irc-bg91 { background-color: #363636; }
@@ -2122,7 +2119,7 @@ part/quit messages where we don't load previews (adds a blank line otherwise) */
 .irc-bg95 { background-color: #9f9f9f; }
 .irc-bg96 { background-color: #bcbcbc; }
 .irc-bg97 { background-color: #e2e2e2; }
-.irc-bg98 { background-color: #ffffff; }
+.irc-bg98 { background-color: #fff; }
 
 .irc-bold {
 	font-weight: bold;

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "npm-run-all --aggregate-output --parallel --continue-on-error test:* lint:*",
     "test:mocha": "mocha --colors",
     "lint:js": "eslint . --report-unused-disable-directives --color",
-    "lint:css": "stylelint --color --report-needless-disables=error \"client/**/*.css\""
+    "lint:css": "stylelint --color \"client/**/*.css\""
   },
   "keywords": [
     "lounge",


### PR DESCRIPTION
The `--report-needless-disables=error` option was added in https://github.com/thelounge/lounge/commit/b25884c5bd9887916d947896e62f51c3c68aa30e but it turns out it completely disables `npm run css:lint` :man_facepalming:

I have tried everything I could think of (switching options, using `--xx error` instead of `--xx=error`, giving it no value, etc.) but no dice. I also looked at their GitHub issues and couldn't find anything. The weirdest thing.
If someone else wants to give it a try, feel free to, but this is puzzling me too much for the benefits it brings.