### PR TITLE
Pass --ignore-scripts to npm install

### DIFF
--- a/src/command-line/install.js
+++ b/src/command-line/install.js
@@ -52,6 +52,7 @@ program
 				[
 					"install",
 					"--production",
+					"--ignore-scripts",
 					"--no-save",
 					"--no-bin-links",
 					"--no-package-lock",


### PR DESCRIPTION
Fixes #1935.

See http://blog.npmjs.org/post/141702881055/package-install-scripts-vulnerability for more information. We don't need to run scripts for packages.