### PR TITLE
Deal with npm's `dist-tag` at Travis deploy time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,3 +45,9 @@ deploy:
     condition: "$BUILD_ENV = production"
     tags: true
     repo: thelounge/lounge
+
+# If the current release is a stable release, remove potential pre-release tag
+after_deploy: |
+  if [ "$(npm_dist_tag)" == "latest" ]; then
+    npm dist-tag rm thelounge next || true
+  fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-- 9 # Current stable 
+- 9 # Current stable
 - 8 # Active LTS until April 2019
 - 6 # Active LTS until April 2018
 
@@ -22,9 +22,20 @@ notifications:
     on_success: never
     on_failure: always
 
+# Identifies `a.b.c-xxx.n` tags as pre-releases, and `a.b.c` as stable releases
+before_deploy: |
+  function npm_dist_tag() {
+    if [[ "$TRAVIS_TAG" = *"-"* ]]; then
+      echo "next"
+    else
+      echo "latest"
+    fi
+  }
+
 deploy:
   skip_cleanup: true # prevent git stash --all which nukes node_modules folder
   provider: npm
+  tag: $(npm_dist_tag)
   email:
     secure: Eb/dO3VEnuG5CFSJbiTBDZ4X29o1bTITqfzc4SZJqkSKHLZ5/l0VHyd1In7T2U9yBtysnmm+dsOWYFwnH5NMt5kvGkkX754HBDz0QXO//IqADA/1cH1MMXuzJjRvHNrtbq3c6Iv0vO827kXfvqwkfGTmXfreT5w+xF7Y+0SjF8pfu2d/Z5omrmoy9J9SF/kfmahKYZwakc3h8p29JPmnFMUAR0JiZS/2gLSHQnGA3mCcnlO+U3bQuTVW3Z9RhiG51f/EMFfNZ8pBttM6CgE2Zth3AT50jbKjRgYdYN2ee/Z3qUJIoA6dfPALC7B+Z2UekqTiKx4SCk+9vZJJXqT8J+Fe67Dki/FgNWnEZaTn8eFs+Gfh2nnokNZUMd/2mMT0y0KbRaOYQarn6lFw+/Cn9hD6e8uRCqY0+YspMvGtV3LuHFy+br6YphlG6YKxJzExtGDvrwlDD70xJtqcgnlET3XOdzvfCpRSskh7FmVJMoL39f/j9r4FzWVDmfnRnDT6Cac2dSdbQM0Ldw3+65l/57K/Km7NeHbLA3LsnjSJqXuysYwosd6iUOQen59Dy+TvwKafEfAGXWcZNguFURIMf2LRZ4rwTZl6pp30nj23U6rmkWm3JTRZC95i/O4yP2rVoljNUEuMlHVts63r3lwXtuGQVo3+lQCYErK4Ceo7cQc=
   api_key:


### PR DESCRIPTION

- Before releasing a pre-release, we currently need to update `package.json` to add the `next` tag, [such as done here](https://github.com/thelounge/lounge/commit/89f1326ce7a39871a0a644983ceda2d60aa7d231).
- Before releasing a stable release, we currently need to remove that, [such as done here](https://github.com/thelounge/lounge/commit/65c6774af0e1e970fe4df63aa55bdc62c9996bc9).
- After releasing a stable release, we currently need to delete the `next` tag, otherwise `latest` tag will point to a version that is more recent than `next`, and it shows as such in the "Tags" section of [the package on Yarn](https://yarnpkg.com/en/package/thelounge).

So far, I didn't make a mistake with the first 2 steps, but it can surely happen someday (actually, I may have made a mistake the first time we went for pre/rc releases!).
The last step is easy to forget, though with little consequences.
Either way, this automates and saves manual steps, which is nice.

I've tested my Bash function [with this code](https://github.com/thelounge/lounge/commit/155cfb5784fa1aed108d859d9d7e526fa5664553), which [results in this](https://travis-ci.org/thelounge/lounge/jobs/343691398#L2917-L2923). This follows a [suggestion made by a Travis person](https://github.com/travis-ci/dpl/issues/415#issuecomment-364892545). The real test will come at deploy time, but I'm not worried about screwing this up this because dist-tags can be updated (fixed) after the fact.