### PR TITLE
Only emit "more" history to the client that requested it

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -396,7 +396,7 @@ Client.prototype.more = function(data) {
 	const target = client.find(data.target);
 
 	if (!target) {
-		return;
+		return null;
 	}
 
 	const chan = target.chan;
@@ -415,10 +415,10 @@ Client.prototype.more = function(data) {
 		messages = chan.messages.slice(Math.max(0, index - 100), index);
 	}
 
-	client.emit("more", {
+	return {
 		chan: chan.id,
 		messages: messages,
-	});
+	};
 };
 
 Client.prototype.open = function(socketId, target) {

--- a/src/server.js
+++ b/src/server.js
@@ -258,7 +258,11 @@ function initializeClient(socket, client, token, lastMessage) {
 	socket.on(
 		"more",
 		function(data) {
-			client.more(data);
+			const history = client.more(data);
+
+			if (history !== null) {
+				socket.emit("more", history);
+			}
 		}
 	);
 


### PR DESCRIPTION
Noticed that when opening a channel on mobile also sent `more` to my desktop client.