### PR TITLE
Set start_url in manifest.json

### DIFF
--- a/client/manifest.json
+++ b/client/manifest.json
@@ -2,6 +2,7 @@
 	"name": "The Lounge",
 	"short_name": "The Lounge",
 	"description": "Self-hosted web IRC client",
+	"start_url": ".",
 	"display": "standalone",
 	"theme_color": "#455164",
 	"background_color": "#455164",


### PR DESCRIPTION
Tested on root and sub folders. This drops GET params and hash from the url so that stored location does not contain `#chan-X` and other stuff.