### PR TITLE
Fix duplicate chat containers and unread markers when reconnecting

### DIFF
--- a/client/js/render.js
+++ b/client/js/render.js
@@ -228,19 +228,21 @@ function renderNetworks(data, singleNetwork) {
 		newChannels = channels;
 	}
 
-	chat.append(
-		templates.chat({
-			channels: channels,
-		})
-	);
+	if (newChannels.length > 0) {
+		chat.append(
+			templates.chat({
+				channels: newChannels,
+			})
+		);
 
-	newChannels.forEach((channel) => {
-		renderChannel(channel);
+		newChannels.forEach((channel) => {
+			renderChannel(channel);
 
-		if (channel.type === "channel") {
-			chat.find("#chan-" + channel.id).data("needsNamesRefresh", true);
-		}
-	});
+			if (channel.type === "channel") {
+				chat.find("#chan-" + channel.id).data("needsNamesRefresh", true);
+			}
+		});
+	}
 
 	utils.confirmExit();
 	sorting();


### PR DESCRIPTION
Fixes #1721.

When reconnecting, it inserted the same existing channels into chat container again, which means selecting channel by id (`#chat-XXX`) returned 2 elements instead of 1, and jQuery being nice, moved unread marker from second container into the first one, causing it to have 2 unread markers in one channel window. After that, the issue just extrapolated with `.unread-marker` selecting 2 markers, duplicating them, and resulting in 4, etc.