### PR TITLE
Provide exact version into `npm install` command

### DIFF
--- a/src/command-line/install.js
+++ b/src/command-line/install.js
@@ -61,7 +61,7 @@ program
 					"--no-progress",
 					"--prefix",
 					packagesPath,
-					packageName,
+					`${packageName}@${json.version}`,
 				],
 				{
 					// This is the same as `"inherit"` except `process.stdout` is ignored


### PR DESCRIPTION
Should avoid dumb `package.json` and caching issues.