### PR TITLE
Fix timestamp tooltips not aligning correctly with timestamps

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1045,7 +1045,6 @@ kbd {
 	word-break: break-word; /* Webkit-specific */
 	display: flex;
 	align-items: flex-start;
-	overflow: hidden;
 	position: relative;
 }
 
@@ -1146,6 +1145,7 @@ kbd {
 	min-width: 0;
 	padding-left: 10px;
 	padding-right: 6px;
+	overflow: hidden; /* Prevents Zalgo text to expand beyond messages */
 }
 
 #loading a,

--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1044,6 +1044,7 @@ kbd {
 	word-wrap: break-word;
 	word-break: break-word; /* Webkit-specific */
 	display: flex;
+	align-items: flex-start;
 	overflow: hidden;
 	position: relative;
 }


### PR DESCRIPTION
Fixes #1998.
Fixes #2000.

Very quick, in-browser attempt at fixing #1998. Not sure if this breaks anything else.

Before | After
--- | ---
<img width="265" alt="screen shot 2018-01-23 at 00 45 05" src="https://user-images.githubusercontent.com/113730/35260093-7b698e9e-ffd7-11e7-9269-87c2dcb33f72.png"> | <img width="241" alt="screen shot 2018-01-23 at 00 50 24" src="https://user-images.githubusercontent.com/113730/35260098-82eea884-ffd7-11e7-8da3-dca7e9fc30ec.png">

