### PR TITLE
Show channel name on channel-related errors

### DIFF
--- a/src/plugins/irc-events/error.js
+++ b/src/plugins/irc-events/error.js
@@ -6,10 +6,18 @@ module.exports = function(irc, network) {
 	const client = this;
 
 	irc.on("irc error", function(data) {
-		let text = data.error;
+		let text = "";
 
-		if (data.reason) {
-			text = data.reason + " (" + text + ")";
+		if (data.channel) {
+			text = `${data.channel}: `;
+		}
+
+		if (data.error === "user_on_channel") {
+			text += `User (${data.nick}) is already on channel`;
+		} else if (data.reason) {
+			text += `${data.reason} (${data.error})`;
+		} else {
+			text += data.error;
 		}
 
 		const lobby = network.channels[0];


### PR DESCRIPTION
Fixes #1207.

Examples:
```
#rockytv: Cannot join channel (+b) - you are banned (banned_from_channel)
#rockytv: Cannot join channel (+l) - channel is full, try again later (channel_is_full)
#rockytv: Xinayder is already on channel (user_on_channel)
```

~~The only problem I've found is that if you try to join the channel again after receiving an error that prevents you from joining it, Lounge will just switch to the tab instead of sending the command again.~~

~~EDIT: regarding the bug related above, it seems to happen only on the 2.7 development branch.~~