### PR TITLE
Fix CTCP commands always sent upper-case

### DIFF
--- a/src/plugins/inputs/ctcp.js
+++ b/src/plugins/inputs/ctcp.js
@@ -4,6 +4,6 @@ exports.commands = ["ctcp"];
 
 exports.input = function({irc}, chan, cmd, args) {
 	if (args.length > 1) {
-		irc.ctcpRequest(args[0], args.slice(1).join(" "));
+		irc.ctcpRequest(...args);
 	}
 };


### PR DESCRIPTION
This is a Node v6+ only fix (so CI will fail until #1727 gets merged).
`irc-framework` upper-cases the first argument, and we were sending everything as a string in first argument. This correctly splits.

```js
> function foo(a, b) {
...   console.log(a);
...   console.log(b);
... }

> foo(["a", "b"].join(" "))
a b
undefined

> foo(...["a", "b"])
a
b
```