### PR TITLE
Remove support for the `lounge` CLI (which was replaced with `thelounge`)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "version": "2.7.1",
   "preferGlobal": true,
   "bin": {
-    "lounge": "index.js",
     "thelounge": "index.js"
   },
   "repository": {

--- a/src/command-line/index.js
+++ b/src/command-line/index.js
@@ -46,13 +46,6 @@ if (!Helper.config.public && !Helper.config.ldap.enable) {
 require("./install");
 require("./uninstall");
 
-// TODO: Remove this when releasing The Lounge v3
-if (process.argv[1].endsWith(`${require("path").sep}lounge`)) {
-	log.warn(`The ${colors.red("lounge")} CLI is ${colors.bold.red("deprecated")} and will be removed in v3.`);
-	log.warn(`Use ${colors.green("thelounge")} instead.`);
-	process.argv[1] = "thelounge";
-}
-
 // `parse` expects to be passed `process.argv`, but we need to remove to give it
 // a version of `argv` that does not contain options already parsed by
 // `parseOptions` above.


### PR DESCRIPTION
Follow-up of https://github.com/thelounge/lounge/pull/1708.