### PR TITLE
Fix bind not being passed to irc-framework

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -276,7 +276,7 @@ Client.prototype.connect = function(args) {
 		gecos: network.realname,
 		password: network.password,
 		tls: network.tls,
-		localAddress: config.bind,
+		outgoing_addr: config.bind,
 		rejectUnauthorized: false,
 		enable_chghost: true,
 		enable_echomessage: true,


### PR DESCRIPTION
This was silently broken in irc-framework 2.6.0 in https://github.com/kiwiirc/irc-framework/commit/7b616172ecb91be7ce7baa01887374ad8374a9a6

Was fixed by https://github.com/kiwiirc/irc-framework/pull/138 and then reverted in https://github.com/kiwiirc/irc-framework/commit/b2118b440291fe6d20f1e0aca2996b31cbc527d8