### PR TITLE
Add a `thelounge uninstall` command to remove themes and packages

### DIFF
--- a/src/command-line/index.js
+++ b/src/command-line/index.js
@@ -65,6 +65,7 @@ if (!Helper.config.public && !Helper.config.ldap.enable) {
 	require("./users");
 }
 require("./install");
+require("./uninstall");
 
 // TODO: Remove this when releasing The Lounge v3
 if (process.argv[1].endsWith(`${require("path").sep}lounge`)) {

--- a/src/command-line/install.js
+++ b/src/command-line/install.js
@@ -55,12 +55,14 @@ program
 					"--no-save",
 					"--no-bin-links",
 					"--no-package-lock",
+					"--no-progress",
 					"--prefix",
 					packagesParent,
 					packageName,
 				],
 				{
-					stdio: "inherit",
+					// This is the same as `"inherit"` except `process.stdout` is ignored
+					stdio: [process.stdin, "ignore", process.stderr],
 				}
 			);
 
@@ -75,7 +77,7 @@ program
 					return;
 				}
 
-				log.info(`${colors.green(packageName)} has been successfully installed.`);
+				log.info(`${colors.green(packageName + " v" + json.version)} has been successfully installed.`);
 			});
 		}).catch((e) => {
 			log.error(`${e}`);

--- a/src/command-line/uninstall.js
+++ b/src/command-line/uninstall.js
@@ -1,0 +1,53 @@
+"use strict";
+
+const colors = require("colors/safe");
+const path = require("path");
+const program = require("commander");
+const Helper = require("../helper");
+const Utils = require("./utils");
+
+program
+	.command("uninstall <package>")
+	.description("Uninstall a theme or a package")
+	.on("--help", Utils.extraHelp)
+	.action(function(packageName) {
+		const fs = require("fs");
+		const child = require("child_process");
+
+		if (!fs.existsSync(Helper.getConfigPath())) {
+			log.error(`${Helper.getConfigPath()} does not exist.`);
+			return;
+		}
+
+		log.info(`Uninstalling ${colors.green(packageName)}...`);
+
+		const packagesPath = Helper.getPackagesPath();
+		const packagesParent = path.dirname(packagesPath);
+
+		const npm = child.spawn(
+			process.platform === "win32" ? "npm.cmd" : "npm",
+			[
+				"uninstall",
+				"--prefix",
+				packagesParent,
+				packageName,
+			],
+			{
+				stdio: "inherit",
+			}
+		);
+
+		npm.on("error", (e) => {
+			log.error(`${e}`);
+			process.exit(1);
+		});
+
+		npm.on("close", (code) => {
+			if (code !== 0) {
+				log.error(`Failed to uninstall ${colors.green(packageName)}. Exit code: ${code}`);
+				return;
+			}
+
+			log.info(`${colors.green(packageName)} has been successfully uninstalled.`);
+		});
+	});

--- a/src/command-line/uninstall.js
+++ b/src/command-line/uninstall.js
@@ -28,14 +28,22 @@ program
 			process.platform === "win32" ? "npm.cmd" : "npm",
 			[
 				"uninstall",
+				"--no-progress",
 				"--prefix",
 				packagesParent,
 				packageName,
 			],
 			{
-				stdio: "inherit",
+				// This is the same as `"inherit"` except `process.stdout` is piped
+				stdio: [process.stdin, "pipe", process.stderr],
 			}
 		);
+
+		let hasUninstalled = false;
+
+		npm.stdout.on("data", () => {
+			hasUninstalled = true;
+		});
 
 		npm.on("error", (e) => {
 			log.error(`${e}`);
@@ -48,6 +56,10 @@ program
 				return;
 			}
 
-			log.info(`${colors.green(packageName)} has been successfully uninstalled.`);
+			if (hasUninstalled) {
+				log.info(`${colors.green(packageName)} has been successfully uninstalled.`);
+			} else {
+				log.warn(`${colors.green(packageName)} was not installed.`);
+			}
 		});
 	});

--- a/src/command-line/uninstall.js
+++ b/src/command-line/uninstall.js
@@ -23,6 +23,13 @@ program
 
 		const packagesPath = Helper.getPackagesPath();
 		const packagesParent = path.dirname(packagesPath);
+		const packagesConfig = path.join(packagesParent, "package.json");
+		const packageWasNotInstalled = `${colors.green(packageName)} was not installed.`;
+
+		if (!fs.existsSync(packagesConfig)) {
+			log.warn(packageWasNotInstalled);
+			return;
+		}
 
 		const npm = child.spawn(
 			process.platform === "win32" ? "npm.cmd" : "npm",
@@ -59,7 +66,7 @@ program
 			if (hasUninstalled) {
 				log.info(`${colors.green(packageName)} has been successfully uninstalled.`);
 			} else {
-				log.warn(`${colors.green(packageName)} was not installed.`);
+				log.warn(packageWasNotInstalled);
 			}
 		});
 	});


### PR DESCRIPTION
Triggered by https://github.com/thelounge/lounge/pull/1619.

Because it currently forces usage of plugins and there is no way to disable them from the server or the client, I think having a way to remove packages should make it in the same release as #1619 (currently v2.7).