### PR TITLE
Store images with correct file extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "irc-framework": "2.10.2",
     "ldapjs": "1.0.1",
     "lodash": "4.17.4",
+    "mime-types": "2.1.17",
     "moment": "2.20.1",
     "package-json": "4.0.1",
     "primer-tooltips": "1.5.1",

--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -3,6 +3,7 @@
 const cheerio = require("cheerio");
 const request = require("request");
 const url = require("url");
+const mime = require("mime-types");
 const Helper = require("../../helper");
 const cleanIrcMessage = require("../../../client/js/libs/handlebars/ircmessageparser/cleanIrcMessage");
 const findLinks = require("../../../client/js/libs/handlebars/ircmessageparser/findLinks");
@@ -146,7 +147,22 @@ function handlePreview(client, msg, preview, res) {
 		return emitPreview(client, msg, preview);
 	}
 
-	storage.store(res.data, res.type.replace("image/", ""), (uri) => {
+	// Get the correct file extension for the provided content-type
+	// This is done to prevent user-input being stored in the file name (extension)
+	const extension = mime.extension(res.type);
+
+	if (!extension) {
+		// For link previews, drop the thumbnail
+		// For other types, do not display preview at all
+		if (preview.type !== "link") {
+			return;
+		}
+
+		preview.thumb = "";
+		return emitPreview(client, msg, preview);
+	}
+
+	storage.store(res.data, extension, (uri) => {
 		preview.thumb = uri;
 
 		emitPreview(client, msg, preview);


### PR DESCRIPTION
This fixes svg image thumbnails, where it would be stored as `xxxxxxx.svg+xml` on disk and express wouldn't serve correct content-type for it.

This also prevents being able to write any user-input string in the file name.