### PR TITLE
Fix border after nickname not taking full height

### DIFF
--- a/client/css/style.css
+++ b/client/css/style.css
@@ -1137,7 +1137,6 @@ kbd {
 }
 
 #chat .from {
-	border-right: 1px solid #f6f6f6;
 	color: #b1c3ce;
 	padding-right: 10px;
 	text-align: right;
@@ -1152,6 +1151,7 @@ kbd {
 	min-width: 0;
 	padding-left: 10px;
 	padding-right: 6px;
+	border-left: 1px solid #f6f6f6;
 	overflow: hidden; /* Prevents Zalgo text to expand beyond messages */
 }
 

--- a/client/themes/morning.css
+++ b/client/themes/morning.css
@@ -39,7 +39,7 @@ body {
 }
 
 /* Borders */
-#chat .from,
+#chat .content,
 #windows .header,
 #chat .user-mode::before,
 #chat .sidebar {

--- a/client/themes/zenburn.css
+++ b/client/themes/zenburn.css
@@ -65,7 +65,7 @@ body {
 }
 
 /* Borders */
-#chat .from,
+#chat .content,
 #windows .header,
 #chat .user-mode::before,
 #chat .sidebar {

--- a/src/plugins/irc-events/motd.js
+++ b/src/plugins/irc-events/motd.js
@@ -9,7 +9,7 @@ module.exports = function(irc, network) {
 		const lobby = network.channels[0];
 
 		if (data.motd) {
-			data.motd.split("\n").forEach((text) => {
+			data.motd.trim().split("\n").forEach((text) => {
 				const msg = new Msg({
 					type: Msg.Type.MOTD,
 					text: text,


### PR DESCRIPTION
Fixes #2054 caused by 6bfd6ed47308c50f231f18edb15fb82d69159505

I moved border instead of changing `align-items` to prevent this issue:

![11-170587745](https://user-images.githubusercontent.com/613331/36075970-9641a5c6-0f5e-11e8-8a73-9697e01a3eb1.png)