### PR TITLE
Make sure existing packages (and themes) are not deleted when installing a new one on Node.js v8

### DIFF
--- a/src/command-line/install.js
+++ b/src/command-line/install.js
@@ -41,18 +41,22 @@ program
 			// Create node_modules folder, otherwise npm will start walking upwards to find one
 			fsextra.ensureDirSync(packagesPath);
 
-			// Create package.json with private set to true to avoid npm warnings
-			fs.writeFileSync(packagesConfig, JSON.stringify({
-				private: true,
-				description: "Packages for The Lounge. All packages in node_modules directory will be automatically loaded.",
-			}, null, "\t"));
+			// Create package.json with private set to true to avoid npm warnings, if
+			// it doesn't exist already
+			if (!fs.existsSync(packagesConfig)) {
+				fs.writeFileSync(packagesConfig, JSON.stringify({
+					private: true,
+					description: "Packages for The Lounge. All packages in node_modules directory will be automatically loaded.",
+				}, null, "\t"));
+			}
 
 			const npm = child.spawn(
 				process.platform === "win32" ? "npm.cmd" : "npm",
 				[
 					"install",
 					"--production",
-					"--no-save",
+					"--save",
+					"--save-exact",
 					"--no-bin-links",
 					"--no-package-lock",
 					"--no-progress",


### PR DESCRIPTION
- When installing a package on Node v8 (or whatever npm version ships with it - v5), all packages not listed in `package.json` are removed. Since we explicitly added `--no-save`, installing a theme would delete the previous one. I am now checking that the file already exists or not. This means that it will still happen to people the next time they run `thelounge install`, because the previous install did not save into `package.json` :/
- Adding `--save` to make sure that the same, correct behavior is done on Node v6 as well (npm v3)
- Adding `--save-exact` for good measure.

This is a rather "quick fix" to fix the current, broken situation before shipping v2.7.0 (which comes with #1619, our first package API), but we are thinking about more extensive changes that would list `npm` in our dependencies, and/or switch to `yarn`.
I don't want to do something more drastic, just fix the immediate issue for now.