### PR TITLE
Fix enabling push notifications on Firefox

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -227,6 +227,7 @@ function index(req, res, next) {
 		"style-src 'self' 'unsafe-inline'", // allow inline due to use in irc hex colors
 		"script-src 'self'", // javascript
 		"worker-src 'self'", // service worker
+		"child-src 'self'", // deprecated fall back for workers, Firefox <58, see #1902
 		"manifest-src 'self'", // manifest.json
 		"font-src 'self' https:", // allow loading fonts from secure sites (e.g. google fonts)
 		"media-src 'self' https:", // self for notification sound; allow https media (audio previews)


### PR DESCRIPTION
Fixes #1902.

Tested on Firefox ESR with about:config flags for push/sw enabled.