### PR TITLE
Add a CLI option to force colors on command outputs

### DIFF
--- a/src/command-line/index.js
+++ b/src/command-line/index.js
@@ -11,15 +11,21 @@ const Helper = require("../helper");
 const Utils = require("./utils");
 
 program.version(Helper.getVersion(), "-v, --version")
+	.option("--colors", "force enabling of colors in command outputs")
 	.option(
 		"-c, --config <key=value>",
-		"override entries of the configuration file, must be specified for each entry that needs to be overriden",
+		"override entries of the configuration file, must be specified for each " +
+		"entry that needs to be overriden",
 		Utils.parseConfigOptions
 	)
 	.on("--help", Utils.extraHelp);
 
 // Parse options from `argv` returning `argv` void of these options.
 const argvWithoutOptions = program.parseOptions(process.argv);
+
+if (program.colors) {
+	colors.enabled = true;
+}
 
 // Check if the app was built before calling setHome as it wants to load manifest.json from the public folder
 if (!fs.existsSync(path.join(
@@ -46,9 +52,9 @@ if (!Helper.config.public && !Helper.config.ldap.enable) {
 require("./install");
 require("./uninstall");
 
-// `parse` expects to be passed `process.argv`, but we need to remove to give it
-// a version of `argv` that does not contain options already parsed by
-// `parseOptions` above.
+// `parse` expects to be passed `process.argv`, but we need to give it a version
+// of `argv` that does not contain options already parsed by `parseOptions`
+// above.
 // This is done by giving it the updated `argv` that `parseOptions` returned,
 // except it returns an object with `args`/`unknown`, so we need to concat them.
 // See https://github.com/tj/commander.js/blob/fefda77f463292/index.js#L686-L763


### PR DESCRIPTION
Not sure if we want this, I was trying to help with https://github.com/thelounge/lounge/pull/1943 and the fact that our colors don't show when running piped.

This is similar to what Mocha, ESLint, Stylelint, etc. have to force colors when displaying their output via piping instead of TTY (for example when using `npm-run-all --print-label` or `npm-run-all --aggregate-output`).

I hesitated to make this part of the config file, then use `-c forceColors=true` but it's less obvious than other options as it's specific to CLI, probably a per-command basis and not per configuration i.e. probably something you never want to enable in config file since it can mess up logs, etc.