### PR TITLE
Track channel state to allow removing channels user is not in

### DIFF
--- a/src/models/chan.js
+++ b/src/models/chan.js
@@ -15,6 +15,11 @@ Chan.Type = {
 	SPECIAL: "special",
 };
 
+Chan.State = {
+	PARTED: 0,
+	JOINED: 1,
+};
+
 let id = 1;
 
 function Chan(attr) {
@@ -25,6 +30,7 @@ function Chan(attr) {
 		key: "",
 		topic: "",
 		type: Chan.Type.CHANNEL,
+		state: Chan.State.PARTED,
 		firstUnread: 0,
 		unread: 0,
 		highlight: 0,

--- a/src/plugins/inputs/part.js
+++ b/src/plugins/inputs/part.js
@@ -29,7 +29,9 @@ exports.input = function(network, chan, cmd, args) {
 
 	// If target is not a channel or we are not connected, instantly remove the channel
 	// Otherwise send part to the server and wait for response
-	if (target.type !== Chan.Type.CHANNEL || !network.irc || !network.irc.connection || !network.irc.connection.connected) {
+	if (target.type !== Chan.Type.CHANNEL
+	|| target.state === Chan.State.PARTED
+	|| !network.irc || !network.irc.connection || !network.irc.connection.connected) {
 		network.channels = _.without(network.channels, target);
 		target.destroy();
 		this.emit("part", {

--- a/src/plugins/irc-events/connection.js
+++ b/src/plugins/irc-events/connection.js
@@ -81,6 +81,10 @@ module.exports = function(irc, network) {
 			client.manager.identHandler.removeSocket(identSocketId);
 			identSocketId = 0;
 		}
+
+		network.channels.forEach((chan) => {
+			chan.state = Chan.State.PARTED;
+		});
 	});
 
 	if (Helper.config.debug.ircFramework) {

--- a/src/plugins/irc-events/join.js
+++ b/src/plugins/irc-events/join.js
@@ -13,6 +13,7 @@ module.exports = function(irc, network) {
 		if (typeof chan === "undefined") {
 			chan = new Chan({
 				name: data.channel,
+				state: Chan.State.JOINED,
 			});
 			network.channels.push(chan);
 			client.save();

--- a/src/plugins/irc-events/kick.js
+++ b/src/plugins/irc-events/kick.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const Chan = require("../../models/chan");
 const Msg = require("../../models/msg");
 
 module.exports = function(irc, network) {
@@ -25,6 +26,7 @@ module.exports = function(irc, network) {
 
 		if (data.kicked === irc.user.nick) {
 			chan.users = new Map();
+			chan.state = Chan.State.PARTED;
 		} else {
 			chan.removeUser(msg.target);
 		}

--- a/test/models/chan.js
+++ b/test/models/chan.js
@@ -175,6 +175,7 @@ describe("Chan", function() {
 				"key",
 				"messages",
 				"name",
+				"state",
 				"topic",
 				"type",
 				"unread",


### PR DESCRIPTION
Some discussion in #1959.

We recently changed channel part to await server response, but if you were kicked from a channel, PART would never come and the channel would be left dangling.

This tracks channel state (parted or joined) to allow instantly removing channels we're already parted in.

cc @RockyTV for test