### PR TITLE
Set decoding=async on image previews

### DIFF
--- a/client/views/image_viewer.tpl
+++ b/client/views/image_viewer.tpl
@@ -9,7 +9,7 @@
 {{/if}}
 
 <a class="image-link" href="{{link}}" target="_blank">
-  <img src="{{image}}" alt="Preview of {{link}}">
+  <img src="{{image}}" decoding="async" alt="">
 </a>
 
 <a class="btn open-btn" href="{{link}}" target="_blank">

--- a/client/views/msg_preview.tpl
+++ b/client/views/msg_preview.tpl
@@ -2,7 +2,7 @@
 <div class="toggle-content toggle-type-{{type}}{{#if shown}} show{{/if}}">
 	{{#equal type "image"}}
 		<a class="toggle-thumbnail" href="{{link}}" target="_blank" rel="noopener">
-			<img src="{{thumb}}">
+			<img src="{{thumb}}" decoding="async" alt="">
 		</a>
 	{{/equal}}
 	{{#equal type "audio"}}
@@ -20,7 +20,7 @@
 	{{#equal type "link"}}
 		{{#if thumb}}
 			<a class="toggle-thumbnail" href="{{link}}" target="_blank" rel="noopener">
-				<img src="{{thumb}}" class="thumb">
+				<img src="{{thumb}}" decoding="async" alt="" class="thumb">
 			</a>
 		{{/if}}
 		<a class="toggle-text" href="{{link}}" target="_blank" rel="noopener">


### PR DESCRIPTION
https://github.com/whatwg/html/issues/1920
https://github.com/ampproject/amphtml/pull/12145
https://html.spec.whatwg.org/multipage/images.html#image-decoding-hint

This is a new spec addition, and browsers are starting to implement this.