### PR TITLE
Report server errors when preview fetch fails

### DIFF
--- a/client/views/msg_preview.tpl
+++ b/client/views/msg_preview.tpl
@@ -28,5 +28,10 @@
 			<div class="body" title="{{body}}">{{body}}</div>
 		</a>
 	{{/equal}}
+	{{#equal type "error"}}
+		{{#equal error "message"}}
+			<em>Server returned an error: {{message}}</em>
+		{{/equal}}
+	{{/equal}}
 </div>
 {{/preview}}

--- a/src/plugins/irc-events/link.js
+++ b/src/plugins/irc-events/link.js
@@ -38,7 +38,14 @@ module.exports = function(client, chan, msg) {
 	})).slice(0, 5); // Only preview the first 5 URLs in message to avoid abuse
 
 	msg.previews.forEach((preview) => {
-		fetch(preview.link, function(res) {
+		fetch(preview.link, function(res, err) {
+			if (err) {
+				preview.type = "error";
+				preview.error = "message";
+				preview.message = err.message;
+				handlePreview(client, msg, preview, res);
+			}
+
 			if (res === null) {
 				return;
 			}
@@ -198,7 +205,7 @@ function fetch(uri, cb) {
 			},
 		});
 	} catch (e) {
-		return cb(null);
+		return cb(null, e);
 	}
 
 	const buffers = [];
@@ -222,7 +229,7 @@ function fetch(uri, cb) {
 				limit = 1024 * 50;
 			}
 		})
-		.on("error", () => cb(null))
+		.on("error", (e) => cb(null, e))
 		.on("data", (data) => {
 			length += data.length;
 			buffers.push(data);
@@ -233,7 +240,7 @@ function fetch(uri, cb) {
 		})
 		.on("end", () => {
 			if (req.response.statusCode < 200 || req.response.statusCode > 299) {
-				return cb(null);
+				return cb(null, new Error(`HTTP ${req.response.statusCode}`));
 			}
 
 			let type = "";


### PR DESCRIPTION
This is gonna report everything: server time outs, DNS failures, wrong HTTP codes, etc. This is pretty useful for knowing why fetch failed, but we might need to filter out some specific errors out (e.g. domain lookup failure).