### PR TITLE
Improve monospace formatting in messages

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -86,7 +86,8 @@ textarea#user-specified-css-input {
 	font-family: Consolas, Menlo, Monaco, "Lucida Console", "DejaVu Sans Mono", "Courier New", monospace;
 }
 
-code {
+code,
+.irc-monospace {
 	font-size: 12px;
 	padding: 2px 4px;
 	color: #e74c3c;


### PR DESCRIPTION
This effectively styles it just like to `code` syntax used in the Help window, such as in the list of available commands.

Before | After
--- | ---
<img width="700" alt="screen shot 2018-02-03 at 12 49 23" src="https://user-images.githubusercontent.com/113730/35769966-45718de2-08e1-11e8-8a6a-c9204952e139.png"> | <img width="708" alt="screen shot 2018-02-03 at 12 49 04" src="https://user-images.githubusercontent.com/113730/35769967-47ca76ee-08e1-11e8-9af7-d88877dd90a1.png">
