### PR TITLE
Fix themes not loading

### DIFF
--- a/src/plugins/packages/index.js
+++ b/src/plugins/packages/index.js
@@ -62,6 +62,8 @@ function loadPackages() {
 			return;
 		}
 
+		packageInfo = packageInfo.thelounge;
+
 		packageMap.set(packageName, packageFile);
 
 		if (packageInfo.type === "theme") {


### PR DESCRIPTION
Broken by e4701be7081e97a6a4e243f104e412be8a0a2c58

`getModuleInfo` returned `info.thelounge` before but it was removed.