### PR TITLE
Fix local themes not being found in theme selector dropdown, and serve local themes using the themes route instead of the public folder

### DIFF
--- a/src/plugins/packages/themes.js
+++ b/src/plugins/packages/themes.js
@@ -14,7 +14,7 @@ module.exports = {
 };
 
 function loadLocalThemes() {
-	fs.readdir(path.join(__dirname, "..", "..", "public", "themes"), (err, builtInThemes) => {
+	fs.readdir(path.join(__dirname, "..", "..", "..", "public", "themes"), (err, builtInThemes) => {
 		if (err) {
 			return;
 		}
@@ -46,7 +46,6 @@ function makeLocalThemeObject(css) {
 	const themeName = css.slice(0, -4);
 	return {
 		displayName: themeName.charAt(0).toUpperCase() + themeName.slice(1),
-		filename: path.join(__dirname, "..", "..", "public", "themes", `${themeName}.css`),
 		name: themeName,
 	};
 }

--- a/src/server.js
+++ b/src/server.js
@@ -48,6 +48,10 @@ module.exports = function() {
 			maxAge: 86400 * 1000,
 		}));
 
+	// This route serves *installed themes only*. Local themes are served directly
+	// from the `public/themes/` folder as static assets, without entering this
+	// handler. Remember this is you make changes to this function, serving of
+	// local themes will not get those changes.
 	app.get("/themes/:theme.css", (req, res) => {
 		const themeName = req.params.theme;
 		const theme = themes.getFilename(themeName);


### PR DESCRIPTION
Fixes #1968.
Fixes #1969.
Supersedes #1970, which contains additional details.

This code was moved from `src/plugins/themes.js` to `src/plugins/packages/themes.js` (one level deeper) in https://github.com/thelounge/lounge/pull/1619/files#diff-9f82c1f3ff2c49ecbb24cd28408ee089L15 but the path being built was not changed.