### PR TITLE
Render MOTD with a single message

### DIFF
--- a/client/js/constants.js
+++ b/client/js/constants.js
@@ -68,26 +68,6 @@ const commands = [
 	"/whois",
 ];
 
-const actionTypes = [
-	"away",
-	"back",
-	"ban_list",
-	"invite",
-	"join",
-	"mode",
-	"kick",
-	"nick",
-	"part",
-	"quit",
-	"topic",
-	"topic_set_by",
-	"action",
-	"whois",
-	"ctcp",
-	"chghost",
-	"channel_list",
-];
-
 const condensedTypes = [
 	"away",
 	"back",
@@ -110,6 +90,5 @@ module.exports = {
 	commands: commands,
 	condensedTypes: condensedTypes,
 	condensedTypesQuery: "." + condensedTypes.join(", ."),
-	actionTypes: actionTypes,
 	timeFormats: timeFormats,
 };

--- a/client/js/libs/handlebars/ircmessageparser/parseStyle.js
+++ b/client/js/libs/handlebars/ircmessageparser/parseStyle.js
@@ -19,7 +19,8 @@ const colorRx = /^(\d{1,2})(?:,(\d{1,2}))?/;
 const hexColorRx = /^([0-9a-f]{6})(?:,([0-9a-f]{6}))?/i;
 
 // Represents all other control codes that to be ignored/filtered from the text
-const controlCodesRx = /[\u0000-\u001F]/g;
+// This regex allows line feed character
+const controlCodesRx = /[\u0000-\u0009\u000B-\u001F]/g;
 
 // Converts a given text into an array of objects, each of them representing a
 // similarly styled section of the text. Each object carries the `text`, style

--- a/client/js/render.js
+++ b/client/js/render.js
@@ -93,8 +93,7 @@ function buildChatMessage(msg) {
 		msg.highlight = true;
 	}
 
-	if (constants.actionTypes.indexOf(type) !== -1) {
-		msg.template = "actions/" + type;
+	if (typeof templates.actions[type] !== "undefined") {
 		template = "msg_action";
 	} else if (type === "unhandled") {
 		template = "msg_unhandled";

--- a/src/plugins/irc-events/motd.js
+++ b/src/plugins/irc-events/motd.js
@@ -9,13 +9,11 @@ module.exports = function(irc, network) {
 		const lobby = network.channels[0];
 
 		if (data.motd) {
-			data.motd.trim().split("\n").forEach((text) => {
-				const msg = new Msg({
-					type: Msg.Type.MOTD,
-					text: text,
-				});
-				lobby.pushMessage(client, msg);
+			const msg = new Msg({
+				type: Msg.Type.MOTD,
+				text: data.motd,
 			});
+			lobby.pushMessage(client, msg);
 		}
 
 		if (data.error) {

--- a/test/client/js/constantsTest.js
+++ b/test/client/js/constantsTest.js
@@ -30,25 +30,15 @@ describe("client-side constants", function() {
 		});
 	});
 
-	describe(".actionTypes", function() {
-		it("should be a non-empty array", function() {
-			expect(constants.actionTypes).to.be.an("array").that.is.not.empty;
-		});
-
-		it("should only contain strings with no whitespaces", function() {
-			constants.actionTypes.forEach((type) => {
-				expect(type).to.be.a("string").that.does.not.match(/\s/);
-			});
-		});
-	});
-
 	describe(".condensedTypes", function() {
 		it("should be a non-empty array", function() {
 			expect(constants.condensedTypes).to.be.an("array").that.is.not.empty;
 		});
 
-		it("should be a subset of `actionTypes`", function() {
-			expect(constants.actionTypes).to.include.members(constants.condensedTypes);
+		it("should only contain ASCII strings", function() {
+			constants.condensedTypes.forEach((type) => {
+				expect(type).to.be.a("string").that.does.match(/^\w+$/);
+			});
 		});
 	});
 

--- a/test/client/js/libs/handlebars/parse.js
+++ b/test/client/js/libs/handlebars/parse.js
@@ -19,10 +19,10 @@ describe("parse Handlebars helper", () => {
 		expect(actual).to.deep.equal(expected);
 	});
 
-	it("should skip control codes", () => {
+	it("should skip all <32 ASCII codes except linefeed", () => {
 		const testCases = [{
-			input: "text\x01with\x04control\x05codes",
-			expected: "textwithcontrolcodes",
+			input: "\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0B\x0C\x0D\x0E\x0F\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1A\x1B\x1C\x1B\x1D\x1D\x1E\x1Ftext\x0Awithcontrolcodestest",
+			expected: '<span class="irc-underline irc-strikethrough irc-monospace">text\nwithcontrolcodestest</span>',
 		}];
 
 		const actual = testCases.map((testCase) => parse(testCase.input));


### PR DESCRIPTION
Instead of splitting it on server and creating `Msg` for every line, just let keep the newlines in `parse` and let CSS render it correctly.