### PR TITLE
Use forked ldapjs to remove dtrace

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "express": "4.16.2",
     "fs-extra": "5.0.0",
     "irc-framework": "2.10.3",
-    "ldapjs": "1.0.2",
     "lodash": "4.17.5",
     "mime-types": "2.1.17",
     "moment": "2.20.1",
@@ -56,6 +55,7 @@
     "semver": "5.5.0",
     "socket.io": "2.0.4",
     "spdy": "3.4.7",
+    "thelounge-ldapjs-non-maintained-fork": "1.0.2",
     "ua-parser-js": "0.7.17",
     "urijs": "1.19.0",
     "web-push": "3.2.5"

--- a/src/plugins/auth/ldap.js
+++ b/src/plugins/auth/ldap.js
@@ -1,7 +1,11 @@
 "use strict";
 
 const Helper = require("../../helper");
-const ldap = require("ldapjs");
+
+// Forked ldapjs for 2 reasons:
+// 1. Removed bunyan https://github.com/joyent/node-ldapjs/pull/399
+// 2. Remove dtrace-provider dependency
+const ldap = require("thelounge-ldapjs-non-maintained-fork");
 
 function ldapAuthCommon(user, bindDN, password, callback) {
 	const config = Helper.config;

--- a/test/plugins/auth/ldap.js
+++ b/test/plugins/auth/ldap.js
@@ -2,7 +2,7 @@
 
 const ldapAuth = require("../../../src/plugins/auth/ldap");
 const Helper = require("../../../src/helper");
-const ldap = require("ldapjs");
+const ldap = require("thelounge-ldapjs-non-maintained-fork");
 const expect = require("chai").expect;
 
 const user = "johndoe";


### PR DESCRIPTION
Fixes #1756.

There are endless isues with dtrace, e.g. #2016. There are 2 commits on top ldapjs that remove bunyan and dtrace-provider dependencies.

This fork isn't going to be maintained (I archived the repo), just like the main project, which is why it was forked in the firstp lace.