### PR TITLE
Show channels for only active server in autocomplete

### DIFF
--- a/client/js/autocompletion.js
+++ b/client/js/autocompletion.js
@@ -282,7 +282,9 @@ function completeCommands(word) {
 function completeChans(word) {
 	const words = [];
 
-	sidebar.find(".chan")
+	sidebar.find(".chan.active")
+		.parent()
+		.find(".chan")
 		.each(function() {
 			const self = $(this);
 			if (!self.hasClass("lobby")) {


### PR DESCRIPTION
Fix #1381.

I hope this is correct. It seems to work for me.