### PR TITLE
Update primer-tooltips to the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "lodash": "4.17.4",
     "moment": "2.20.1",
     "package-json": "4.0.1",
-    "primer-tooltips": "1.5.0",
+    "primer-tooltips": "1.5.1",
     "read": "1.0.7",
     "request": "2.83.0",
     "semver": "5.4.1",


### PR DESCRIPTION
Only changes between v1.5.0 and v1.5.1 (according to https://github.com/primer/primer/commits/master/modules/primer-tooltips) are:

- https://github.com/primer/primer/pull/394
- https://github.com/primer/primer/pull/409

So we are not affected.