### PR TITLE
Fix messages not being condensed correctly

### DIFF
--- a/client/js/socket-events/msg.js
+++ b/client/js/socket-events/msg.js
@@ -58,7 +58,7 @@ function processReceivedMessage(data) {
 	render.appendMessage(
 		container,
 		targetId,
-		channel.prop("data-type"),
+		channel.data("type"),
 		data.msg
 	);
 


### PR DESCRIPTION
Fixes #2028.

This was caused by jQuery conversion I did a couple of days ago, and this is the only place where `.data` was not used.