### PR TITLE
Unbind image events after the image is loaded

### DIFF
--- a/client/js/renderPreview.js
+++ b/client/js/renderPreview.js
@@ -26,11 +26,15 @@ function renderPreview(preview, msg) {
 
 	// If there is an image in preview, wait for it to load before appending it to DOM
 	// This is done to prevent problems keeping scroll to the bottom while images load
-	image.on("load", () => appendPreview(preview, msg, template));
+	image.on("load.preview", () => {
+		image.off(".preview");
+
+		appendPreview(preview, msg, template);
+	});
 
 	// If the image fails to load, remove it from DOM and still render the preview
 	if (preview.type === "link") {
-		image.on("abort error", () => {
+		image.on("abort.preview error.preview", () => {
 			image.parent().remove();
 
 			appendPreview(preview, msg, template);


### PR DESCRIPTION
We don't need to "leak" memory by keeping them around